### PR TITLE
Added fields model and uid to method 'discover()'

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -214,7 +214,7 @@ class SoCo(_SocoSingletonBase):  # pylint: disable=R0904
     # Stores the topology of all Zones in the network
     topology = {}
 
-    def __init__(self, ip_address, uid, model):
+    def __init__(self, ip_address, uid=None, model=None):
         # Check if ip_address is a valid IPv4 representation.
         # Sonos does not (yet) support IPv6
         try:


### PR DESCRIPTION
model: preserves model name for later use
uid: get uid for a speaker without performing a deep scan (get_speaker_info())

For these changes, the ctor (**init**() method) of SoCo has been updated. 

In my project (shSonos on Github) the network is scanned periodically for new speakers. The 'uid' is the only unique identifier. If a new speaker was found, a deep scan is performed, otherwise there will be only an update after an elapsed period.
