### PR TITLE
make the value of the IP_MULTICAST_TTL option one byte long

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -14,6 +14,7 @@ import re
 import itertools
 import requests
 import time
+import structt
 
 from .services import DeviceProperties, ContentDirectory
 from .services import RenderingControl, AVTransport, ZoneGroupTopology
@@ -55,7 +56,8 @@ def discover(timeout=1, include_invisible=False):
     _sock = socket.socket(
         socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     # UPnP v1.0 requires a TTL of 4
-    _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 4)
+    _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
+        struct.pack("B", 4))
     # Send a few times. UDP is unreliable
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))

--- a/soco/core.py
+++ b/soco/core.py
@@ -57,7 +57,7 @@ def discover(timeout=1, include_invisible=False):
         socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     # UPnP v1.0 requires a TTL of 4
     _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
-        struct.pack("B", 4))
+                     struct.pack("B", 4))
     # Send a few times. UDP is unreliable
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))

--- a/soco/core.py
+++ b/soco/core.py
@@ -14,7 +14,7 @@ import re
 import itertools
 import requests
 import time
-import structt
+import struct
 
 from .services import DeviceProperties, ContentDirectory
 from .services import RenderingControl, AVTransport, ZoneGroupTopology


### PR DESCRIPTION
The multicast TTL may have value in [0, 255], which fits in one byte. Linux allows an 32-bit integer to be passed if its value is less than 256. Some `setsockopt` implementations (like OpenBSD), though, are less tolerant and require the input to actually be one byte long.