### PR TITLE
Keys in headers list are all uppercased.

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -22,6 +22,7 @@ except ImportError:  # python 2.7
 import threading
 import socket
 import logging
+import requests
 
 import soco
 
@@ -38,7 +39,7 @@ class EventNotifyHandler(SimpleHTTPRequestHandler):
 
     def do_NOTIFY(self):
         """ Handle a NOTIFY request.  See the UPnP Spec for details."""
-        headers = dict(self.headers)
+        headers = requests.structures.CaseInsensitiveDict(self.headers)
         seq = headers['seq']  # Event sequence number
         sid = headers['sid']  # Event Subscription Identifier
         content_length = int(headers['content-length'])


### PR DESCRIPTION
I tested the eventing from #121 again, but got some KeyError problems.

```
----------------------------------------
Exception happened during processing of request from ('10.0.4.2', 3668)
Traceback (most recent call last):
  File "/usr/lib/python3.3/socketserver.py", line 610, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.3/socketserver.py", line 345, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.3/socketserver.py", line 666, in __init__
    self.handle()
  File "/usr/lib/python3.3/http/server.py", line 400, in handle
    self.handle_one_request()
  File "/usr/lib/python3.3/http/server.py", line 388, in handle_one_request
    method()
  File "/home/petter/dev/forks/SoCo/soco/events.py", line 44, in do_NOTIFY
    content_length = int(headers['content-length'])
KeyError: 'content-length'
----------------------------------------
```

```
----------------------------------------
Exception happened during processing of request from ('10.0.4.2', 3667)
Traceback (most recent call last):
  File "/usr/lib/python3.3/socketserver.py", line 610, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.3/socketserver.py", line 345, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.3/socketserver.py", line 666, in __init__
    self.handle()
  File "/usr/lib/python3.3/http/server.py", line 400, in handle
    self.handle_one_request()
  File "/usr/lib/python3.3/http/server.py", line 388, in handle_one_request
    method()
  File "/home/petter/dev/forks/SoCo/soco/events.py", line 43, in do_NOTIFY
    seq = headers['seq']  # Event sequence number
KeyError: 'seq'
----------------------------------------
```

So I dumped all the headers: 

```
SID,
SEQ,
CONTENT-TYPE,
CONTENT-LENGTH,
CONNECTION,
NT,
NTS,
HOST
```
