### PR TITLE
Radio redux

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -487,7 +487,30 @@ class SoCo(_SocoSingletonBase):
             return self.play()
         return False
 
-    @only_on_master
+    def play_stream(self, stream_object, start=True):
+        """Play a DIDL object as a stream
+
+        To play as a stream means that it will this single item without
+        affecting the queue
+
+        Args:
+            stream_object (DidlObject): A Didl Object that represents a stream
+            start (bool): Whether to start play back after adding the stream
+        """
+        # E.g. radio favorites are returned without an desc element. This hack
+        # may turn out to be insufficient if we want to try and play radio
+        # stations from music services in the future
+        if stream_object.desc is None:
+            stream_object.desc = 'SA_RINCON65031_'
+        meta = to_didl_string(stream_object).encode('utf-8')
+        self.avTransport.SetAVTransportURI([
+            ('InstanceID', 0),
+            ('CurrentURI', stream_object.resources[0].uri),
+            ('CurrentURIMetaData', meta)
+        ])
+        if start:
+            self.play()
+
     def pause(self):
         """Pause the currently playing track.
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -492,22 +492,24 @@ class SoCo(_SocoSingletonBase):
             return self.play()
         return False
 
+    @only_on_master
     def play_stream(self, stream_object, start=True):
         """Play a DIDL object as a stream
 
-        To play as a stream means that it will this single item without
+        To play as a stream means that this single will be played without
         affecting the queue
 
         Args:
             stream_object (DidlObject): A Didl Object that represents a stream
             start (bool): Whether to start play back after adding the stream
+
         """
         # E.g. radio favorites are returned without an desc element. This hack
         # may turn out to be insufficient if we want to try and play radio
         # stations from music services in the future
         if stream_object.desc is None:
             stream_object.desc = 'SA_RINCON65031_'
-        meta = to_didl_string(stream_object).encode('utf-8')
+        meta = to_didl_string(stream_object)
         self.avTransport.SetAVTransportURI([
             ('InstanceID', 0),
             ('CurrentURI', stream_object.resources[0].uri),

--- a/soco/core.py
+++ b/soco/core.py
@@ -16,7 +16,7 @@ import requests
 from . import config
 from .data_structures import (
     DidlObject, DidlPlaylistContainer, DidlResource,
-    Queue, from_didl_string, to_didl_string
+    Queue, from_didl_string, to_didl_string, SearchResult,
 )
 from .exceptions import SoCoSlaveException
 from .groups import ZoneGroup
@@ -494,7 +494,7 @@ class SoCo(_SocoSingletonBase):
 
     @only_on_master
     def play_stream(self, stream_object, start=True):
-        """Play a DIDL object as a stream
+        """Play a DIDL object as a stream.
 
         To play as a stream means that this single will be played without
         affecting the queue
@@ -502,7 +502,6 @@ class SoCo(_SocoSingletonBase):
         Args:
             stream_object (DidlObject): A Didl Object that represents a stream
             start (bool): Whether to start play back after adding the stream
-
         """
         # E.g. radio favorites are returned without an desc element. This hack
         # may turn out to be insufficient if we want to try and play radio
@@ -1336,15 +1335,19 @@ class SoCo(_SocoSingletonBase):
     def get_favorite_radio_shows(self, start=0, max_items=100):
         """Get favorite radio shows from Sonos' Radio app.
 
-        Returns:
-        A list containing the total number of favorites, the number of
-        favorites returned, and the actual list of favorite radio shows,
-        represented as a dictionary with `title` and `uri` keys.
+        .. note:: These objects returned by this method, cannot yet be browsed
+            to get to the actual playable shows. This functionality will be
+            added later. For now, the object are only for information.
 
-        Depending on what you're building, you'll want to check to see if the
-        total number of favorites is greater than the amount you
-        requested (`max_items`), if it is, use `start` to page through and
-        get the entire list of favorites.
+        Args:
+            start (int): The number to start the retrieval from.
+            max_items (int): The total number of results to return.
+
+        ``start`` and ``max_items`` are used for paging of the results.
+
+        Returns:
+            :class:`~.SearchResult`: A :class:`~.SearchResult` object,
+                containing both the search results and search metdata
         """
 
         return self.__get_radio_favorites('radio_shows', start, max_items)
