### PR TITLE
Implementation of spotifyplugin

### DIFF
--- a/soco/plugins/spotify.py
+++ b/soco/plugins/spotify.py
@@ -44,7 +44,7 @@ class SpotifyTrack(object):
 
     @title.setter
     def title(self, title):
-        self.data['title'] = title
+        self.data['title'] = title.encode('utf-8')
 
     @property
     def didl_metadata(self):
@@ -105,7 +105,7 @@ class SpotifyAlbum(object):
 
     @title.setter
     def title(self, title):
-        self.data['title'] = title
+        self.data['title'] = title.encode('utf-8')
 
     @property
     def uri(self):


### PR DESCRIPTION
Implemented add_to_queue which will add a track using the spotify URI (i.e. spotify:track:20DfkHC5grnKNJCzZQB6KC). It will fetch the meta data from the public API that Spotify provides if it's not provided.

Example of using the plugin:

```
from soco.plugins.spotify import Spotify
from soco.plugins.spotify import SpotifyTrack
# create a new plugin, pass the soco instance to it
myplugin = Spotify(device)
print 'index: ' + str(myplugin.add_track_to_queue(SpotifyTrack('spotify:track:20DfkHC5grnKNJCzZQB6KC')))
print 'index: ' + str(myplugin.add_album_to_queue(SpotifyAlbum('spotify:album:6a50SaJpvdWDp13t0wUcPU')))
```

Adding functions to call the Spotify public API should use existing libraries, maybe https://github.com/mopidy/pyspotify
But the lookup for metadata is done in the plugin so the dependency isn't requried.
