### PR TITLE
Zero pad the index in playlist queue.

### DIFF
--- a/examples/commandline/sonoshell.py
+++ b/examples/commandline/sonoshell.py
@@ -80,10 +80,10 @@ def print_queue():
         else:
             color = ANSI_RESET
 
+        idx = str(idx).rjust(index_padding)
         print(
-            "%s%0*d: %s - %s. From album %s." % (
+            "%s%s: %s - %s. From album %s." % (
                 color,
-                index_padding,
                 idx,
                 track['artist'],
                 track['title'],


### PR DESCRIPTION
for a queue

```
1: foo
2: bar
...
...
34: gazonk
```

this patch zero pads the index so it's displayed as

```
01: foo
02: bar
...
...
34: gazonk
```
