### PR TITLE
Make sure to_didl_string returns unicode also on python 3

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -19,6 +19,7 @@ items such as tracks, playlists, composers, albums etc.
 
 from __future__ import unicode_literals
 
+import sys
 import warnings
 warnings.simplefilter('always', DeprecationWarning)
 import textwrap
@@ -52,7 +53,10 @@ def to_didl_string(*args):
         })
     for arg in args:
         didl.append(arg.to_element())
-    return XML.tostring(didl)
+    if sys.version_info[0] == 2:
+        return XML.tostring(didl)
+    else:
+        return XML.tostring(didl, encoding='unicode')
 
 
 def from_didl_string(string):


### PR DESCRIPTION
When I tried to add a uri to queue with python 3 I encountered an error (that the object returned by to_didl_string has no encode method) that suggested that to_didl_string does in fact not return a unicode string in python 3 the way the docstring says. I fixed this by adding the `encoding='unicode'` argument to `xml.etree.ElementTree.tostring` when on Python 3.

I guess this means I'm the only who has ever used SoCo on Python 3 since the new data structures, which is kind of disappointing :P for a big py3 proponent as me.