### PR TITLE
Remove forgotten traceback formatting, fixes #158

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import select
 import socket
 import logging
-import traceback
 from textwrap import dedent
 import re
 import itertools
@@ -907,7 +906,6 @@ class SoCo(_SocoSingletonBase):
                 track['title'] = trackinfo[index + 3:]
             else:
                 LOGGER.warning('Could not handle track info: "%s"', trackinfo)
-                LOGGER.warning(traceback.format_exc())
                 track['title'] = trackinfo
 
         # If the speaker is playing from the line-in source, querying for track


### PR DESCRIPTION
There used to be a try except in get_current_track_info, where-in the caught exception would be logged. The try-except is no longer there, and therefore the logging of the traceback needed to be remove. This was also the only use of the traceback module, so that import has been removed.

I consider this a bug-fix and will merge shortly. Juts putting it up here for reference.
