### PR TITLE
Added testrepository to development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pylint
 coveralls
 pytest-cov
 wheel
+testrepository


### PR DESCRIPTION
The testrepository development dependency is required to fix this error:

```
python setup.py --help-commands
Traceback (most recent call last):
  File "setup.py", line 88, in <module>
    classifiers=CLASSIFIERS,
  File "/usr/lib64/python2.7/distutils/core.py", line 138, in setup
    ok = dist.parse_command_line()
  File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 273, in parse_command_line
    result = _Distribution.parse_command_line(self)
  File "/usr/lib64/python2.7/distutils/dist.py", line 464, in parse_command_line
    if self.handle_display_options(option_order):
  File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 636, in handle_display_options
    return _Distribution.handle_display_options(self, option_order)
  File "/usr/lib64/python2.7/distutils/dist.py", line 669, in handle_display_options
    self.print_commands()
  File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 396, in print_commands
    cmdclass = ep.load(False) # don't require extras, we're not running
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/lib/python2.7/site-packages/pbr/testr_command.py", line 47, in <module>
    from testrepository import commands
ImportError: No module named testrepository
```
