### PR TITLE
New year tidy

### DIFF
--- a/examples/plugins/socoplugins.py
+++ b/examples/plugins/socoplugins.py
@@ -6,13 +6,12 @@
 
 import time
 
-from soco import SoCo, SonosDiscovery
+from soco import SoCo
 from soco.plugins import SoCoPlugin
 
 
 def main():
-    sd = SonosDiscovery()
-    speakers = sd.get_speaker_ips()
+    speakers = [speaker.ip_address for speaker in SoCo.discover()]
 
     if not speakers:
         print 'no speakers found, exiting.'

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -14,14 +14,13 @@ __website__ = 'https://github.com/SoCo/SoCo'
 __license__ = 'MIT License'
 
 
-from .core import discover, SoCo, SonosDiscovery
+from .core import discover, SoCo
 from .exceptions import SoCoException, UnknownSoCoException
 
 # You really should not `import *` - it is poor practice
 # but if you do, here is what you get:
 __all__ = [
     'discover',
-    'SonosDiscovery',
     'SoCo',
     'SoCoException',
     'UnknownSoCoException',

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -14,7 +14,8 @@ __website__ = 'https://github.com/SoCo/SoCo'
 __license__ = 'MIT License'
 
 
-from .core import discover, SoCo
+from .core import SoCo
+from .discovery import discover
 from .exceptions import SoCoException, UnknownSoCoException
 
 # You really should not `import *` - it is poor practice

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -8,7 +8,8 @@ import logging
 from datetime import datetime
 import re
 import weakref
-from .core import discover, PLAY_MODES
+from .core import PLAY_MODES
+from .discovery import discover
 from .xml import XML
 
 log = logging.getLogger(__name__)  # pylint: disable=C0103

--- a/soco/core.py
+++ b/soco/core.py
@@ -206,6 +206,8 @@ class SoCo(_SocoSingletonBase):
         self._visible_zones = set()
         self._zgs_cache = None
 
+        _LOG.debug("Created SoCo instance for ip: %s", ip_address)
+
     def __str__(self):
         return "<{0} object at ip {1}>".format(
             self.__class__.__name__, self.ip_address)

--- a/soco/core.py
+++ b/soco/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0302,fixme, protected-access
-""" The core module contains SonosDiscovery and SoCo classes that implement
+""" The core module contains the SoCo class that implements
 the main entry to the SoCo functionality
 """
 
@@ -11,7 +11,6 @@ import socket
 import logging
 from textwrap import dedent
 import re
-import itertools
 import requests
 import time
 import struct
@@ -114,27 +113,6 @@ def discover(timeout=1, include_invisible=False):
                 return zone.all_zones
             else:
                 return zone.visible_zones
-
-
-class SonosDiscovery(object):  # pylint: disable=R0903
-    """Retained for backward compatibility only. Will be removed in future
-    releases
-
-    .. deprecated:: 0.7
-       Use :func:`discover` instead.
-
-    """
-
-    def __init__(self):
-        import warnings
-        warnings.warn("SonosDiscovery is deprecated. Use discover instead.")
-
-    @staticmethod
-    def get_speaker_ips():
-        """ Deprecated in favour of discover() """
-        import warnings
-        warnings.warn("get_speaker_ips is deprecated. Use discover instead.")
-        return [i.ip_address for i in discover()]
 
 
 class _ArgsSingleton(type):
@@ -454,19 +432,6 @@ class SoCo(_SocoSingletonBase):
             ('InstanceID', 0),
             ('CrossfadeMode', crossfade_value)
             ])
-
-    @property
-    def speaker_ip(self):
-        """Retained for backward compatibility only. Will be removed in future
-        releases
-
-        .. deprecated:: 0.7
-           Use :attr:`ip_address` instead.
-
-        """
-        import warnings
-        warnings.warn("speaker_ip is deprecated. Use ip_address instead.")
-        return self.ip_address
 
     def play_from_queue(self, index, start=True):
         """ Play a track from the queue by index. The index number is
@@ -1152,39 +1117,6 @@ class SoCo(_SocoSingletonBase):
             self.speaker_info['mac_address'] = dom.findtext('.//MACAddress')
 
             return self.speaker_info
-
-    def get_group_coordinator(self, zone_name):
-        """
-        .. deprecated:: 0.8
-           Use :meth:`group` or :meth:`all_groups` instead.
-
-        """
-        import warnings
-        warnings.warn(
-            "get_group_coordinator is deprecated. "
-            "Use the group or all_groups methods instead")
-        for group in self.all_groups:
-            for member in group:
-                if member.player_name == zone_name:
-                    return group.coordinator.ip_address
-        return None
-
-    def get_speakers_ip(self, refresh=False):
-        """ Get the IP addresses of all the Sonos speakers in the network.
-
-        Arguments:
-            refresh -- Refresh the speakers IP cache. Ignored. For backward
-            compatibility only
-
-        Returns:
-            a set of IP addresses of the Sonos speakers.
-
-        .. deprecated:: 0.8
-
-
-        """
-        # pylint: disable=star-args, unused-argument
-        return set(z.ip_address for z in itertools.chain(*self.all_groups))
 
     def get_current_transport_info(self):
         """ Get the current playback state

--- a/soco/core.py
+++ b/soco/core.py
@@ -6,14 +6,10 @@ the main entry to the SoCo functionality
 
 from __future__ import unicode_literals
 
-import select
 import socket
 import logging
-from textwrap import dedent
 import re
 import requests
-import time
-import struct
 
 from .services import DeviceProperties, ContentDirectory
 from .services import RenderingControl, AVTransport, ZoneGroupTopology
@@ -29,90 +25,6 @@ from .xml import XML
 from soco import config
 
 _LOG = logging.getLogger(__name__)
-
-
-def discover(timeout=1, include_invisible=False):
-    """ Discover Sonos zones on the local network.
-
-    Return an set of visible SoCo instances for each zone found.
-    Include invisible zones (bridges and slave zones in stereo pairs if
-    `include_invisible` is True. Will block for up to `timeout` seconds, after
-    which return `None` if no zones found.
-
-    """
-
-    # pylint: disable=invalid-name
-    PLAYER_SEARCH = dedent("""\
-        M-SEARCH * HTTP/1.1
-        HOST: 239.255.255.250:1900
-        MAN: "ssdp:discover"
-        MX: 1
-        ST: urn:schemas-upnp-org:device:ZonePlayer:1
-        """).encode('utf-8')
-    MCAST_GRP = "239.255.255.250"
-    MCAST_PORT = 1900
-
-    _sock = socket.socket(
-        socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-    # UPnP v1.0 requires a TTL of 4
-    _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
-                     struct.pack("B", 4))
-    # Send a few times. UDP is unreliable
-    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
-    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
-    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
-
-    t0 = time.time()
-    while True:
-        # Check if the timeout is exceeded. We could do this check just
-        # before the currently only continue statement of this loop,
-        # but I feel it is safer to do it here, so that we do not forget
-        # to do it if/when another continue statement is added later.
-        # Note: this is sensitive to clock adjustments. AFAIK there
-        # is no monotonic timer available before Python 3.3.
-        t1 = time.time()
-        if t1-t0 > timeout:
-            return None
-
-        # The timeout of the select call is set to be no greater than
-        # 100ms, so as not to exceed (too much) the required timeout
-        # in case the loop is executed more than once.
-        response, _, _ = select.select([_sock], [], [], min(timeout, 0.1))
-
-        # Only Zone Players should respond, given the value of ST in the
-        # PLAYER_SEARCH message. However, to prevent misbehaved devices
-        # on the network to disrupt the discovery process, we check that
-        # the response contains the "Sonos" string; otherwise we keep
-        # waiting for a correct response.
-        #
-        # Here is a sample response from a real Sonos device (actual numbers
-        # have been redacted):
-        # HTTP/1.1 200 OK
-        # CACHE-CONTROL: max-age = 1800
-        # EXT:
-        # LOCATION: http://***.***.***.***:1400/xml/device_description.xml
-        # SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)
-        # ST: urn:schemas-upnp-org:device:ZonePlayer:1
-        # USN: uuid:RINCON_B8*************00::urn:schemas-upnp-org:device:
-        #                                                     ZonePlayer:1
-        # X-RINCON-BOOTSEQ: 3
-        # X-RINCON-HOUSEHOLD: Sonos_7O********************R7eU
-
-        if response:
-            data, addr = _sock.recvfrom(1024)
-            if b"Sonos" not in data:
-                continue
-
-            # Now we have an IP, we can build a SoCo instance and query that
-            # player for the topology to find the other players. It is much
-            # more efficient to rely upon the Zone Player's ability to find
-            # the others, than to wait for query responses from them
-            # ourselves.
-            zone = config.SOCO_CLASS(addr[0])
-            if include_invisible:
-                return zone.all_zones
-            else:
-                return zone.visible_zones
 
 
 class _ArgsSingleton(type):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+""" The core module contains the SoCo class that implements
+the main entry to the SoCo functionality
+"""
+
+from __future__ import unicode_literals
+
+import socket
+import select
+from textwrap import dedent
+import time
+import struct
+
+from soco import config
+from .utils import really_utf8
+
+
+def discover(timeout=1, include_invisible=False):
+    """ Discover Sonos zones on the local network.
+
+    Return an set of visible SoCo instances for each zone found.
+    Include invisible zones (bridges and slave zones in stereo pairs if
+    `include_invisible` is True. Will block for up to `timeout` seconds, after
+    which return `None` if no zones found.
+
+    """
+
+    # pylint: disable=invalid-name
+    PLAYER_SEARCH = dedent("""\
+        M-SEARCH * HTTP/1.1
+        HOST: 239.255.255.250:1900
+        MAN: "ssdp:discover"
+        MX: 1
+        ST: urn:schemas-upnp-org:device:ZonePlayer:1
+        """).encode('utf-8')
+    MCAST_GRP = "239.255.255.250"
+    MCAST_PORT = 1900
+
+    _sock = socket.socket(
+        socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    # UPnP v1.0 requires a TTL of 4
+    _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
+                     struct.pack("B", 4))
+    # Send a few times. UDP is unreliable
+    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
+    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
+    _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
+
+    t0 = time.time()
+    while True:
+        # Check if the timeout is exceeded. We could do this check just
+        # before the currently only continue statement of this loop,
+        # but I feel it is safer to do it here, so that we do not forget
+        # to do it if/when another continue statement is added later.
+        # Note: this is sensitive to clock adjustments. AFAIK there
+        # is no monotonic timer available before Python 3.3.
+        t1 = time.time()
+        if t1-t0 > timeout:
+            return None
+
+        # The timeout of the select call is set to be no greater than
+        # 100ms, so as not to exceed (too much) the required timeout
+        # in case the loop is executed more than once.
+        response, _, _ = select.select([_sock], [], [], min(timeout, 0.1))
+
+        # Only Zone Players should respond, given the value of ST in the
+        # PLAYER_SEARCH message. However, to prevent misbehaved devices
+        # on the network to disrupt the discovery process, we check that
+        # the response contains the "Sonos" string; otherwise we keep
+        # waiting for a correct response.
+        #
+        # Here is a sample response from a real Sonos device (actual numbers
+        # have been redacted):
+        # HTTP/1.1 200 OK
+        # CACHE-CONTROL: max-age = 1800
+        # EXT:
+        # LOCATION: http://***.***.***.***:1400/xml/device_description.xml
+        # SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)
+        # ST: urn:schemas-upnp-org:device:ZonePlayer:1
+        # USN: uuid:RINCON_B8*************00::urn:schemas-upnp-org:device:
+        #                                                     ZonePlayer:1
+        # X-RINCON-BOOTSEQ: 3
+        # X-RINCON-HOUSEHOLD: Sonos_7O********************R7eU
+
+        if response:
+            data, addr = _sock.recvfrom(1024)
+            if b"Sonos" not in data:
+                continue
+
+            # Now we have an IP, we can build a SoCo instance and query that
+            # player for the topology to find the other players. It is much
+            # more efficient to rely upon the Zone Player's ability to find
+            # the others, than to wait for query responses from them
+            # ourselves.
+            zone = config.SOCO_CLASS(addr[0])
+            if include_invisible:
+                return zone.all_zones
+            else:
+                return zone.visible_zones

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-""" The core module contains the SoCo class that implements
-the main entry to the SoCo functionality
-"""
+""" Discovery of Sonos devices on the network. """
 
 from __future__ import unicode_literals
 

--- a/soco/events.py
+++ b/soco/events.py
@@ -218,13 +218,13 @@ class EventNotifyHandler(SimpleHTTPRequestHandler):
         # find the relevant service from the sid
         with _sid_to_service_lock:
             service = _sid_to_service.get(sid)
-        variables = parse_event_xml(content)
-        # Build the Event object
-        event = Event(sid, seq, service, timestamp, variables)
         log.info(
             "Event %s received for %s service on thread %s at %s", seq,
             service.service_id, threading.current_thread(), timestamp)
         log.debug("Event content: %s", content)
+        variables = parse_event_xml(content)
+        # Build the Event object
+        event = Event(sid, seq, service, timestamp, variables)
         # pass the event details on to the service so it can update its cache.
         if service is not None:  # It might have been removed by another thread
             # pylint: disable=protected-access

--- a/soco/events.py
+++ b/soco/events.py
@@ -211,14 +211,16 @@ class EventNotifyHandler(SimpleHTTPRequestHandler):
         sid = headers['sid']  # Event Subscription Identifier
         content_length = int(headers['content-length'])
         content = self.rfile.read(content_length)
-        log.debug("Event %s received for sid: %s", seq, sid)
-        log.debug("Current thread is %s", threading.current_thread())
         # find the relevant service from the sid
         with _sid_to_service_lock:
             service = _sid_to_service.get(sid)
         variables = parse_event_xml(content)
         # Build the Event object
         event = Event(sid, seq, service, variables)
+        log.info(
+            "Event %s received for %s service on thread %s", seq,
+            service.service_id, threading.current_thread())
+        log.debug("Event content: %s", content)
         # pass the event details on to the service so it can update its cache.
         if service is not None:  # It might have been removed by another thread
             # pylint: disable=protected-access
@@ -251,7 +253,7 @@ class EventServerThread(threading.Thread):
         # Start the server on the local IP at port 1400.  Handling of requests
         # is delegated to instances of the EventNotifyHandler class
         listener = EventServer(self.address, EventNotifyHandler)
-        log.debug("Event listener running on %s", listener.server_address)
+        log.info("Event listener running on %s", listener.server_address)
         # Listen for events untill told to stop
         while not self.stop_flag.is_set():
             listener.handle_request()
@@ -388,7 +390,7 @@ class Subscription(object):
                 stop_flag = self.stop_flag
                 interval = self.interval
                 while not stop_flag.wait(interval):
-                    log.debug("Autorenewing subscription %s", sub.sid)
+                    log.info("Autorenewing subscription %s", sub.sid)
                     sub.renew()
 
         # TIMEOUT is provided for in the UPnP spec, but it is not clear if
@@ -432,7 +434,7 @@ class Subscription(object):
             self.timeout = int(timeout.lstrip('Second-'))
         self._timestamp = time.time()
         self.is_subscribed = True
-        log.debug(
+        log.info(
             "Subscribed to %s, sid: %s",
             service.base_url + service.event_subscription_url, self.sid)
         # Add the queue to the master dict of queues so it can be looked up
@@ -507,7 +509,7 @@ class Subscription(object):
             self.timeout = int(timeout.lstrip('Second-'))
         self._timestamp = time.time()
         self.is_subscribed = True
-        log.debug(
+        log.info(
             "Renewed subscription to %s, sid: %s",
             self.service.base_url + self.service.event_subscription_url,
             self.sid)
@@ -539,7 +541,7 @@ class Subscription(object):
         response.raise_for_status()
         self.is_subscribed = False
         self._timestamp = None
-        log.debug(
+        log.info(
             "Unsubscribed from %s, sid: %s",
             self.service.base_url + self.service.event_subscription_url,
             self.sid)

--- a/soco/services.py
+++ b/soco/services.py
@@ -107,10 +107,6 @@ class Service(object):
         #: A cache for storing the result of network calls. By default, this is
         #: TimedCache(default_timeout=0). See :class:`TimedCache`
         self.cache = Cache(default_timeout=0)
-        log.debug(
-            "Created service %s, ver %s, id %s, base_url %s, control_url %s",
-            self.service_type, self.version, self.service_id, self.base_url,
-            self.control_url)
 
         # From table 3.3 in
         # http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf
@@ -333,6 +329,8 @@ class Service(object):
             self.base_url + self.control_url, headers=headers, data=body)
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
+        log.info(
+            "Received status %s from %s", status, self.soco.ip_address)
         if status == 200:
             # The response is good. Get the output params, and return them.
             # NB an empty dict is a valid result. It just means that no
@@ -341,8 +339,6 @@ class Service(object):
             # Store in the cache. There is no need to do this if there was an
             # error, since we would want to try a network call again.
             cache.put(result, action, args, timeout=cache_timeout)
-            log.info(
-                "Received status %s from %s", status, self.soco.ip_address)
             return result
         elif status == 500:
             # Internal server error. UPnP requires this to be returned if the

--- a/unittest/test_events.py
+++ b/unittest/test_events.py
@@ -65,9 +65,10 @@ DUMMY_EVENT = """
 
 def test_event_object():
     # Basic initialisation
-    dummy_event = Event('123', '456', 'dummy', {'zone': 'kitchen'})
+    dummy_event = Event('123', '456', 'dummy', 123456.7, {'zone': 'kitchen'})
     assert dummy_event.sid == '123'
     assert dummy_event.seq == '456'
+    assert dummy_event.timestamp == 123456.7
     assert dummy_event.service =='dummy'
     assert dummy_event.variables == {'zone':'kitchen'}
     # attribute access


### PR DESCRIPTION
Tidying up some odd and ends.

- remove code which has been deprecated for more than three releases

- move discover to its own module.  Note that `from soco import discover` will work just as it did before.

- slightly saner debug logging (clarified a few messages, removed pointless ones etc)