### PR TITLE
Update play_uri to create Metadata if title provided

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -470,12 +470,17 @@ class SoCo(_SocoSingletonBase):
             ('Speed', 1)
             ])
 
-    def play_uri(self, uri='', meta=''):
+    def play_uri(self, uri='', meta='', title=''):
         """ Play a given stream. Pauses the queue.
+        If there is no metadata passed in and there is a title set then a
+        metadata object will be created. This is often the case if you have
+        a custom stream, it will need at least the title in the metadata in
+        order to play.
 
         Arguments:
         uri -- URI of a stream to be played.
-        meta --- The track metadata to show in the player, DIDL format.
+        meta -- The track metadata to show in the player, DIDL format.
+        title -- The track title to show in the player
 
         Returns:
         True if the Sonos speaker successfully started playing the track.
@@ -483,6 +488,19 @@ class SoCo(_SocoSingletonBase):
         Raises SoCoException (or a subclass) upon errors.
 
         """
+        if meta == '' and title != '':
+            meta_template = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'\
+                '/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '\
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '\
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'\
+                '<item id="R:0/0/0" parentID="R:0/0" restricted="true">'\
+                '<dc:title>{title}</dc:title><upnp:class>'\
+                'object.item.audioItem.audioBroadcast</upnp:class><desc '\
+                'id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:'\
+                'metadata-1-0/">{service}</desc></item></DIDL-Lite>'
+            tunein_service = 'SA_RINCON65031_'
+            # Radio stations need to have at least a title to play
+            meta = meta_template.format(title=title, service=tunein_service)
 
         self.avTransport.SetAVTransportURI([
             ('InstanceID', 0),
@@ -491,38 +509,6 @@ class SoCo(_SocoSingletonBase):
             ])
         # The track is enqueued, now play it.
         return self.play()
-
-    def play_uri_with_title(self, uri='', title=''):
-        """ Play a given stream without constructed meta data for a title.
-        This is often the case if you have a custom stream, it will need
-        at least the title in the metadata in order to play.
-        Pauses the queue.
-
-        Arguments:
-        uri -- URI of a stream to be played.
-        title -- The track title to show in the player.
-
-        Returns:
-        True if the Sonos speaker successfully started playing the track.
-
-        Raises SoCoException (or a subclass) upon errors.
-
-        """
-        meta_template = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/'\
-            '1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '\
-            'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '\
-            'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'\
-            '<item id="R:0/0/0" parentID="R:0/0" restricted="true">'\
-            '<dc:title>{title}</dc:title><upnp:class>'\
-            'object.item.audioItem.audioBroadcast</upnp:class><desc '\
-            'id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:'\
-            'metadata-1-0/">{service}</desc></item></DIDL-Lite>'
-        tunein_service = 'SA_RINCON65031_'
-        # Radio stations need to have at least a title to play
-        metadata = meta_template.format(title=title, service=tunein_service)
-
-        # Now play the track
-        return self.play_uri(uri, metadata)
 
     def pause(self):
         """ Pause the currently playing track.


### PR DESCRIPTION
This change allows users to pass in custom URI's along with a title, and get them played on the Sonos system - it saves them having to manually create a metadata string to also pass with it.

This has come out of research detailed here:
https://github.com/SoCo/SoCo/issues/99#issuecomment-55367164
