### PR TITLE
Fixed typo in SetZoneAttributes

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -270,7 +270,7 @@ class SoCo(_SocoSingletonBase):
     @player_name.setter
     def player_name(self, playername):
         """ Set the speaker's name """
-        self.deviceProperties.SetZoneAtrributes([
+        self.deviceProperties.SetZoneAttributes([
             ('DesiredZoneName', playername),
             ('DesiredIcon', ''),
             ('DesiredConfiguration', '')


### PR DESCRIPTION
I bought a new ZP1 and wanted to see if I could change name of it from `socos` that turned out to not work because of this small typo in soco/core.py. I'll add a PR in socos for the 'player_name' setting code there, but it requires this fix, so it'll have to wait for ( I guess ) SoCo 0.9!
