### PR TITLE
Added title to metadata to adhere to new requirements

### DIFF
--- a/examples/commandline/tunein.py
+++ b/examples/commandline/tunein.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
             # TODO seems at least & needs to be escaped - should move this to play_uri and maybe escape other chars.
             uri = uri.replace('&', '&amp;')
 
-            metadata = meta_template.format(title='', service=tunein_service)
+            metadata = meta_template.format(title=fave['title'], service=tunein_service)
 
             print mySonos.play_uri( uri, metadata)
 


### PR DESCRIPTION
This commit adds the title to the metadata when trying to play a radio station with the tunein example. This became required with the sonos update as of 1/6-13. This is the fix to issue #16.
