### PR TITLE
Added volume command with optional +/- operators in sonoshell.py

### DIFF
--- a/examples/commandline/sonoshell.py
+++ b/examples/commandline/sonoshell.py
@@ -34,7 +34,7 @@ def get_volume_adjustment_factor(operator):
     factor = 1
     if len(operator) > 1:
         try:
-            factor = int(filter(str.isdigit, operator))
+            factor = int(operator[1:])
         except ValueError:
             print("Adjustment factor for volume has to be a int.")
             return False


### PR DESCRIPTION
commandline example.

This patch adds functionality for reading the current volume by running:
  python sonoshell.py <ip> volume

This patch also adds functionality for adjusting the volume by running:
  python sonoshell.py <ip> volume +
or
  python sonoshell.py <ip> volume -
