### PR TITLE
Added support play line in from another Sonos player

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -859,10 +859,10 @@ class SoCo(_SocoSingletonBase):
             ('InstanceID', 0)
         ])
 
-    def switch_to_line_in(self, speaker = self):
+    def switch_to_line_in(self, speaker=None):
         """ Switch the speaker's input to line-in.
         
-        note:: optional SoCo instance to be passed as `speaker`, to use play line in for
+        note:: optional SoCo instance to be passed as `speaker`, to play line in for
         
         Returns:
         True if the Sonos speaker successfully switched to line-in.
@@ -874,10 +874,13 @@ class SoCo(_SocoSingletonBase):
         Raises SoCoException (or a subclass) upon errors.
 
         """
-
+        if not speaker: 
+            uid = self.uid
+        else:
+            uid = speaker.uid
         self.avTransport.SetAVTransportURI([
             ('InstanceID', 0),
-            ('CurrentURI', 'x-rincon-stream:{0}'.format(speaker.uid)),
+            ('CurrentURI', 'x-rincon-stream:{0}'.format(uid)),
             ('CurrentURIMetaData', '')
         ])
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -859,12 +859,14 @@ class SoCo(_SocoSingletonBase):
             ('InstanceID', 0)
         ])
 
-    def switch_to_line_in(self):
+    def switch_to_line_in(self, speaker = self):
         """ Switch the speaker's input to line-in.
-
+        
+        note:: optional SoCo instance to be passed as `speaker`, to use play line in for
+        
         Returns:
         True if the Sonos speaker successfully switched to line-in.
-
+        
         If an error occurs, we'll attempt to parse the error and return a UPnP
         error code. If that fails, the raw response sent back from the Sonos
         speaker will be returned.
@@ -875,7 +877,7 @@ class SoCo(_SocoSingletonBase):
 
         self.avTransport.SetAVTransportURI([
             ('InstanceID', 0),
-            ('CurrentURI', 'x-rincon-stream:{0}'.format(self.uid)),
+            ('CurrentURI', 'x-rincon-stream:{0}'.format(speaker.uid)),
             ('CurrentURIMetaData', '')
         ])
 


### PR DESCRIPTION
Current switch_to_line_in method does not support playing a line in source from another Sonos player. Amendments below allow method to be called with a SoCo instance as an argument to specify source line in to play. In same manner join method is called.

If Instance is omitted default behaviour will be to play current instances line in.
