### PR TITLE
Only on master

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -17,6 +17,7 @@ from .services import RenderingControl, AVTransport, ZoneGroupTopology
 from .services import AlarmClock
 from .groups import ZoneGroup
 from .exceptions import SoCoUPnPException, SoCoSlaveException
+    SoCoSlaveException
 from .data_structures import DidlPlaylistContainer,\
     SearchResult, Queue, DidlObject, DidlMusicAlbum,\
     from_didl_string, to_didl_string, DidlResource
@@ -89,8 +90,8 @@ def only_on_master(function):
     def inner_function(self, *args, **kwargs):
         """Master checking inner function"""
         if not self.is_coordinator:
-            message = 'The method "{}" can only be called on the '\
-              'coordinator in a group'.format(function.__name__)
+            message = 'The method or property "{0}" can only be called/used '\
+                'on the coordinator in a group'.format(function.__name__)
             raise SoCoSlaveException(message)
         return function(self, *args, **kwargs)
     return inner_function
@@ -348,6 +349,7 @@ class SoCo(_SocoSingletonBase):
         ])
 
     @property
+    @only_on_master  # Only for symmetry with the setter
     def cross_fade(self):
         """ The speaker's cross fade state.
         True if enabled, False otherwise """
@@ -359,6 +361,7 @@ class SoCo(_SocoSingletonBase):
         return True if int(cross_fade_state) else False
 
     @cross_fade.setter
+    @only_on_master
     def cross_fade(self, crossfade):
         """ Set the speaker's cross fade state. """
         crossfade_value = '1' if crossfade else '0'
@@ -367,6 +370,7 @@ class SoCo(_SocoSingletonBase):
             ('CrossfadeMode', crossfade_value)
         ])
 
+    @only_on_master
     def play_from_queue(self, index, start=True):
         """ Play a track from the queue by index. The index number is
         required as an argument, where the first index is 0.
@@ -422,6 +426,7 @@ class SoCo(_SocoSingletonBase):
             ('Speed', 1)
         ])
 
+    @only_on_master
     def play_uri(self, uri='', meta='', title='', start=True):
         """ Play a given stream. Pauses the queue.
         If there is no metadata passed in and there is a title set then a
@@ -482,6 +487,7 @@ class SoCo(_SocoSingletonBase):
             ('Speed', 1)
         ])
 
+    @only_on_master
     def stop(self):
         """ Stop the currently playing track.
 
@@ -496,6 +502,7 @@ class SoCo(_SocoSingletonBase):
             ('Speed', 1)
         ])
 
+    @only_on_master
     def seek(self, timestamp):
         """ Seeks to a given timestamp in the current track, specified in the
         format of HH:MM:SS or H:MM:SS.
@@ -515,6 +522,7 @@ class SoCo(_SocoSingletonBase):
             ('Target', timestamp)
         ])
 
+    @only_on_master
     def next(self):
         """ Go to the next track.
 
@@ -535,6 +543,7 @@ class SoCo(_SocoSingletonBase):
             ('Speed', 1)
         ])
 
+    @only_on_master
     def previous(self):
         """ Go back to the previously played track.
 
@@ -1517,6 +1526,7 @@ class SoCo(_SocoSingletonBase):
             metadata[camel_to_underscore(tag)] = int(response[tag])
         return response, metadata
 
+    @only_on_master
     def add_uri_to_queue(self, uri):
         """Adds the URI to the queue
 
@@ -1529,6 +1539,7 @@ class SoCo(_SocoSingletonBase):
         item = DidlObject(resources=res, title='', parent_id='', item_id='')
         return self.add_to_queue(item)
 
+    @only_on_master
     def add_to_queue(self, queueable_item):
         """ Adds a queueable item to the queue """
         metadata = to_didl_string(queueable_item)
@@ -1542,6 +1553,7 @@ class SoCo(_SocoSingletonBase):
         qnumber = response['FirstTrackNumberEnqueued']
         return int(qnumber)
 
+    @only_on_master
     def remove_from_queue(self, index):
         """ Remove a track from the queue by index. The index number is
         required as an argument, where the first index is 0.
@@ -1563,6 +1575,7 @@ class SoCo(_SocoSingletonBase):
             ('UpdateID', updid),
         ])
 
+    @only_on_master
     def clear_queue(self):
         """ Removes all tracks from the queue.
 
@@ -1685,6 +1698,7 @@ class SoCo(_SocoSingletonBase):
         return DidlPlaylistContainer(
             resources=res, title=title, parent_id='SQ:', item_id=item_id)
 
+    @only_on_master
     # pylint: disable=invalid-name
     def create_sonos_playlist_from_queue(self, title):
         """ Create a new Sonos playlist from the current queue.

--- a/soco/core.py
+++ b/soco/core.py
@@ -17,7 +17,6 @@ from .services import RenderingControl, AVTransport, ZoneGroupTopology
 from .services import AlarmClock
 from .groups import ZoneGroup
 from .exceptions import SoCoUPnPException, SoCoSlaveException
-    SoCoSlaveException
 from .data_structures import DidlPlaylistContainer,\
     SearchResult, Queue, DidlObject, DidlMusicAlbum,\
     from_didl_string, to_didl_string, DidlResource

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -60,3 +60,7 @@ class MusicServiceException(SoCoException):
 class UnknownXMLStructure(SoCoException):
 
     """Raised if XML with and unknown or unexpected structure is returned"""
+
+
+class SoCoSlaveException(SoCoException):
+    """Raised when a master command is called on a slave"""

