### PR TITLE
Add snapshot class

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -238,6 +238,10 @@ class Snapshot(object):
     def _restore_queue(self):
         """ Restores the previous state of the queue
 
+            Note: The restore currently adds the items back into the queue
+            using the URI, for items the Sonos system already knows about
+            this is OK, but for other items, they may be missing some of
+            their metadata as it will not be automatically picked up
         """
         if self.queue is not None:
             # Clear the queue so that it can be reset


### PR DESCRIPTION
This class allows the user to take a snapshot of a given sonos device, then later restore it to that state.

Example usage:

```
device = SoCo('192.168.0.14')
snap = Snapshot(device)
snap.snapshot()

# Do something here that changes what's playing etc.

snap.restore()
```

This file requires the folowing changes: #219 #220 

Some mention of a snapshot class was make in https://github.com/SoCo/SoCo/issues/99#issuecomment-55367164

Also if #223 is changed (Ideally to support adding multiple items to a queue in one go) then the performance of snapshotting the queue may be improved.
