### PR TITLE
uid not set when using SoCo derived class

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -737,6 +737,10 @@ class SoCo(_SocoSingletonBase):
                 if zone._uid == coordinator_uid:
                     group_coordinator = zone
                     zone._is_coordinator = True
+                    # If this is the coordinator, and the same IP address
+                    # then set it as the default UID
+                    if ip_addr == self.ip_address:
+                        self._uid = zone._uid
                 else:
                     zone._is_coordinator = False
                 zone._player_name = member_attribs['ZoneName']


### PR DESCRIPTION
With v0.8 I have found an issue when calling "play_from_queue" that the UID is "None" - it does a call to the "uid" property, that then checks self._uid - if that is not set yet it calls: _parse_zone_group_state()

But this method currently does not actually set the self_uid that this then returned fro the "uid" property.
