### PR TITLE
Test both if XML element is None AND if .text is None, fixes #181

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -183,6 +183,8 @@ class MusicLibraryItem(MusicInfoItem):
             result = xml.find(ns_tag(*value))
             if result is None:
                 content[key] = None
+            elif result.text is None:
+                content[key] = None
             else:
                 # The xml objects should contain utf-8 internally
                 content[key] = really_unicode(result.text)


### PR DESCRIPTION
This makes sure that when we look for certain tags in XML, we check NOTH whether we find it AND it its .text property is None. Fixes #181
