### PR TITLE
Ml browse

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -19,7 +19,8 @@ from .services import RenderingControl, AVTransport, ZoneGroupTopology
 from .services import AlarmClock
 from .groups import ZoneGroup
 from .exceptions import CannotCreateDIDLMetadata
-from .data_structures import get_ml_item, QueueItem, URI, MLSonosPlaylist
+from .data_structures import get_ml_item, QueueItem, URI, MLSonosPlaylist,\
+    MLShare
 from .utils import really_utf8, camel_to_underscore
 from .xml import XML
 
@@ -1262,6 +1263,8 @@ class SoCo(_SocoSingletonBase):
         for container in dom:
             if search_type == 'sonos_playlists':
                 item = MLSonosPlaylist.from_xml(container)
+            elif search_type == 'share':
+                item = MLShare.from_xml(container)
             else:
                 item = get_ml_item(container)
             # Append the item to the list

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -553,6 +553,19 @@ class MLShare(MusicLibraryItem):
     item_class = 'object.container'
 
 
+class MLCategory(MusicLibraryItem):
+    """Class that represents a music library category.
+
+    :ivar item_class: The item_class for the MLCategory is 'object.container'
+    :ivar _translation: The dictionary-key-to-xml-tag-and-namespace-
+        translation used when instantiating a MLCategory from XML is inherited
+        from :py:class:`.MusicLibraryItem`.
+
+    """
+
+    item_class = 'object.container'
+
+
 class MLAlbumList(MusicLibraryItem):
     """Class that represents a music library album list.
 
@@ -1293,7 +1306,7 @@ DIDL_CLASS_TO_CLASS = {'object.item.audioItem.musicTrack': MLTrack,
                        'object.container.genre.musicGenre': MLGenre,
                        'object.container.person.composer': MLComposer,
                        'object.container.playlistContainer': MLPlaylist,
-                       'object.container': MLShare,
+                       'object.container': MLCategory,
                        'object.container.albumlist': MLAlbumList,
                        'object.container.playlistContainer.sameArtist':
                            MLSameArtist}

--- a/unittest/test_data_structures.py
+++ b/unittest/test_data_structures.py
@@ -498,15 +498,13 @@ def test_get_ml_item():
             ARTIST_XML,
             GENRE_XML,
             COMPOSER_XML,
-            PLAYLIST_XML,
-            SHARE_XML]
+            PLAYLIST_XML]
     classes = [data_structures.MLTrack,
                data_structures.MLAlbum,
                data_structures.MLArtist,
                data_structures.MLGenre,
                data_structures.MLComposer,
-               data_structures.MLPlaylist,
-               data_structures.MLShare]
+               data_structures.MLPlaylist]
     for xml, class_ in zip(xmls, classes):
         etree = XML.fromstring(xml.encode('utf-8'))
         item = data_structures.get_ml_item(etree)


### PR DESCRIPTION
Hi everyone

Here it is, finally, the much talked about browse method for music library items. This PR is based of work in #191, so it should not be merged before that is in. Only the last two commits pertain to this PR.

The implementation is based on the research done by @robwebset as [discussed on google groups](https://groups.google.com/forum/#!topic/python-soco/tFnNlGTp9TU) and in #186.

The browse method allows you to get the sub-elements of any ml item like so::

``` python
import soco
soc = soco.SoCo('...ipaddress..')
some_album = soc.get_albums()['item_list'][0]
tracks_in_that_album = soc.browse(some_album)
```

Calling the browse method without a ml_item will give the top level items which for the music library tree are the categories.

The only exception is that the playlists category (which contains imported playlists) cannot be browsed. Browsing a track returns nothing.

As previously discussed, I think this makes for a more intuitive interface than the one @robwebset implemented in #186 in that; you don't have to handle sub-category strings yourself, if you want the sub-elements of an item you just ask for them.

Making this browse method also makes the entire music lib implementation symmetric to that way the Wimp plugin is implemented (and I guess others could be implemented) in that it has a browse function and a few search function specific types of data.

This PR also introduces a new ML class based of a new DIDL Lite class for "object.container.playlistContainer.sameArtist". This structure is (among other items) returned when browsing an artist or composer.

If you want to test it more thoroughly you can use this code:

``` python
from soco import SoCo
soc = SoCo('192.168.0.12')


def recursive_browse(item, cat, level=0):
    """Recursively browse items in the music lib"""
    print '{0}: {1}{2}'.format(cat, '+' * level, item)
    level += 1
    for new_item in soc.browse(item)['item_list']:
        recursive_browse(new_item, cat, level)


def browse_all():
    """Browse the entire tree recursively"""
    cats = soc.browse()['item_list']
    for index, cat in enumerate(cats):
        # The Playlists category cannot for some reason not be browsed, since
        # it does not have an id.
        if hasattr(cat, 'item_id'):
            recursive_browse(cat, index)
    print 'DONE'


def test_browse_single(search_type):
    """Test browsing a single type"""
    main = soc.get_music_library_information(search_type)['item_list'][0]
    print '\nThe {0} \'{1}\' contains the following items:'.\
        format(search_type[:-1], main)
    for item in soc.browse(main)['item_list']:
        print item


def test_browse():
    """Test the browse fucntionality of all supported types"""
    for search_type in ['artists', 'album_artists', 'albums', 'genres',
                        'composers', 'tracks', 'categories']:
        test_browse_single(search_type)
    print 'DONE'


if __name__ == '__main__':
    #test_browse()
    #browse_all()
```

The `test_browse()` function tries to browse one item of each of the searches you can do with get_music_library_information and the `browse_all()` runs through the entire tree category by category.

Let me know what you think.
