### PR TITLE
Allow specification of discovery interface. Closes #242

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -35,6 +35,20 @@ def discover(timeout=1, include_invisible=False, interface_addr=None):
     Returns:
         (set): a set of SoCo instances, one for each zone found, or else None.
 
+    Note:
+        There is no easy cross-platform way to find out the addresses of the
+        local machine's network interfaces. You might try the
+        `netifaces module <https://pypi.python.org/pypi/netifaces>`_ and some
+        code like this::
+
+            >>> from netifaces import interfaces, AF_INET, ifaddresses
+            >>> data = [ifaddresses(i) for i in interfaces()]
+            >>> [d[AF_INET][0]['addr'] for d in data if d.get(AF_INET)]
+            ['127.0.0.1', '192.168.1.20']
+
+            This should provide you with a list of values to try for
+            interface_addr if you are having trouble finding your Sonos devices
+
     """
 
     # pylint: disable=invalid-name

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 
+import logging
 import socket
 import select
 from textwrap import dedent
@@ -11,6 +12,8 @@ import struct
 
 from soco import config
 from .utils import really_utf8
+
+_LOG = logging.getLogger(__name__)
 
 
 def discover(timeout=1, include_invisible=False, interface_addr=None):
@@ -78,6 +81,7 @@ def discover(timeout=1, include_invisible=False, interface_addr=None):
             socket.IPPROTO_IP, socket.IP_MULTICAST_IF, address)
 
     # Send a few times. UDP is unreliable
+    _LOG.info("Sending discovery packets")
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
     _sock.sendto(really_utf8(PLAYER_SEARCH), (MCAST_GRP, MCAST_PORT))
@@ -120,6 +124,7 @@ def discover(timeout=1, include_invisible=False, interface_addr=None):
 
         if response:
             data, addr = _sock.recvfrom(1024)
+            _LOG.debug('Received discovery response from %s: "%s"', addr, data)
             if b"Sonos" not in data:
                 continue
 


### PR DESCRIPTION
This is based on ideas in #242. It allows an interface address to be specified when using discovery.  Unlike #242 however it requires the user of the SoCo library to specify the interfaces to be used, rather than using the netifaces module to find all the interfaces on the local machine.  This makes the code rather more simple, avoids the need for a dependency, and makes the user responsible for working out which interfaces to use based on knowledge of his or her system.

Thanks to @trollkarlen