### PR TITLE
Preliminary speaker info with more information

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1095,21 +1095,38 @@ class SoCo(_SocoSingletonBase):
             return self.speaker_info
         else:
             response = requests.get('http://' + self.ip_address +
-                                    ':1400/status/zp')
-            dom = XML.fromstring(response.content)
+                                    ':1400/xml/device_description.xml')
+            dom = XML.fromstring(response.content.encode('UTF-8'))
 
-        if dom.findtext('.//ZoneName') is not None:
-            self.speaker_info['zone_name'] = \
-                dom.findtext('.//ZoneName')
-            self.speaker_info['zone_icon'] = dom.findtext('.//ZoneIcon')
+        device = dom.find('{urn:schemas-upnp-org:device-1-0}device')
+        if device is not None:
+            self.speaker_info['zone_name'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}roomName')
+
+            # no zone icon in device_description.xml -> player icon
+            self.speaker_info['player_icon'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}iconList/'
+                '{urn:schemas-upnp-org:device-1-0}icon/'
+                '{urn:schemas-upnp-org:device-1-0}url'
+            )
+
             self.speaker_info['uid'] = self.uid
-            self.speaker_info['serial_number'] = \
-                dom.findtext('.//SerialNumber')
-            self.speaker_info['software_version'] = \
-                dom.findtext('.//SoftwareVersion')
-            self.speaker_info['hardware_version'] = \
-                dom.findtext('.//HardwareVersion')
-            self.speaker_info['mac_address'] = dom.findtext('.//MACAddress')
+            self.speaker_info['serial_number'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}serialNum')
+            self.speaker_info['software_version'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}softwareVersion')
+            self.speaker_info['hardware_version'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}hardwareVersion')
+            self.speaker_info['model_number'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}modelNumber')
+            self.speaker_info['model_name'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}modelName')
+            self.speaker_info['display_version'] = device.findtext(
+                '{urn:schemas-upnp-org:device-1-0}displayVersion')
+
+            # no mac adress - extract from serial number
+            mac = self.speaker_info['serial_number'].split(':')[0]
+            self.speaker_info['mac_address'] = mac
 
             return self.speaker_info
 

--- a/unittest/soco_unittest.py
+++ b/unittest/soco_unittest.py
@@ -316,14 +316,16 @@ class GetSpeakerInfo(unittest.TestCase):
     def setUp(self):  # pylint: disable-msg=C0103
         # The values in this list must be kept up to date with the values in
         # the test doc string
-        self.info_keys = sorted(['zone_name', 'zone_icon', 'uid',
+        self.info_keys = sorted(['zone_name', 'player_icon', 'uid',
                                  'serial_number', 'software_version',
-                                 'hardware_version', 'mac_address'])
+                                 'hardware_version', 'mac_address',
+                                 'model_name', 'model_number',
+                                 'display_version'])
 
     def test(self):
         """ Tests if the return value is a dictionary that contains the keys:
-        zone_name, zone_icon, uid, serial_number, software_version,
-        hardware_version, mac_address
+        zone_name, player_icon, uid, serial_number, software_version,
+        hardware_version, mac_address, model_name, model_number, display_version
         and that values have been found for all keys, i.e. they are not None
         """
         speaker_info = SOCO.get_speaker_info()


### PR DESCRIPTION
Updated the ```get_speaker_info()``` function to parse ```xml/device_description.xml``` as described in #320

- changed zone_icon to player_icon
- added model_number
- added model_name
- added display_version

No unit tests yet