### PR TITLE
Deprecate soco.SoCo.get_speakers_ip() in favour of soco.discover()

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -931,8 +931,9 @@ class SoCo(_SocoSingletonBase):
         if self.speakers_ip and not refresh:
             return self.speakers_ip
         else:
-            for speaker in self.group.members:
-                self.speakers_ip.append(speaker.ip_address)
+            for group in self.all_groups:
+                for speaker in group:
+                    self.speakers_ip.append(speaker.ip_address)
 
             return self.speakers_ip
 


### PR DESCRIPTION
I was looking into the code for 'partymode' when I found the call to get_speakers_ip, this appears to be the only place it is used, and there's an old unit-test written for it that is currently disabled, perhaps it's time to deprecate it in favour of the new discover function!

Now there are two possible problems with this change:
 1: get_speakers_ip runs a lot faster than discover() ( on my network ~ 200ms vs ~ 1200ms )
 2: get_speakers_ip also returns BR100

I would still argue that it makes sense to deprecate get_speakers_ip and look into optimizing discover() ( if actually needed ).

BR100 can not be used to initialize SoCo, which implies that the one call to get_speakers_ip in partymode shouldn't really return BR100 anyway. ( And now I just realized why I've always seen a error when running partymode )

One way of getting the ips is DRYer than two.

I suggest looking into a separate way of finding BR100, but right now I don't see any usecase where it's needed.
