### PR TITLE
String Prefix order on SonosDiscovery from py3k update fails under python 2

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -48,7 +48,7 @@ class SonosDiscovery(object):  # pylint: disable=R0903
                 data, addr = self._sock.recvfrom(2048)
                 # Look for the model in parentheses in a line like this
                 # SERVER: Linux UPnP/1.0 Sonos/22.0-65180 (ZPS5)
-                search = re.search(rb'SERVER.*\((.*)\)', data)
+                search = re.search(br'SERVER.*\((.*)\)', data)
                 try:
                     model = really_unicode(search.group(1))
                 except AttributeError:


### PR DESCRIPTION
It appears that a late change to my conflict resolution from the merge of my py3k branch fails in python 2(.7). I didn't re-run the unittests until I pulled the changes from the main repository today. Its a simple enough fix, but a shame it got in there nonetheless.