@@ -1352,26 +1355,27 @@ class SoCo(_SocoSingletonBase):
     def get_favorite_radio_stations(self, start=0, max_items=100):
         """Get favorite radio stations from Sonos' Radio app.
 
-        Returns:
-        A list containing the total number of favorites, the number of
-        favorites returned, and the actual list of favorite radio stations,
-        represented as a dictionary with `title` and `uri` keys.
+        Args:
+            start (int): The number to start the retrieval from.
+            max_items (int): The total number of results to return.
 
-        Depending on what you're building, you'll want to check to see if the
-        total number of favorites is greater than the amount you
-        requested (`max_items`), if it is, use `start` to page through and
-        get the entire list of favorites.
+        ``start`` and ``max_items`` are used for paging of the results.
+
+        Returns:
+            :class:`~.SearchResult`: A :class:`~.SearchResult` object,
+                containing both the search results and search metdata
         """
         return self.__get_radio_favorites('radio_stations', start, max_items)
 
     def __get_radio_favorites(self, favorite_type, start=0, max_items=100):
         """ Helper method for `get_favorite_radio_*` methods.
 
-        Arguments:
-        favorite_type -- Specify either `radio_stations` or `radio_shows`.
-        start -- Which number to start the retrieval from. Used for paging.
-        max_items -- The total number of results to return.
+        Args:
+            favorite_type (str): Either `radio_stations` or `radio_shows`.
+            start (int): The number to start the retrieval from.
+            max_items (int): The total number of results to return.
 
+        ``start`` and ``max_items`` are used for paging of the results.
         """
         try:
             browse_type = favorite_type

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -472,9 +472,9 @@ class DidlObject(DidlMetaClass(str('DidlMetaClass'), (object,), {})):
 
     @classmethod
     def from_dict(cls, content):
-        """Create an instance from a dict.
+        r"""Create an instance from a dict.
 
-        An alternative constructor. Equivalent to DidlObject(**content).
+        An alternative constructor. Equivalent to DidlObject(\*\*content).
 
         Arg:
             content (dict): Dict containing metadata information.Required and

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -954,6 +954,13 @@ class DidlMusicGenre(DidlGenre):
     tag = 'item'
 
 
+class DidlRadioShow(DidlContainer):
+
+    """Class that represents a music genre."""
+
+    item_class = 'object.container.radioShow'
+
+
 ###############################################################################
 # SPECIAL LISTS                                                               #
 ###############################################################################


### PR DESCRIPTION
I have had this stuff laying around for a while. It is the last part of finally using data structures everywhere. The last part that was missing was the radio shows and favorites.

This PR adds a generic `play_stream` method, which plays a playable DidlObject as a stream i.e. in Sonos single play mode which doesn't affect the queue.

Besides this I have also changed the `get_favorite_radio_shows` and `get_favorite_radio_stations` methods to return DidlObjects (and cleaned them up a bit). This means that you can now do:

``` python
>>> import soco
>>> zone = soco.discover().pop()
>>> 
>>> stations = zone.get_favorite_radio_stations()
>>> print(stations)
SearchResult(items=[<DidlAudioBroadcast 'b'DR P3 93.9 (Euro Hits)'' at 0x7f199661cd68>, <DidlAudioBroadcast 'b'Radio ?stsj?lland 104.7 (World Music)'' at 0x7f199661cb00>], search_type='browse_favorite_radio_stations')
>>> 
>>> station = stations[0]
>>> zone.play_stream(station)
```

I seems to work good, `but I need help testing the favorite_radio_shows part`, as I have been unable to find a show I could mark as a favorite. I need someone that has a radio show favorite to either test that it works getting the favorite shows and that play_stream can play them or simple send me the name of the radio station and show, then I can test it myself.

Let me know what you think
