### PR TITLE
Fix timeout-related regression in core.discover

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -110,8 +110,6 @@ def discover(timeout=1, include_invisible=False):
                 return zone.all_zones
             else:
                 return zone.visible_zones
-        else:
-            return None
 
 
 class SonosDiscovery(object):  # pylint: disable=R0903


### PR DESCRIPTION
The new timeout logic in core.discover had a side-effect of forcing the timeout to be 100ms in all cases, even when a longer timeout is passed. This fix retains the 100ms timeout for the response queries, while allowing the while loop to continue for the full timeout period. 
