### PR TITLE
Using properties instead of methods

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -70,52 +70,62 @@ class SonosDiscovery(object):  # pylint: disable=R0903
 
 
 class SoCo(object):  # pylint: disable=R0904
-    """A simple class for controlling a Sonos speaker.
+    """A simple class for controlling a Sonos speaker
 
-    Public functions:
-    play -- Plays the current item.
-    play_uri -- Plays a track or a music stream by URI.
-    play_from_queue -- Plays an item in the queue.
-    pause -- Pause the currently playing track.
-    stop -- Stop the currently playing track.
-    seek -- Move the currently playing track a given elapsed time.
-    next -- Go to the next track.
-    previous -- Go back to the previous track.
-    mute -- Get or Set Mute (or unmute) the speaker.
-    volume -- Get or set the volume of the speaker.
-    bass -- Get or set the speaker's bass EQ.
-    set_player_name  -- set the name of the Sonos Speaker
-    treble -- Set the speaker's treble EQ.
-    set_play_mode -- Change repeat and shuffle settings on the queue.
-    set_loudness -- Turn on (or off) the speaker's loudness compensation.
-    switch_to_line_in -- Switch the speaker's input to line-in.
-    status_light -- Turn on (or off) the Sonos status light.
-    get_current_track_info -- Get information about the currently playing
-                              track.
-    get_speaker_info -- Get information about the Sonos speaker.
-    partymode -- Put all the speakers in the network in the same group.
-    join -- Join this speaker to another "master" speaker.
-    unjoin -- Remove this speaker from a group.
-    get_queue -- Get information about the queue.
-    get_folders -- Get search folders from the music library
-    get_artists -- Get artists from the music library
-    get_album_artists -- Get album artists from the music library
-    get_albums -- Get albums from the music library
-    get_genres -- Get genres from the music library
-    get_composers -- Get composers from the music library
-    get_tracks -- Get tracks from the music library
-    get_playlists -- Get playlists from the music library
-    get_music_library_information -- Get information from the music library
-    get_current_transport_info -- get speakers playing state
-    add_to_queue -- Add a track to the end of the queue
-    remove_from_queue -- Remove a track from the queue
-    clear_queue -- Remove all tracks from queue
-    get_favorite_radio_shows -- Get favorite radio shows from Sonos' Radio app.
-    get_favorite_radio_stations -- Get favorite radio stations.
-    get_group_coordinator -- Get the coordinator for a grouped collection of
-                             Sonos units.
-    get_speakers_ip -- Get the IP addresses of all the Sonos speakers in the
-                       network.
+    Public functions::
+
+        play -- Plays the current item.
+        play_uri -- Plays a track or a music stream by URI.
+        play_from_queue -- Plays an item in the queue.
+        pause -- Pause the currently playing track.
+        stop -- Stop the currently playing track.
+        seek -- Move the currently playing track a given elapsed time.
+        next -- Go to the next track.
+        previous -- Go back to the previous track.
+        switch_to_line_in -- Switch the speaker's input to line-in.
+        get_current_track_info -- Get information about the currently playing
+                                  track.
+        get_speaker_info -- Get information about the Sonos speaker.
+        partymode -- Put all the speakers in the network in the same group.
+        join -- Join this speaker to another "master" speaker.
+        unjoin -- Remove this speaker from a group.
+        get_queue -- Get information about the queue.
+        get_folders -- Get search folders from the music library
+        get_artists -- Get artists from the music library
+        get_album_artists -- Get album artists from the music library
+        get_albums -- Get albums from the music library
+        get_genres -- Get genres from the music library
+        get_composers -- Get composers from the music library
+        get_tracks -- Get tracks from the music library
+        get_playlists -- Get playlists from the music library
+        get_music_library_information -- Get information from the music library
+        get_current_transport_info -- get speakers playing state
+        add_to_queue -- Add a track to the end of the queue
+        remove_from_queue -- Remove a track from the queue
+        clear_queue -- Remove all tracks from queue
+        get_favorite_radio_shows -- Get favorite radio shows from Sonos' Radio app.
+        get_favorite_radio_stations -- Get favorite radio stations.
+        get_group_coordinator -- Get the coordinator for a grouped collection of
+                                 Sonos units.
+        get_speakers_ip -- Get the IP addresses of all the Sonos speakers in the
+                           network.
+
+    Properties::
+
+        mute -- The speaker's mute status.
+        volume -- The speaker's volume.
+        bass -- The speaker's bass EQ.
+        treble -- The speaker's treble EQ.
+        loudness -- The status of the speaker's loudness compensation.
+        status_light -- The state of the Sonos status light.
+        player_name  -- The speaker's name.
+        play_mode -- The queue's repeat/shuffle settings.
+
+    .. warning::
+
+        These properties are not cached and will obtain information over the
+        network, so may take longer than expected to set or return a value. It
+        may be a good idea for you to cache the value in your own code.
 
     """
     # Stores the IP addresses of all the speakers in a network
@@ -124,6 +134,7 @@ class SoCo(object):  # pylint: disable=R0904
     topology = {}
 
     def __init__(self, speaker_ip):
+        #: The speaker's ip address
         self.speaker_ip = speaker_ip
         self.speaker_info = {}  # Stores information about the current speaker
         self.deviceProperties = DeviceProperties(self)
@@ -131,34 +142,37 @@ class SoCo(object):  # pylint: disable=R0904
         self.renderingControl = RenderingControl(self)
         self.avTransport = AVTransport(self)
 
-    def set_player_name(self, playername):
-        """  Sets the name of the player
+    @property
+    def player_name(self):
+        """  The speaker's name. A string. """
+        result = self.deviceProperties.GetZoneAtrributes()
+        return result["CurrentZoneName"]
 
