### PR TITLE
Fixed bug in get_group_coordinator

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -705,7 +705,6 @@ class SoCo(object):  # pylint: disable=R0904
         coord_uuid = None
         zgroups =  self.zoneGroupTopology.GetZoneGroupState()['ZoneGroupState']
         XMLtree = XML.fromstring(really_utf8(zgroups))
-        print zgroups
 
         for grp in XMLtree:
             for zone in grp:
@@ -717,7 +716,8 @@ class SoCo(object):  # pylint: disable=R0904
             for zone in grp:
                 if coord_uuid == zone.attrib['UUID']:
                     #find IP of coordinator UUID for this group
-                    coord_ip = zone.attrib['Location'].split('//')[1].split(':')[0]
+                    coord_ip = zone.attrib['Location'].\
+                        split('//')[1].split(':')[0]
 
         return coord_ip
 


### PR DESCRIPTION
This fix addresses issue #64. The get_group_coordinator() method
returns ‘None’ for a zone which is in Stereo mode, when invoked on a
device which is a slave.

The method also needs to be invoked on a device that is initialized
with an IP address that belongs to the zone. This should not be the
case.

I’ve refactored the method to get the topology of all devices and
extract the coordinator for the given zone name. This allows us to get
the coordinator IP for any zone from any initialized SoCo object.
