### PR TITLE
Made playername mandatory since not providing it resulted in no action

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -86,7 +86,7 @@ class SoCo(object):
         self.speaker_info = {} # Stores information about the current speaker
 
 
-    def set_player_name(self,playername=False):
+    def set_player_name(self, playername):
         """  Sets the name of the player
 
         Returns:
@@ -95,13 +95,12 @@ class SoCo(object):
         Raises SoCoException (or a subclass) upon errors.
 
         """
-        if playername is not False:
-            body = SET_PLAYER_NAME_BODY_TEMPLATE.format(playername=playername)
+        body = SET_PLAYER_NAME_BODY_TEMPLATE.format(playername=playername)
 
-            response = self.__send_command(DEVICE_ENDPOINT,SET_PLAYER_NAME_ACTION,body)
+        response = self.__send_command(DEVICE_ENDPOINT,SET_PLAYER_NAME_ACTION,body)
 
-            if response != SET_PLAYER_NAME_RESPONSE:
-                self.__parse_error(response)
+        if response != SET_PLAYER_NAME_RESPONSE:
+            self.__parse_error(response)
 
 
     def set_play_mode(self, playmode):


### PR DESCRIPTION
This has been bugging me for a while, since it is one of the first methods you see, when you open up the file. Anyway, the `set_player_name` method has only one argument and it is optional. However, since all available code is inside an if that checks if you provided it, not providing it will result in the method executing absolutely no code. I don't think this makes much sense and so this pull request makes the `playername` argument mandatory.

Note, while testing the fix I noticed that this method raises an exception. It works, but raises an exception I guess since the "mission accomplished" return value has changed. In any case that was also the case before, so it should not affect this pull request. I will open an issue for it separately.

I consider this a simple fix and will pull in a few days if there are no wild objections, unless someone reviews in the meantime so it can be committed sooner.

Regards Kenneth
