### PR TITLE
Event timestamp

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -178,6 +178,7 @@ class Event(object):
         # overridden, and will not allow direct setting of attributes
         self.__dict__['sid'] = sid
         self.__dict__['seq'] = seq
+	self.__dict__['timestamp'] = time.time()
         self.__dict__['service'] = service
         self.__dict__['variables'] = variables if variables is not None else {}
 

--- a/soco/events.py
+++ b/soco/events.py
@@ -178,7 +178,7 @@ class Event(object):
         # overridden, and will not allow direct setting of attributes
         self.__dict__['sid'] = sid
         self.__dict__['seq'] = seq
-	self.__dict__['timestamp'] = time.time()
+	self.__dict__['timestamp'] = time.time()    #Local Time the Event was created
         self.__dict__['service'] = service
         self.__dict__['variables'] = variables if variables is not None else {}
 

--- a/soco/events.py
+++ b/soco/events.py
@@ -178,7 +178,7 @@ class Event(object):
         # overridden, and will not allow direct setting of attributes
         self.__dict__['sid'] = sid
         self.__dict__['seq'] = seq
-	self.__dict__['timestamp'] = time.time()    #Local Time the Event was created
+	self.__dict__['timestamp'] = time.time()    #Local Time the Event object was created
         self.__dict__['service'] = service
         self.__dict__['variables'] = variables if variables is not None else {}
 


### PR DESCRIPTION
I have a Play:1 that I would like to be able to control without the controller app - I don't always have my phone on me. I've built a python app that does just that, but had to make a slight change to <b>events.py</b> to accomplish it. Basically, the Play:1 behaves normally in all respects except when a "trigger" event occurs. I've defined the trigger to be a volume change in one direction, followed by a change in the opposite direction - within two seconds. Outside of that window, the volume buttons behave normally. Once the trigger event occurs, I use SoCo and Google TTS to report the local temperature and then speak the names of the favorite radio stations. The user uses the "+" button to select and the "-" button to cancel.

The change I had to make was to add a timestamp to events. This allows me to determine if the volume change events are within the two second window or not. Here's the change I made to <b>events.py</b> - it appears to be as simple as adding a timestamp to the dictionary for the event as follows:

```python
         # overridden, and will not allow direct setting of attributes
         self.__dict__['sid'] = sid
         self.__dict__['seq'] = seq
+        self.__dict__['timestamp'] = time.time()    #Local Time the Event object was created
         self.__dict__['service'] = service
         self.__dict__['variables'] = variables if variables is not None else {}
```
I've been using this for a while now and it works just fine. I'm effectively able to control the Play:1 like a desktop radio and, when I want to, join it to the other Sonos system in my house. There may be a better way to do this - but I believe it would be useful to include a timestamp on events in any case.

P.S. New to GitHub - all three commits essentially do the same thing.