--- a/unittest/test_core.py
+++ b/unittest/test_core.py
@@ -15,7 +15,28 @@ IP_ADDR = '192.168.1.101'
 
 @pytest.yield_fixture()
 def moco():
-    """ A mock soco with fake services.
+    """A mock soco with fake services and hardcoded is_coordinator
+
+    Allows calls to services to be tracked. Should not cause any network access
+    """
+    services = (
+        'AVTransport', 'RenderingControl', 'DeviceProperties',
+        'ContentDirectory', 'ZoneGroupTopology')
+    patchers = [mock.patch('soco.core.{0}'.format(service))
+                for service in services]
+    for patch in patchers:
+        patch.start()
+    with mock.patch("soco.SoCo.is_coordinator",
+                    new_callable=mock.PropertyMock) as is_coord:
+        is_coord = True
+        yield SoCo(IP_ADDR)
+    for patch in reversed(patchers):
+        patch.stop()
+
+
+@pytest.yield_fixture()
+def moco_only_on_master():
+    """A mock soco with fake services.
 
     Allows calls to services to be tracked. Should not cause any network access
     """
@@ -182,61 +203,33 @@ class TestAVTransport:
         )
 
     def test_soco_play(self, moco):
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = True
-            moco.play()
-            moco.avTransport.Play.assert_called_once_with(
-                [('InstanceID', 0), ('Speed', 1)]
-            )
-            is_coord.assert_called_once_with()
-
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = False
-            with pytest.raises(SoCoSlaveException):
-                moco.play()
-            is_coord.assert_called_once_with()
+        moco.play()
+        moco.avTransport.Play.assert_called_once_with(
+            [('InstanceID', 0), ('Speed', 1)]
+        )
 
     def test_soco_play_uri(self, moco):
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = True
-            uri = 'http://archive.org/download/TenD2005-07-16.flac16/TenD2005-07-16t10Wonderboy_64kb.mp3'
-            moco.play_uri(uri)
-            moco.avTransport.SetAVTransportURI.assert_called_once_with([
-                ('InstanceID', 0),
-                ('CurrentURI', uri),
-                ('CurrentURIMetaData', '')
-            ])
+        uri = 'http://archive.org/download/TenD2005-07-16.flac16/TenD2005-07-16t10Wonderboy_64kb.mp3'
+        moco.play_uri(uri)
+        moco.avTransport.SetAVTransportURI.assert_called_once_with([
+            ('InstanceID', 0),
+            ('CurrentURI', uri),
+            ('CurrentURIMetaData', '')
+        ])
 
     def test_soco_play_uri_calls_play(self, moco):
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = True
-            uri = 'http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3'
-            moco.play_uri(uri)
+        uri = 'http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3'
+        moco.play_uri(uri)
 
-            moco.avTransport.Play.assert_called_with(
-                [('InstanceID', 0), ('Speed', 1)]
-            )
+        moco.avTransport.Play.assert_called_with(
+            [('InstanceID', 0), ('Speed', 1)]
+        )
 
     def test_soco_pause(self, moco):
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = True
-            moco.pause()
-            moco.avTransport.Pause.assert_called_once_with(
-                [('InstanceID', 0), ('Speed', 1)]
-            )
-            is_coord.assert_called_once_with()
-
-        with mock.patch("soco.SoCo.is_coordinator",
-                        new_callable=mock.PropertyMock) as is_coord:
-            is_coord.return_value = False
-            with pytest.raises(SoCoSlaveException):
-                moco.pause()
-            is_coord.assert_called_once_with()
+        moco.pause()
+        moco.avTransport.Pause.assert_called_once_with(
+            [('InstanceID', 0), ('Speed', 1)]
+        )
 
     def test_soco_stop(self, moco):
         moco.stop()
@@ -759,3 +752,18 @@ class TestZoneGroupTopology:
                 'ZoneGroupState': ZGS
             }
         assert g.short_label == "Kitchen + 1"
+
+
+def test_only_on_master_true(moco_only_on_master):
+    with mock.patch('soco.SoCo.is_coordinator', new_callable=mock.PropertyMock) as is_coord:
+        is_coord.return_value = True
+        moco_only_on_master.play()
+        is_coord.assert_called_once_with()
+
+
+def test_not_on_master_false(moco_only_on_master):
+    with mock.patch('soco.SoCo.is_coordinator', new_callable=mock.PropertyMock) as is_coord:
+        is_coord.return_value = False
+        with pytest.raises(SoCoSlaveException):
+            moco_only_on_master.play()
+        is_coord.assert_called_once_with()


### PR DESCRIPTION
This is my attempt to solve the problem of calling master-only methods on a slave. It fixes this along the lines of option 2 as discussed here https://github.com/SoCo/SoCo/issues/138#issuecomment-44221244 by @lawrenceakka (Raises SoCoSlaveException when calling a master command on a slave). It is implemented as a decorator should be used to decorate all the master only methods in SoCo (of course it might it might turn out to be better to reverse the logic if there are many more master-only than master-and-slave method).

Right now it is only implemented on the play and pause method, because I wanted to get some input about whether you like this approach or not, before I start testing all the methods in SoCo for whether they can be called on a slave.

Please also have a look at the test modifications. This is my first run-in with mock (I spent about twice the time on the test modifications as I did on the implementation), so I'm very curious if there is a better way to adapt the tests for this change.

EDIT: I improved the test modifications, so that they actually are still unit tests, so it should be better now, but still could use a review.