### PR TITLE
Add a more aggressive discovery method

### DIFF
--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -15,13 +15,14 @@ __license__ = 'MIT License'
 
 
 from .core import SoCo
-from .discovery import discover
+from .discovery import discover, discovering
 from .exceptions import SoCoException, UnknownSoCoException
 
 # You really should not `import *` - it is poor practice
 # but if you do, here is what you get:
 __all__ = [
     'discover',
+    'discovering',
     'SoCo',
     'SoCoException',
     'UnknownSoCoException',

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -16,6 +16,58 @@ from .utils import really_utf8
 _LOG = logging.getLogger(__name__)
 
 
+def discovering(timeout=1, include_invisible=False):
+    """ Discover Sonos zones on the local network.
+
+    This is a more aggressive search than the discover method, using multiple
+    attempts to check different network addresses
+
+    Args:
+        timeout (int): block for this many seconds, at most. Default 1
+        include_invisible (bool): include invisible zones in the return set.
+            Default False
+
+    Returns:
+        (set): a set of SoCo instances, one for each zone found, or else None.
+    """
+    # Start by calling the base discovery method
+    devices = discover(timeout, include_invisible)
+
+    # Check if the devices were found
+    if devices:
+        return devices
+
+    # If we reach here then there are no devices found, so we can try
+    # some alternative methods.  As there are no really good ways of
+    # finding the active network in a platform independent manner we
+    # try a few different things, practice has shown that these quite
+    # often result in finding the devices
+    int_addr = socket.gethostbyname(socket.gethostname())
+    _LOG.debug("Searching for devices using gethostname")
+    if int_addr not in [None, '']:
+        devices = discover(timeout, include_invisible, int_addr)
+        if devices:
+            return devices
+
+    int_addr = socket.gethostbyname(socket.getfqdn())
+    _LOG.debug("Searching for devices using getfqdn")
+    if int_addr not in [None, '']:
+        devices = discover(timeout, include_invisible, int_addr)
+        if devices:
+            return devices
+
+    # Try and find the address ourselves by going to a web page
+    soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    soc.connect(("sonos.com", 80))
+    int_addr = soc.getsockname()[0]
+    soc.close()
+    _LOG.debug("Searching for devices using web search")
+    if int_addr not in [None, '']:
+        devices = discover(timeout, include_invisible, int_addr)
+
+    return devices
+
+
 def discover(timeout=1, include_invisible=False, interface_addr=None):
     """ Discover Sonos zones on the local network.
 


### PR DESCRIPTION
Having messed about with some auto-discovery code, I found that if you have multiple network devices, the Sonos discover code can be a bit hit and miss.  This is mostly the case if you have something like VMWare or a wired and wireless network card, and don't set up your wireless card to connect to a network.

This pull request adds a new method "discovering" that will work better in these cases.

To see it on your system, if you have an ethernet and wireless card - make sure one is not connected to a live network - then run the old discover - there is a 50/50 chance that it will not pick up the correct card - then after the discover fails - try the discovering method.

On my 2 different systems that were showing the issue of not finding the sonos devices, it started working :)

If anyone wants to hack this about a bit - then please feel free to take a copy, alter it, then do a new pull request.

Thanks

Rob
