### PR TITLE
Add LastChange xmltree (dom-object) to the event variables 

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -101,6 +101,7 @@ def parse_event_xml(xml_event):
             if variable.tag == "LastChange":
                 last_change_tree = XML.fromstring(
                     variable.text.encode('utf-8'))
+                result['last_change_xml_tree'] = last_change_tree
                 # We assume there is only one InstanceID tag. This is true for
                 # Sonos, as far as we know.
                 # InstanceID can be in one of two namespaces, depending on


### PR DESCRIPTION
Add LastChange xmltree (dom-object) to the event variables  for backward compatibility and for manual LastChange event parsing. 