-        Returns:
-        True if the player name was successfully set.
-
-        Raises SoCoException (or a subclass) upon errors.
-
-        """
+    @player_name.setter
+    def player_name(self, playername):
         self.deviceProperties.SetZoneAtrributes([
             ('DesiredZoneName', playername),
             ('DesiredIcon', ''),
             ('DesiredConfiguration', '')
             ])
 
-    def set_play_mode(self, playmode):
-        """ Sets the play mode for the queue. Case-insensitive options are:
+    @property
+    def play_mode(self):
+        """ The queue's play mode. Case-insensitive options are::
+
         NORMAL -- Turns off shuffle and repeat.
         REPEAT_ALL -- Turns on repeat and turns off shuffle.
         SHUFFLE -- Turns on shuffle *and* repeat. (It's strange, I know.)
         SHUFFLE_NOREPEAT -- Turns on shuffle and turns off repeat.
 
-        Returns:
-        True if the play mode was successfully set.
-
-        Raises SoCoException (or a subclass) upon errors.
-
         """
+        result = self.avTransport.GetTransportSettings([
+            ('InstanceID', 0),
+            ])
+        return result['PlayMode']
+
+    @play_mode.setter
+    def play_mode(self, playmode):
         modes = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL')
         playmode = playmode.upper()
         if not playmode in modes:
@@ -324,141 +338,105 @@ class SoCo(object):  # pylint: disable=R0904
             ('Speed', 1)
             ])
 
-    def mute(self, mute=None):
-        """ Mute or unmute the Sonos speaker.
+    @property
+    def mute(self):
+        """ The speaker's mute state. True if muted, False otherwise """
 
-        Arguments:
-        mute -- True to mute. False to unmute.
+        response = self.renderingControl.GetMute([
+            ('InstanceID', 0),
+            ('Channel', 'Master')
+            ])
+        mute_state = response['CurrentMute']
+        return True if int(mute_state) else False
 
-        Returns:
-        True if the Sonos speaker was successfully muted or unmuted.
+    @mute.setter
+    def mute(self, mute):
+        mute_value = '1' if mute else '0'
+        self.renderingControl.SetMute([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ('DesiredMute', mute_value)
+            ])
 
-        If the mute argument was not specified: returns the current mute status
-        0 for unmuted, 1 for muted
+    @property
+    def volume(self):
+        """ The speaker's volume. An integer between 0 and 100. """
 
-        Raises SoCoException (or a subclass) upon errors.
+        response = self.renderingControl.GetVolume([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ])
+        volume = response['CurrentVolume']
+        return int(volume)
 
