### PR TITLE
Rewrote function print_queue to print a 1 based list instead of 0 based.

### DIFF
--- a/examples/commandline/sonoshell.py
+++ b/examples/commandline/sonoshell.py
@@ -57,7 +57,7 @@ def print_current_track_info():
 
 def print_queue():
     queue = sonos.get_queue()
-    for idx, track in enumerate(queue):
+    for idx, track in enumerate(queue, 1):
         print(
             "%d: %s - %s. From album %s." % (
                 idx,


### PR DESCRIPTION
Rewrote function print_queue to print a 1 based list instead of 0 based.

Even though developers tend to think 0,1,2,3....N a list like 1,2,3,...N is more human readable, and this also makes it follow 'playlist_position' from 'print_current_track_info', which can be used to highlight the current track in the queue if we ever want that. 
