### PR TITLE
Add create_sonos_playlist_from_queue with test

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -197,7 +197,9 @@ class SoCo(_SocoSingletonBase):
         get_favorite_radio_shows -- Get favorite radio shows from Sonos'
                                     Radio app.
         get_favorite_radio_stations -- Get favorite radio stations.
-        create_sonos_playlist -- Creates a new Sonos' playlist
+        create_sonos_playlist -- Create a new empty Sonos playlist
+        create_sonos_playlist_from_queue -- Create a new Sonos playlist
+                                            from the current queue.
         add_item_to_sonos_playlist -- Adds a queueable item to a Sonos'
                                        playlist
 
@@ -1579,7 +1581,7 @@ class SoCo(_SocoSingletonBase):
                 item.album_art_uri
 
     def create_sonos_playlist(self, title):
-        """ Create a new Sonos' playlist .
+        """ Create a new empty Sonos playlist.
 
         :params title: Name of the playlist
 
@@ -1594,6 +1596,29 @@ class SoCo(_SocoSingletonBase):
             ('EnqueuedURIMetaData', ''),
             ])
 
+        obj_id = response['AssignedObjectID'].split(':', 2)[1]
+        uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(obj_id)
+
+        return MLSonosPlaylist(uri, title, 'SQ:')
+
+    # pylint: disable=invalid-name
+    def create_sonos_playlist_from_queue(self, title):
+        """ Create a new Sonos playlist from the current queue.
+
+            :params title: Name of the playlist
+
+            :returns: An instance of
+                :py:class:`~.soco.data_structures.MLSonosPlaylist`
+
+        """
+        # Note: probably same as Queue service method SaveAsSonosPlaylist
+        # but this has not been tested.  This method is what the
+        # controller uses.
+        response = self.avTransport.SaveQueue([
+            ('InstanceID', 0),
+            ('Title', title),
+            ('ObjectID', '')
+        ])
         obj_id = response['AssignedObjectID'].split(':', 2)[1]
         uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(obj_id)
 

--- a/unittest/test_core.py
+++ b/unittest/test_core.py
@@ -251,6 +251,24 @@ class TestAVTransport:
         assert playlist.uri == expected_uri
         assert playlist.parent_id == "SQ:"
 
+    def test_create_sonos_playlist_from_queue(self, moco):
+        playlist_name = "saved queue"
+        playlist_id = 1
+        moco.avTransport.SaveQueue.return_value = {
+            'AssignedObjectID': 'SQ:{0}'.format(playlist_id)
+        }
+        playlist = moco.create_sonos_playlist_from_queue(playlist_name)
+        moco.avTransport.SaveQueue.assert_called_once_with(
+            [('InstanceID', 0),
+             ('Title', playlist_name),
+             ('ObjectID', '')]
+        )
+        assert playlist.title == playlist_name
+        expected_uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(
+            playlist_id)
+        assert playlist.uri == expected_uri
+        assert playlist.parent_id == "SQ:"
+
     def test_add_item_to_sonos_playlist(self, moco):
         playlist = mock.Mock()
         playlist.item_id = 7


### PR DESCRIPTION
Could be called saved_queue_as_sonos_playlist but either are long.

Uses the same service call that the controller app does.  Thank you wireshark.

Could even be merged into `create_sonos_playlist` with some kind of optional parameter from_queue=True/False.  That seems a bit ugly to me.
