### PR TITLE
Clear zone group cache and reparse zone group information after join …

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -14,7 +14,7 @@ from functools import wraps
 
 from .services import DeviceProperties, ContentDirectory
 from .services import RenderingControl, AVTransport, ZoneGroupTopology
-from .services import AlarmClock
+from .services import AlarmClock, zone_group_state_shared_cache
 from .groups import ZoneGroup
 from .exceptions import SoCoUPnPException, SoCoSlaveException
 from .data_structures import DidlPlaylistContainer,\
@@ -867,6 +867,8 @@ class SoCo(_SocoSingletonBase):
             ('CurrentURI', 'x-rincon:{0}'.format(master.uid)),
             ('CurrentURIMetaData', '')
         ])
+        zone_group_state_shared_cache.clear()
+        self._parse_zone_group_state()
 
     def unjoin(self):
         """ Remove this speaker from a group.
@@ -885,6 +887,8 @@ class SoCo(_SocoSingletonBase):
         self.avTransport.BecomeCoordinatorOfStandaloneGroup([
             ('InstanceID', 0)
         ])
+        zone_group_state_shared_cache.clear()
+        self._parse_zone_group_state()
 
     def switch_to_line_in(self):
         """ Switch the speaker's input to line-in.

--- a/unittest/test_core.py
+++ b/unittest/test_core.py
@@ -323,19 +323,19 @@ class TestAVTransport:
         assert queue_size == 384
         moco.contentDirectory.reset_mock()
 
-    def test_join(self, moco):
+    def test_join(self, moco_zgs):
         moco2 = mock.Mock()
         moco2.uid = "RINCON_000XXX1400"
-        moco.join(moco2)
-        moco.avTransport.SetAVTransportURI.assert_called_once_with(
+        moco_zgs.join(moco2)
+        moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
             [('InstanceID', 0),
-                ('CurrentURI', 'x-rincon:RINCON_000XXX1400'),
-                ('CurrentURIMetaData', '')]
+             ('CurrentURI', 'x-rincon:RINCON_000XXX1400'),
+             ('CurrentURIMetaData', '')]
         )
 
-    def test_unjoin(self, moco):
-        moco.unjoin()
-        moco.avTransport.BecomeCoordinatorOfStandaloneGroup\
+    def test_unjoin(self, moco_zgs):
+        moco_zgs.unjoin()
+        moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup\
             .assert_called_once_with([('InstanceID', 0)])
 
     def test_switch_to_line_in(self, moco_zgs):


### PR DESCRIPTION
…and unjoin. Fixes #321 

This PR fixes a problem where the un-joining (and sub-sequent joining) would not be reflected correctly in is_coordinator due to caching of the requests for the group information.

This PR fixes it by clearing the group information cache and re-reading it after each such join or un-join operation.


As this is a bug fix, I will commit shortly.