### PR TITLE
Iss308 fix add item to sonos playlist after data structure refactoring

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1516,7 +1516,6 @@ class SoCo(_SocoSingletonBase):
     def add_to_queue(self, queueable_item):
         """ Adds a queueable item to the queue """
         metadata = to_didl_string(queueable_item)
-        metadata.encode('utf-8')
         response = self.avTransport.AddURIToQueue([
             ('InstanceID', 0),
             ('EnqueuedURI', queueable_item.resources[0].uri),

--- a/soco/core.py
+++ b/soco/core.py
@@ -15,7 +15,7 @@ from .services import DeviceProperties, ContentDirectory
 from .services import RenderingControl, AVTransport, ZoneGroupTopology
 from .services import AlarmClock
 from .groups import ZoneGroup
-from .exceptions import DIDLMetadataError, SoCoUPnPException
+from .exceptions import SoCoUPnPException
 from .data_structures import DidlPlaylistContainer,\
     SearchResult, Queue, DidlObject, DidlMusicAlbum,\
     from_didl_string, to_didl_string, DidlResource

--- a/soco/core.py
+++ b/soco/core.py
@@ -1703,34 +1703,25 @@ class SoCo(_SocoSingletonBase):
                 be added
 
         """
-        # Check if the required attributes are there
-        for attribute in ['didl_metadata', 'uri']:
-            if not hasattr(queueable_item, attribute):
-                message = 'queueable_item has no attribute {0}'.\
-                    format(attribute)
-                raise AttributeError(message)
-        # Get the metadata
-        try:
-            metadata = XML.tostring(queueable_item.didl_metadata)
-        except DIDLMetadataError as exception:
-            message = ('The queueable item could not be enqueued, because it '
-                       'raised a DIDLMetadataError exception with the '
-                       'following message:\n{0}').format(str(exception))
-            raise ValueError(message)
-        if isinstance(metadata, str):
-            metadata = metadata.encode('utf-8')
-
+        # Get the update_id for the playlist
         response, _ = self._music_lib_search(sonos_playlist.item_id, 0, 1)
         update_id = response['UpdateID']
+
+        # Form the metadata for queueable_item
+        metadata = to_didl_string(queueable_item)
+
+        # Make the request
         self.avTransport.AddURIToSavedQueue([
             ('InstanceID', 0),
             ('UpdateID', update_id),
             ('ObjectID', sonos_playlist.item_id),
-            ('EnqueuedURI', queueable_item.uri),
+            ('EnqueuedURI', queueable_item.resources[0].uri),
             ('EnqueuedURIMetaData', metadata),
-            ('AddAtIndex', 4294967295)  # this field has always this value, we
-                                        # do not known the meaning of this
-                                        # "magic" number.
+            # 2 ** 32 - 1 = 4294967295, this field has always this value. Most
+            # likely, playlist positions are represented as a 32 bit uint and
+            # this is therefore the largest index possible. Asking to add at
+            # this index therefore probably amounts to adding it "at the end"
+            ('AddAtIndex', 4294967295)
         ])
 
     def get_item_album_art_uri(self, item):

--- a/unittest/test_core.py
+++ b/unittest/test_core.py
@@ -7,7 +7,7 @@ import mock
 from soco import SoCo
 from soco.groups import ZoneGroup
 from soco.xml import XML
-from soco.data_structures import DidlMusicTrack
+from soco.data_structures import DidlMusicTrack, to_didl_string
 from soco.exceptions import SoCoUPnPException
 
 IP_ADDR = '192.168.1.101'
@@ -378,9 +378,12 @@ class TestAVTransport:
         playlist = mock.Mock()
         playlist.item_id = 7
 
+        ressource = mock.Mock()
+        ressource.uri  = 'fake_uri'
         track = mock.Mock()
+        track.resources = [ressource]
         track.uri = 'fake_uri'
-        track.didl_metadata = XML.Element('a')
+        track.to_element.return_value = XML.Element('a')
 
         update_id = 100
 
@@ -405,7 +408,7 @@ class TestAVTransport:
              ('UpdateID', update_id),
              ('ObjectID', playlist.item_id),
              ('EnqueuedURI', track.uri),
-             ('EnqueuedURIMetaData', XML.tostring(track.didl_metadata)),
+             ('EnqueuedURIMetaData', to_didl_string(track)),
              ('AddAtIndex', 4294967295)]
         )
 


### PR DESCRIPTION
This is the PR that should fix issue #308. I merely change the implementation of the method to reflect the new data structures by essentially copying the implementation of add_to_queue.

This PR also removes a do-nothing-line from add_to_queue that was left after the fix in #306. At first I didn't understand why it even worked. In #306 I made sure that to_didle_string always returns a unicode object, the way its docstring suggests it should. But then I actually thought that the service call always wanted utf-8, because that is what is needed for the XML, so I was very surprised that the encoded version of the metadata was not assigned to anything and therefore not used. Then I checked up on and as it turns out the service calls does expect unicode (the way we originally decided, decode early, unicode inside, encode late), so that was the reason that it worked even with this line doing nothing. In any case, it is now removed.