### PR TITLE
Return the position in the queue when adding via URI

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1278,7 +1278,7 @@ class SoCo(_SocoSingletonBase):
         :type uri: str
         """
         item = URI(uri)
-        self.add_to_queue(item)
+        return self.add_to_queue(item)
 
     def add_to_queue(self, queueable_item):
         """ Adds a queueable item to the queue """


### PR DESCRIPTION
When a user adds an item to the queue using "add_to_queue" it will return the position in the queue.

For consistency, "add_uri_to_queue"" should also return the position in the queue.

Please would it be possible to flag this for the 0.9 release?

Thanks, Rob
