### PR TITLE
Support for returning full Album Art URI's

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1288,7 +1288,7 @@ class SoCo(_SocoSingletonBase):
         :type uri: str
         """
         item = URI(uri)
-        self.add_to_queue(item)
+        return self.add_to_queue(item)
 
     def add_to_queue(self, queueable_item):
         """ Adds a queueable item to the queue """


### PR DESCRIPTION
This patch allows the caller to specify that the album art URI that is returned is fully qualified (like the get_current_track_info interface does).  This means it can be used immediately without any manual processing.  This was sort of mentioned in the following conversation:

https://groups.google.com/forum/?hl=en#!topic/python-soco/z4HkdJfu8yk
