### PR TITLE
Scan all interfaces and logger cleanup

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -27,7 +27,7 @@ from soco import config
 
 import netifaces
 
-LOGGER = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 
 def discover(timeout=1, include_invisible=False):
@@ -61,7 +61,7 @@ def discover(timeout=1, include_invisible=False):
        if inet_addr == "127.0.0.1":
           continue
 
-       LOGGER.debug("Searching {}".format(inet_addr))
+       _log.debug("Searching {}".format(inet_addr))
 
        _sock = socket.socket(
            socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
@@ -88,10 +88,10 @@ def discover(timeout=1, include_invisible=False):
            # wait for query responses from them ourselves.
            zone = config.SOCO_CLASS(addr[0])
            if include_invisible:
-               LOGGER.debug("Found {}".format(zone.all_zones))
+               _log.debug("Found {}".format(zone.all_zones))
                all_zones += zone.all_zones
            else:
-               LOGGER.debug("Found {}".format(zone.visible_zones))
+               _log.debug("Found {}".format(zone.visible_zones))
                all_zones += zone.visible_zones
 
     return all_zones
@@ -999,7 +999,7 @@ class SoCo(_SocoSingletonBase):
                 track['artist'] = trackinfo[:index]
                 track['title'] = trackinfo[index + 3:]
             else:
-                LOGGER.warning('Could not handle track info: "%s"', trackinfo)
+                _log.warning('Could not handle track info: "%s"', trackinfo)
                 track['title'] = trackinfo
 
         # If the speaker is playing from the line-in source, querying for track

--- a/soco/plugins/__init__.py
+++ b/soco/plugins/__init__.py
@@ -8,7 +8,7 @@ import logging
 import importlib
 
 
-LOGGER = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 
 class SoCoPlugin(object):
@@ -16,7 +16,7 @@ class SoCoPlugin(object):
 
     def __init__(self, soco):
         cls = self.__class__.__name__
-        LOGGER.info('Initializing SoCo plugin {cls}'.format(cls=cls))
+        _log.info('Initializing SoCo plugin {cls}'.format(cls=cls))
         self.soco = soco
 
     @property
@@ -28,7 +28,7 @@ class SoCoPlugin(object):
     def from_name(cls, fullname, soco, *args, **kwargs):
         """ Instantiate a plugin by its full name """
 
-        LOGGER.info('Loading plugin {fullname}'.format(fullname=fullname))
+        _log.info('Loading plugin {fullname}'.format(fullname=fullname))
 
         parts = fullname.split('.')
         modname = '.'.join(parts[:-1])
@@ -37,6 +37,6 @@ class SoCoPlugin(object):
         mod = importlib.import_module(modname)
         cls = getattr(mod, clsname)
 
-        LOGGER.info('Loaded class {cls}'.format(cls=cls))
+        _log.info('Loaded class {cls}'.format(cls=cls))
 
         return cls(soco, *args, **kwargs)


### PR DESCRIPTION
The old imp only scanned the first interface and will now scan all interfaces, bad thing will be timeout*no-interface. Then some additional cleanup to make the logger global internal. I was not able to split the pull request im afraid so we have to take it like this or you can just fetch from me and apply manually. 

/T