-        """
-        if mute is None:
-            response = self.renderingControl.GetMute([
-                ('InstanceID', 0),
-                ('Channel', 'Master')
-                ])
-            mute_state = response['CurrentMute']
-            return int(mute_state)
-        else:
-            mute_value = '1' if mute else '0'
-            self.renderingControl.SetMute([
-                ('InstanceID', 0),
-                ('Channel', 'Master'),
-                ('DesiredMute', mute_value)
-                ])
+    @volume.setter
+    def volume(self, volume):
+        volume = int(volume)
+        volume = max(0, min(volume, 100))  # Coerce in range
+        self.renderingControl.SetVolume([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ('DesiredVolume', volume)
+            ])
 
-    def volume(self, volume=None):
-        """ Get or set the Sonos speaker volume.
+    @property
+    def bass(self):
+        """ The speaker's bass EQ. An integer between -10 and 10. """
 
-        Arguments:
-        volume -- A value between 0 and 100.
+        response = self.renderingControl.GetBass([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ])
+        bass = response['CurrentBass']
+        return int(bass)
 
-        Returns:
-        If the volume argument was specified: returns true if the Sonos speaker
-        successfully set the volume.
+    @bass.setter
+    def bass(self, bass):
+        bass = int(bass)
+        bass = max(-10, min(bass, 10))  # Coerce in range
+        self.renderingControl.SetBass([
+            ('InstanceID', 0),
+            ('DesiredBass', bass)
+            ])
 
-        If the volume argument was not specified: returns the current volume of
-        the Sonos speaker.
+    @property
+    def treble(self):
+        """ The speaker's treble EQ. An integer between -10 and 10. """
 
-        Raises SoCoException (or a subclass) upon errors.
+        response = self.renderingControl.GetTreble([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ])
+        treble = response['CurrentTreble']
+        return int(treble)
 
-        """
-        if volume is not None:
-            volume = max(0, min(volume, 100))  # Coerce in range
-            self.renderingControl.SetVolume([
-                ('InstanceID', 0),
-                ('Channel', 'Master'),
-                ('DesiredVolume', volume)
-                ])
-        else:
-            response = self.renderingControl.GetVolume([
-                ('InstanceID', 0),
-                ('Channel', 'Master'),
-                ])
-            volume = response['CurrentVolume']
-            return int(volume)
+    @treble.setter
+    def treble(self, treble):
+        treble = int(treble)
+        treble = max(-10, min(treble, 10))  # Coerce in range
+        self.renderingControl.SetTreble([
+            ('InstanceID', 0),
+            ('DesiredTreble', treble)
+            ])
 
-    def bass(self, bass=None):
-        """ Get or set the Sonos speaker's bass EQ.
-
-        Arguments:
-        bass -- A value between -10 and 10.
-
-        Returns:
-        If the bass argument was specified: returns true if the Sonos speaker
-        successfully set the bass EQ.
-
-        If the bass argument was not specified: returns the current base value.
-
-        Raises SoCoException (or a subclass) upon errors.
-
-        """
-        if bass is not None:
-            bass = max(-10, min(bass, 10))  # Coerce in range
-            self.renderingControl.SetBass([
-                ('InstanceID', 0),
-                ('DesiredBass', bass)
-                ])
-        else:
-            response = self.renderingControl.GetBass([
-                ('InstanceID', 0),
-                ('Channel', 'Master'),
-                ])
-            bass = response['CurrentBass']
-            return int(bass)
-
-    def treble(self, treble=None):
-        """ Get or set the Sonos speaker's treble EQ.
-
-        Arguments:
-        treble -- A value between -10 and 10.
-
-        Returns:
-        If the treble argument was specified: returns true if the Sonos speaker
-        successfully set the treble EQ.
-
-        If the treble argument was not specified: returns the current treble
-        value.
-
-        Raises SoCoException (or a subclass) upon errors.
-
-        """
-        if treble is not None:
-            treble = max(-10, min(treble, 10))  # Coerce in range
-            self.renderingControl.SetTreble([
-                ('InstanceID', 0),
-                ('DesiredTreble', treble)
-                ])
-        else:
-            response = self.renderingControl.GetTreble([
-                ('InstanceID', 0),
-                ('Channel', 'Master'),
-                ])
-            treble = response['CurrentTreble']
-            return int(treble)
-
-    def set_loudness(self, loudness):
-        """ Set the Sonos speaker's loudness compensation.
+    @property
+    def loudness(self):
+        """ The Sonos speaker's loudness compensation. True if on, otherwise
+        False.
 
         Loudness is a complicated topic. You can find a nice summary about this
         feature here: http://forums.sonos.com/showthread.php?p=4698#post4698
 
-        Arguments:
-        loudness -- True to turn on loudness compensation. False to disable it.
-
-        Returns:
-        True if the Sonos speaker successfully set the loundess compensation.
-
-        Raises SoCoException (or a subclass) upon errors.
-
         """
