### PR TITLE
Adds SoCo.get_sonos_playlists and MLSonosPlaylist

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -981,11 +981,15 @@ class SoCo(_SocoSingletonBase):
         return queue
 
     def get_sonos_playlists(self, start=0, max_items=100):
-        """ Convenience method for: get_music_library_information('sonos_playlists')
-        Refer to the docstring for that method
+        """ Convenience method for:
+            get_music_library_information('sonos_playlists')
+            Refer to the docstring for that method
 
         """
-        out = self.get_music_library_information('sonos_playlists')
+        out = self.get_music_library_information(
+            'sonos_playlists',
+            start,
+            max_items)
         return out
 
     def get_artists(self, start=0, max_items=100):
@@ -1061,8 +1065,9 @@ class SoCo(_SocoSingletonBase):
 
         :param search_type: The kind of information to retrieve. Can be one of:
             'artists', 'album_artists', 'albums', 'genres', 'composers',
-            'tracks', 'share' and 'playlists', where playlists are the imported
-            file based playlists from the music library
+            'tracks', 'share', 'sonos_playlists', and 'playlists', where
+            playlists are the imported file based playlists from the
+            music library
         :param start: Starting number of returned matches
         :param max_items: Maximum number of returned matches. NOTE: The maximum
             may be restricted by the unit, presumably due to transfer
@@ -1078,7 +1083,8 @@ class SoCo(_SocoSingletonBase):
             :py:class:`~.soco.data_structures.MLGenre`,
             :py:class:`~.soco.data_structures.MLComposer`,
             :py:class:`~.soco.data_structures.MLTrack`,
-            :py:class:`~.soco.data_structures.MLShare` and
+            :py:class:`~.soco.data_structures.MLShare`,
+            :py:class:`~.soco.data_structures.MLSonosPlaylist and
             :py:class:`~.soco.data_structures.MLPlaylist` depending on the
             type of the search.
         :raises: :py:class:`SoCoException` upon errors

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -612,15 +612,15 @@ class MLSonosPlaylist(MusicLibraryItem):
 
     :ivar parent_id: The parent ID for the MLSonosPlaylist is 'SQ:'
     :ivar _translation: The dictionary-key-to-xml-tag-and-namespace-
-        translation used when instantiating MLSonosPlaylist from XML is inherited
-        from :py:class:`.MusicLibraryItem`.
+        translation used when instantiating MLSonosPlaylist from
+        XML is inherited from :py:class:`.MusicLibraryItem`.
 
     """
 
     parent_id = 'SQ:'
 
     def __init__(self, uri, title,
-                item_class='object.container.playlistContainer'):
+                 item_class='object.container.playlistContainer'):
         """ Instantiate the MLSonosPlaylist item by passing the arguments to the
         super class :py:meth:`.MusicLibraryItem.__init__`.
 
@@ -1243,7 +1243,8 @@ class MSPlaylist(MusicServiceItem):
 PARENT_ID_TO_CLASS = {'A:TRACKS': MLTrack, 'A:ALBUM': MLAlbum,
                       'A:ARTIST': MLArtist, 'A:ALBUMARTIST': MLAlbumArtist,
                       'A:GENRE': MLGenre, 'A:COMPOSER': MLComposer,
-                      'A:PLAYLISTS': MLPlaylist, 'S:': MLShare, 'SQ:': MLSonosPlaylist}
+                      'A:PLAYLISTS': MLPlaylist, 'S:': MLShare,
+                      'SQ:': MLSonosPlaylist}
 
 MS_TYPE_TO_CLASS = {'artist': MSArtist, 'album': MSAlbum, 'track': MSTrack,
                     'albumList': MSPlaylist}

--- a/unittest/test_data_structures.py
+++ b/unittest/test_data_structures.py
@@ -507,6 +507,7 @@ def test_mlsonosplaylist():
     common_tests('SQ:', '13 title: Koop',
                  playlist, content, SONOS_PLAYLIST_XML, SONOS_PLAYLIST_DICT)
 
+
 def test_mlshare():
     """Test the MLShare class"""
     # Set the tests up


### PR DESCRIPTION
based on comments in https://github.com/SoCo/SoCo/issues/113

to test it

```
lists = sonos.get_sonos_playlists()
print("search_type: %s number_retured: %s update_id: %s total_matches: %d" % (
 lists.get('search_type'),
 lists.get('number_retured'),
 lists.get('update_id'),
 lists.get('total_matches')))

for idx, playlist in enumerate(lists.get('item_list'), 1):
    print("idx: %d, playlist: %s" % (idx, playlist))
```

I'm not sure yet why the unit-test is failing.
