### PR TITLE
Fix capitalization of object.item.audioItem

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -598,7 +598,7 @@ class DidlAudioItem(DidlItem):
 
     """An audio item."""
 
-    item_class = 'object.item.audioitem'
+    item_class = 'object.item.audioItem'
     _translation = DidlItem._translation.copy()
     _translation.update(
         {


### PR DESCRIPTION
I was seeing exceptions like "soco.exceptions.DIDLMetadataError: Unknown UPnP class: object.item.audioItem" when subscribing to events.

Fixing the capitalization of DidlAudioItem's item_class member fixed it for me.