+        response = self.renderingControl.GetLoudness([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ])
+        loudness = response["CurrentLoudness"]
+        return True if int(loudness) else False
+
+    @loudness.setter
+    def loudness(self, loudness):
         loudness_value = '1' if loudness else '0'
         self.renderingControl.SetLoudness([
             ('InstanceID', 0),
@@ -556,21 +534,18 @@ class SoCo(object):  # pylint: disable=R0904
             ('CurrentURIMetaData', '')
             ])
 
-    def status_light(self, led_on):
-        """ Turn on (or off) the white Sonos status light.
-
-        Turns on or off the little white light on the Sonos speaker. (It's
-        between the mute button and the volume up button on the speaker.)
-
-        Arguments:
-        led_on -- True to turn on the light. False to turn off the light.
-
-        Returns:
-        True if the Sonos speaker successfully turned on (or off) the light.
-
-        Raises SoCoException (or a subclass) upon errors.
+    @property
+    def status_light(self):
+        """ The white Sonos status light between the mute button and the volume
+        up button on the speaker. True if on, otherwise False.
 
         """
+        result = self.deviceProperties.GetLEDState()
+        LEDState = result["CurrentLEDState"]
+        return True if LEDState == "On" else False
+
+    @status_light.setter
+    def status_light(self, led_on):
         led_state = 'On' if led_on else 'Off'
         self.deviceProperties.SetLEDState([
             ('DesiredLEDState', led_state),

--- a/unittest/soco_unittest.py
+++ b/unittest/soco_unittest.py
@@ -86,40 +86,40 @@ class Volume(unittest.TestCase):
 
     def test_get_and_set(self):
         """ Tests if the set functionlity works when given valid arguments """
-        old = SOCO.volume()
+        old = SOCO.volume
         self.assertIn(old, self.valid_values, NOT_IN_RANGE)
         if old == self.valid_values[0]:
             new = old + 1
         else:
             new = old - 1
-        SOCO.volume(new)
+        SOCO.volume = new
         wait()
-        self.assertEqual(SOCO.volume(), new, NOT_EXP)
-        SOCO.volume(old)
+        self.assertEqual(SOCO.volume, new, NOT_EXP)
+        SOCO.volume = old
         wait()
 
     def test_invalid_arguments(self):
         """ Tests if the set functionality coerces into range when given
         integers outside of allowed range
         """
-        old = SOCO.volume()
+        old = SOCO.volume
         # NOTE We don't test coerce from too large values, since that would
         # put the unit at full volume
-        SOCO.volume(self.valid_values[0] - 1)
+        SOCO.volume = self.valid_values[0] - 1
         wait()
-        self.assertEqual(SOCO.volume(), 0, NOT_EXP)
-        SOCO.volume(old)
+        self.assertEqual(SOCO.volume, 0, NOT_EXP)
+        SOCO.volume = old
         wait()
 
     def test_set_0(self):
         """ Tests whether the volume can be set to 0. Regression test for:
         https://github.com/rahims/SoCo/issues/29
         """
-        old = SOCO.volume()
-        SOCO.volume(0)
+        old = SOCO.volume
+        SOCO.volume = 0
         wait()
-        self.assertEqual(SOCO.volume(), 0, NOT_EXP)
-        SOCO.volume(old)
+        self.assertEqual(SOCO.volume, 0, NOT_EXP)
+        SOCO.volume = old
         wait()
 
 
@@ -133,29 +133,29 @@ class Bass(unittest.TestCase):
 
     def test_get_and_set(self):
         """ Tests if the set functionlity works when given valid arguments """
-        old = SOCO.bass()
+        old = SOCO.bass
         self.assertIn(old, self.valid_values, NOT_IN_RANGE)
         # Values on the boundaries of the valid equivalence partition
         for value in [self.valid_values[0], self.valid_values[-1]]:
-            SOCO.bass(value)
+            SOCO.bass = value
             wait()
-            self.assertEqual(SOCO.bass(), value, NOT_EXP)
-        SOCO.bass(old)
+            self.assertEqual(SOCO.bass, value, NOT_EXP)
+        SOCO.bass = old
         wait()
 
     def test_invalid_arguments(self):
         """ Tests if the set functionality produces the expected "coerce in
         range" functionality when given a value outside of its range
         """
-        old = SOCO.bass()
+        old = SOCO.bass
         # Values on the boundaries of the two invalid equivalence partitions
-        SOCO.bass(self.valid_values[0] - 1)
+        SOCO.bass = self.valid_values[0] - 1
         wait()
-        self.assertEqual(SOCO.bass(), self.valid_values[0], NOT_EXP)
-        SOCO.bass(self.valid_values[-1] + 1)
+        self.assertEqual(SOCO.bass, self.valid_values[0], NOT_EXP)
+        SOCO.bass = self.valid_values[-1] + 1
         wait()
-        self.assertEqual(SOCO.bass(), self.valid_values[-1], NOT_EXP)
-        SOCO.bass(old)
+        self.assertEqual(SOCO.bass, self.valid_values[-1], NOT_EXP)
+        SOCO.bass = old
         wait()
 
 
@@ -169,29 +169,29 @@ class Treble(unittest.TestCase):
 
     def test_get_and_set(self):
         """ Tests if the set functionlity works when given valid arguments """
-        old = SOCO.treble()
+        old = SOCO.treble
         self.assertIn(old, self.valid_values, NOT_IN_RANGE)
         # Values on the boundaries of the valid equivalence partition
         for value in [self.valid_values[0], self.valid_values[-1]]:
-            SOCO.treble(value)
+            SOCO.treble = value
             wait()
-            self.assertEqual(SOCO.treble(), value, NOT_EXP)
-        SOCO.treble(old)
+            self.assertEqual(SOCO.treble, value, NOT_EXP)
+        SOCO.treble = old
         wait()
 
     def test_invalid_arguments(self):
         """ Tests if the set functionality produces the expected "coerce in
         range" functionality when given a value outside its range
         """
-        old = SOCO.treble()
+        old = SOCO.treble
         # Values on the boundaries of the two invalid equivalence partitions
-        SOCO.treble(self.valid_values[0] - 1)
+        SOCO.treble = self.valid_values[0] - 1
         wait()
-        self.assertEqual(SOCO.treble(), self.valid_values[0], NOT_EXP)
-        SOCO.treble(self.valid_values[-1] + 1)
+        self.assertEqual(SOCO.treble, self.valid_values[0], NOT_EXP)
+        SOCO.treble = self.valid_values[-1] + 1
         wait()
-        self.assertEqual(SOCO.treble(), self.valid_values[-1], NOT_EXP)
-        SOCO.treble(old)
+        self.assertEqual(SOCO.treble, self.valid_values[-1], NOT_EXP)
+        SOCO.treble = old
         wait()
 
 
@@ -378,14 +378,14 @@ class Mute(unittest.TestCase):
 
     def test(self):
         """ Tests of the mute method works """
-        old = SOCO.mute()
+        old = SOCO.mute
         self.assertEqual(old, 0, 'The unit should not be muted when running '
                          'the unit tests')
-        SOCO.mute(True)
+        SOCO.mute = True
         wait()
-        new = SOCO.mute()
+        new = SOCO.mute
         self.assertEqual(new, 1, 'The unit did not succesfully mute')
-        SOCO.mute(False)
+        SOCO.mute = False
         wait()
 
 


### PR DESCRIPTION
See #58.  Replacing a number of methods with properties, e.g.:

Use 

``` python
soco.volume = 30
soco.volume -=3
soco.status_light = True
```

instead of

``` python
soco.volume(30)
soco.volume(soco.volume()-3)
soco.status_light("On")
```

Also updates the Integration tests accordingly.
#45 by @petteraas will need a few changes to take account of this if this is accepted.
