### PR TITLE
Event stream capture and replay

### DIFF
--- a/dev_tools/analyze_event_stream.py
+++ b/dev_tools/analyze_event_stream.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+
+"""Small utility to nicely format events"""
+
+from __future__ import print_function, unicode_literals
+
+import sys
+import textwrap
+import argparse
+import xml.dom.minidom
+import traceback
+
+try:
+    import pygments
+    # pylint: disable=no-name-in-module
+    from pygments.lexers import XmlLexer
+    from pygments.formatters import TerminalFormatter
+except ImportError:
+    print('Module "pygments" could not be imported. Please install it. '\
+        'Exiting!')
+    sys.exit(100)
+
+PLATFORM = sys.platform.lower()
+if PLATFORM == 'win32':
+    COLOR = False
+else:
+    COLOR = True
+
+from soco.xml import XML
+from soco.events import parse_event_xml
+
+
+def get_numbered_event_from_stream(filename, event_number):
+    """Return a numbered event from an event stream file"""
+    event_file = open(filename, 'rb')
+    message = 0
+    while True:
+        try:
+            size_bytes = event_file.read(20)
+            if len(size_bytes) != 20:
+                break
+            size = int(size_bytes)
+            xml_event = event_file.read(size)
+            if message == event_number:
+                event_file.close()
+                return xml_event, None, message
+            message += 1
+        except IOError:
+            break
+
+    event_file.close()
+    print('Event number {} not found'.format(event_number))
+    return None, None, None
+
+
+def get_first_event_with_exception(filename):
+    """Get the first event that produces an exception when parsed"""
+    event_file = open(filename, 'rb')
+    message_no = 0
+    while True:
+        try:
+            size_bytes = event_file.read(20)
+            if len(size_bytes) != 20:
+                break
+            size = int(size_bytes)
+            xml_event = event_file.read(size)
+            try:
+                parse_event_xml(xml_event)
+            except Exception:  # pylint: disable=broad-except
+                exception_string = traceback.format_exc()
+                return xml_event, exception_string, message_no
+        except IOError:
+            break
+        message_no += 1
+
+    event_file.close()
+    print('No events with exceptions found')
+    return None, None, None
+
+
+def extract_didl(event, didl_parts=None):
+    """Extract the DIDL content
+
+    Recursive substitute DIDL content with a placeholder and put the content
+    in a list
+    """
+    if didl_parts is None:
+        didl_parts = []
+
+    content = event.text
+    if event.text is not None and content.startswith('<'):
+        didl_parts.append(content)
+        event.text = '=== DIDL REPLACEMENT {} ==='.format(len(didl_parts) - 1)
+
+    content = event.attrib.get('val')
+    if content is not None and content.startswith('<'):
+        didl_parts.append(content)
+        event.attrib['val'] = '=== DIDL REPLACEMENT {} ==='.format(
+            len(didl_parts) - 1)
+
+    for element in event:
+        extract_didl(element, didl_parts)
+
+    return event, didl_parts
+
+
+def indent_and_color_xml(elementtree, color=False):
+    """Indent and color an elementtree and return as str"""
+    reparsed = xml.dom.minidom.parseString(XML.tostring(elementtree))
+    indented = reparsed.toprettyxml(indent="  ", newl="\n")
+    if indented.find('\n') > -1:
+        indented = indented[indented.find('\n') + 1:]
+    if color:
+        return pygments.highlight(indented, XmlLexer(), TerminalFormatter())
+    else:
+        return indented
+
+
+def __build_option_parser():
+    """ Build the option parser for this script """
+    description = """
+    Tool to output and nicely format single event from an event stream.
+    """
+    description = textwrap.dedent(description).strip()
+
+    parser = \
+        argparse.ArgumentParser(description=description,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('file_', metavar='FILE', type=str, nargs=1,
+                        help='the file to analyze')
+    parser.add_argument('event_number', metavar='EVENT_NUMBER', type=int,
+                        help='the event number to output, -1 means first '\
+                        'event that produces and exception when parsed')
+    parser.add_argument('-o', '--output-file', type=str,
+                        help='the output filename')
+    return parser
+
+
+def main():
+    """ Main method of the script """
+    parser = __build_option_parser()
+    args = parser.parse_args()
+    if args.event_number == -1:
+        event, exception, message_no = \
+            get_first_event_with_exception(args.file_[0])
+    else:
+        event, exception, message_no = \
+            get_numbered_event_from_stream(args.file_[0], args.event_number)
+    if event is None:
+        return
+
+    # First extract the didl parts from the main event
+    event, didl_parts = extract_didl(XML.fromstring(event))
+    didl_parts = [XML.fromstring(part) for part in didl_parts]
+    # Then extract DIDL parts from other DIDL parts
+    more_didl_parts = []
+    for didl_part in list(didl_parts):
+        _, more_didl_parts = extract_didl(didl_part, more_didl_parts)
+    more_didl_parts = [XML.fromstring(part) for part in more_didl_parts]
+
+    didl_parts += more_didl_parts
+
+    # Format and color the XML
+    use_color = COLOR and args.output_file is None
+    event = indent_and_color_xml(event, use_color)
+    didl_parts = [indent_and_color_xml(e, use_color) for e in didl_parts]
+
+    # Form output string
+    output_string = '##### EVENT {}\n{}\n'.format(message_no, event)
+
+    for didl_number, didl_part in enumerate(didl_parts):
+        output_string += '### DIDL REPLACEMENT {}\n{}\n'.format(didl_number,
+                                                                didl_part)
+    if exception is not None:
+        output_string += '### EXCEPTION\n{}'.format(exception)
+
+    if args.output_file is not None:
+        with open(args.output_file, 'wb') as file_:
+            file_.write(output_string.encode('ascii'))
+    else:
+        print(output_string)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests
-six

--- a/soco/events.py
+++ b/soco/events.py
@@ -79,7 +79,7 @@ def replay_event_stream(binary_file_like_object):
             size = int(size_bytes)
             xml_event = binary_file_like_object.read(size)
             event = parse_event_xml(xml_event)
-            print('########## {} ##########'.format(message))
+            print('########## {0} ##########'.format(message))
             print(event)
             message += 1
         except IOError:

--- a/soco/events.py
+++ b/soco/events.py
@@ -7,7 +7,7 @@ Classes to handle Sonos UPnP Events and Subscriptions
 
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 
 import threading
@@ -29,9 +29,64 @@ from .data_structures import from_didl_string
 
 
 log = logging.getLogger(__name__)  # pylint: disable=C0103
+event_stream = None  # pylint: disable=invalid-name
+event_stream_lock = threading.Lock()  # pylint: disable=invalid-name
 
 
-def parse_event_xml(xml_event):
+def activate_event_stream_logging(binary_file_like_object):
+    """Activate event stream logging
+
+    Args:
+        binary_file_like_object (file_like_object): A file like object or
+            stream, writable and in binary mode
+    """
+    global event_stream  # pylint: disable=global-statement,invalid-name
+    event_stream = binary_file_like_object
+
+
+def save_event_to_stream(xml_event):
+    """Save a single event to the stream
+
+    The format of the event stream is a simple 20 digit zero padded number of
+    bytes that the event content consists of and then the content.
+    """
+    length = '{0:0>20}'.format(len(xml_event)).encode('ascii')
+    with event_stream_lock:
+        event_stream.write(length)
+        event_stream.write(xml_event)
+        try:
+            event_stream.flush()
+        except AttributeError:
+            pass
+
+
+def replay_event_stream(binary_file_like_object):
+    """Replay an event stream.
+
+    Replay will start at current position. See save_event_to_stream for
+    specification on the format.
+
+    Args:
+        binary_file_like_object (file_like_object): A file like object or
+            stream in binary mode
+    """
+    message = 0
+    while True:
+        try:
+            size_bytes = binary_file_like_object.read(20)
+            if len(size_bytes) != 20:
+                break
+            size = int(size_bytes)
+            xml_event = binary_file_like_object.read(size)
+            event = parse_event_xml(xml_event)
+            print('########## {} ##########'.format(message))
+            print(event)
+            message += 1
+        except IOError:
+            break
+
+
+def parse_event_xml(xml_event):  # pylint: disable=too-many-branches
     """ Parse the body of a UPnP event
 
     Arg:
@@ -86,6 +141,9 @@ def parse_event_xml(xml_event):
 
 
     """
+    # If activated, save the event to the event stream
+    if event_stream is not None:
+        save_event_to_stream(xml_event)
 
     result = {}
     tree = XML.fromstring(xml_event)

--- a/soco/events.py
+++ b/soco/events.py
@@ -78,8 +78,8 @@ def replay_event_stream(binary_file_like_object):
                 break
             size = int(size_bytes)
             xml_event = binary_file_like_object.read(size)
-            event = parse_event_xml(xml_event)
             print('########## {0} ##########'.format(message))
+            event = parse_event_xml(xml_event)
             print(event)
             message += 1
         except IOError:

--- a/unittest/test_events.py
+++ b/unittest/test_events.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import pytest
 import mock
-from six import BytesIO
+from io import BytesIO
 from soco.events import parse_event_xml, Event, activate_event_stream_logging
 from soco import events
 


### PR DESCRIPTION
Hallo everyone

(first of, and besides the main content here, I have added ``six`` to the requirements. It is a convenience module used by **everyone** for easier 2 and 3 compatible imports of things that changed name or nature and is written by one of the core maintainers. I suspect we can replace much or our own code that does this, with this more well tested module, but in here, I just use to get a BytesIO object. If you think this must be handled in a separate PR, then let me know)

Troubleshooting problems with the events code, can be annoying, since they may depend on special circumstances at the person who experiences the bug, and therefore be difficult or impossible for someone else to reproduce, which makes them harder to troubleshoot.

I have attempted to make this easier, by adding functionality to events.py, to allow us to capture a stream of content passed to the function that parses the events, ``parse_event_xml``, as this is often where the errors happen when we have bugs with events. This stream can be saved e.g. to a file, which can be sent along with the bug report. The person investigating the issue, can the replay it and get the same error.

To capture an event stream, simply pass the ``events.activate_event_stream_logging`` function a binary file like object:

```python
from soco import events
file_object = open('event_stream.bin', 'wb')
events.activate_event_stream_logging(file_object)
# Then follow all your usual event code, with making subscriptions etc.
```

When each is saved, the object is flushed, so it wont matter if an exception stops the program, you will still have the stream. To replay the stream do:
```python
from soco import events
file_object = open('event_stream.bin', 'rb')
events.replay_event_stream(file_object)
```
and that is it.

Besides the code to simply replay the event stream I have also added a dev tool to nicely format an event (These events are XML inside XML inside XML, which can be a bit annoying). It is located in dev_tools and is named ``analyze_event_stream.py``. It takes a filename of the event stream file and the numbers of the event you want formatted as arguments. The number can also be set to -1, which means, show me the first event that raises an exception (the exception will then also be output). So, to see an event from a healthy stream you do e.g `python analyze_event_stream.py event_stream.bin 2` and get:

```XML
##### EVENT 2
<ns0:propertyset xmlns:ns0="urn:schemas-upnp-org:event-1-0">
  <ns0:property>
    <LastChange>=== DIDL REPLACEMENT 0 ===</LastChange>
  </ns0:property>
</ns0:propertyset>

### DIDL REPLACEMENT 0
<ns0:Event xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/RCS/">
  <ns0:InstanceID val="0">
    <ns0:Volume channel="Master" val="8"/>
    <ns0:Volume channel="LF" val="100"/>
    <ns0:Volume channel="RF" val="100"/>
  </ns0:InstanceID>
</ns0:Event>
```

and when looking at a stream with that raises an exception you do: `python analyze_event_stream.py event_stream2.bin -1` and get:

```XML
##### EVENT 0
<ns0:propertyset xmlns:ns0="urn:schemas-upnp-org:event-1-0">
  <ns0:property>
    <LastChange>=== DIDL REPLACEMENT 0 ===</LastChange>
  </ns0:property>
</ns0:propertyset>

### DIDL REPLACEMENT 0
<ns0:Event xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/AVT/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/">
  <ns0:InstanceID val="0">
    <ns0:TransportState val="STOPPED"/>
    <ns0:CurrentPlayMode val="NORMAL"/>
    <ns0:CurrentCrossfadeMode val="0"/>
    <ns0:NumberOfTracks val="48"/>
    <ns0:CurrentTrack val="1"/>
    <ns0:CurrentSection val="0"/>
    <ns0:CurrentTrackURI val="x-sonos-http:tr%3a13539832.mp3?sid=2&amp;flags=8224&amp;sn=3"/>
    <ns0:CurrentTrackDuration val="0:04:34"/>
    <ns0:CurrentTrackMetaData val="=== DIDL REPLACEMENT 0 ==="/>
    <r:NextTrackURI val="x-sonos-http:tr%3a4007095.mp3?sid=2&amp;flags=8224&amp;sn=3"/>
    <r:NextTrackMetaData val="=== DIDL REPLACEMENT 1 ==="/>
    <r:EnqueuedTransportURI val="x-rincon-cpcontainer:0006206cplaylist_spotify%3aplaylist-534597253"/>
    <r:EnqueuedTransportURIMetaData val="=== DIDL REPLACEMENT 2 ==="/>
    <ns0:PlaybackStorageMedium val="NETWORK"/>
    <ns0:AVTransportURI val="x-rincon-queue:RINCON_B8E93781F3EA01400#0"/>
    <ns0:AVTransportURIMetaData val=""/>
    <ns0:NextAVTransportURI val=""/>
    <ns0:NextAVTransportURIMetaData val=""/>
    <ns0:CurrentTransportActions val="Set, Play, Stop, Pause, Seek, Next, Previous"/>
    <r:CurrentValidPlayModes val="SHUFFLE,REPEAT,CROSSFADE"/>
    <r:MuseSessions val=""/>
    <ns0:TransportStatus val="OK"/>
    <r:SleepTimerGeneration val="0"/>
    <r:AlarmRunning val="0"/>
    <r:SnoozeRunning val="0"/>
    <r:RestartPending val="0"/>
    <ns0:TransportPlaySpeed val="NOT_IMPLEMENTED"/>
    <ns0:CurrentMediaDuration val="NOT_IMPLEMENTED"/>
    <ns0:RecordStorageMedium val="NOT_IMPLEMENTED"/>
    <ns0:PossiblePlaybackStorageMedia val="NONE, NETWORK"/>
    <ns0:PossibleRecordStorageMedia val="NOT_IMPLEMENTED"/>
    <ns0:RecordMediumWriteStatus val="NOT_IMPLEMENTED"/>
    <ns0:CurrentRecordQualityMode val="NOT_IMPLEMENTED"/>
    <ns0:PossibleRecordQualityModes val="NOT_IMPLEMENTED"/>
  </ns0:InstanceID>
</ns0:Event>

### DIDL REPLACEMENT 1
<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
  <item id="-1" parentID="-1" restricted="true">
    <res duration="0:04:34" protocolInfo="sonos.com-http:*:audio/mpeg:*">x-sonos-http:tr%3a13539832.mp3?sid=2&amp;flags=8224&amp;sn=3</res>
    <r:streamContent/>
    <r:radioShowMd/>
    <upnp:albumArtURI>/getaa?s=1&amp;u=x-sonos-http%3atr%253a13539832.mp3%3fsid%3d2%26flags%3d8224%26sn%3d3</upnp:albumArtURI>
    <dc:title>Sweet Emotion</dc:title>
    <upnp:class>object.item.audioItem.musicTrack</upnp:class>
    <dc:creator>Aerosmith</dc:creator>
    <upnp:album>Devil's Got a New Disguise - The Very Best of Aerosmith</upnp:album>
  </item>
</DIDL-Lite>

### DIDL REPLACEMENT 2
<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
  <item id="-1" parentID="-1" restricted="true">
    <res duration="0:04:44" protocolInfo="sonos.com-http:*:audio/mpeg:*">x-sonos-http:tr%3a4007095.mp3?sid=2&amp;flags=8224&amp;sn=3</res>
    <upnp:albumArtURI>/getaa?s=1&amp;u=x-sonos-http%3atr%253a4007095.mp3%3fsid%3d2%26flags%3d8224%26sn%3d3</upnp:albumArtURI>
    <dc:title>More Than a Feeling</dc:title>
    <upnp:class>object.item.audioItem.musicTrack</upnp:class>
    <dc:creator>Boston</dc:creator>
    <upnp:album>Essential 70s Rock</upnp:album>
  </item>
</DIDL-Lite>

### DIDL REPLACEMENT 3
<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
  <item id="0006206cplaylist_spotify%3aplaylist-534597253" parentID="000d2064charts-playlists-152" restricted="true">
    <dc:title>03. Classic Rock</dc:title>
    <upnp:class>object.container.playlistContainer</upnp:class>
    <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON519_XXXXXXXXX@gmail.com</desc>
  </item>
</DIDL-Lite>

### EXCEPTION
Traceback (most recent call last):
  File "analyze_event_stream.py", line 68, in get_first_event_with_exception
    parse_event_xml(xml_event)
  File "/home/kenneth/venv/soco/SoCo/soco/events.py", line 194, in parse_event_xml
    value = from_didl_string(value)[0]
  File "/home/kenneth/venv/soco/SoCo/soco/data_structures.py", line 82, in from_didl_string
    items.append(cls.from_element(elt))
  File "/home/kenneth/venv/soco/SoCo/soco/data_structures.py", line 362, in from_element
    " got '<{1}>'".format(cls.tag, element.tag))
soco.exceptions.DIDLMetadataError: Wrong element. Expected '<container>', got '<{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item>'
```
Notice how in internal XML is extracted and replaced by placeholders. It will also output with syntax highlighting on Linux terminals;)

The dev tool also takes an optional -o argument, which if given, then the output will be written to that file instead for the terminal.

Let me know what you think.