### PR TITLE
Snapshot: Make sure a compatible track is selected before changing the play_mode

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -148,9 +148,6 @@ class Snapshot(object):
 
             if self.is_playing_queue and self.playlist_position > 0:
                 # was playing from playlist
-                # reinstate track, position, play mode, cross fade
-                self.device.play_mode = self.play_mode
-                self.device.cross_fade = self.cross_fade
 
                 if self.playlist_position is not None:
 
@@ -164,6 +161,11 @@ class Snapshot(object):
                 if self.track_position is not None:
                     if self.track_position != "":
                         self.device.seek(self.track_position)
+
+                # reinstate track, position, play mode, cross fade
+                # Need to make sure there is a proper track selected first
+                self.device.play_mode = self.play_mode
+                self.device.cross_fade = self.cross_fade
             else:
                 # was playing a stream (radio station, file, or nothing)
                 # reinstate uri and meta data


### PR DESCRIPTION
This is a fix for the snapshot class.  I have seen a problem where the play_mode is changed as per the saved snapshot, but the track that was previously playing has not been restored.  So if you were playing a stream after a snapshot and then try and restore Sonos will give you an error that you are trying to change the play_mode to one that is not supported.

Just switching the order solves this.

Please can this be flagged for 0.10
