### PR TITLE
Re-enable PyPy target for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "pypy"
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
PyPy on Travis-CI has been updated, so builds are working again (see #85).
