### PR TITLE
Make integration tests py.testable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
 [pytest]
 markers =
-    integration: mark a test as a integration test.
+    integration: mark a test as an integration test.
 python_files = test_*.py soco_unittest.py
+# By default, run with verbose on and show detail for skipped and xfail tests
+addopts = -rsxX -v
+# We need py.test >=2.5 (for yield_fixtures)
+minversion = 2.5

--- a/unittest/conftest.py
+++ b/unittest/conftest.py
@@ -1,11 +1,13 @@
 """ py.test hooks """
+
+
 def pytest_addoption(parser):
-    """ Add the --ip commandline option"""
+    """ Add the --ip commandline option """
     parser.addoption(
-        '--ip', 
-        type=str, 
-        default=None, 
-        action='store', 
-        dest='IP', 
+        '--ip',
+        type=str,
+        default=None,
+        action='store',
+        dest='IP',
         help='the IP address for the zone to be used for the integration tests'
         )

--- a/unittest/soco_unittest.py
+++ b/unittest/soco_unittest.py
@@ -85,8 +85,7 @@ NOT_IN_RANGE = 'The returned value is not in the expected range'
 def setup_module(module):
     ip = pytest.config.option.IP
     if ip is None:
-        raise SoCoUnitTestInitError(
-            "No ip address specified. Use the --ip option.")
+        pytest.fail("No ip address specified. Use the --ip option.")
     init(ip=ip)
     state = get_state()
     module.state = state


### PR DESCRIPTION
These changes make tests in soco_unittest runnable via py.test. I have not touched the code in execute_unittests.py, which is still usable. But if you want to use py.test, you can do this in the root directory

``` sh
py.test -m "integration" --ip XXX.XXX.XXX.XXX
```

will run just the integration tests

``` sh
py.test -m "not integration"
```

 will run everything _except_ the integration tests, and

``` sh
py.test  --ip XXX.XXX.XXX.XXX
```

will run everything
