### PR TITLE
Better list slicing, removing deprecated code

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1867,7 +1867,7 @@ class SoCo(_SocoSingletonBase):
             full_album_art_uri=full_album_art_uri,
             subcategories=subcategories, search_term=track,
             complete_result=True)
-        result._metadata['search_type'] = 'search_track'
+        result.search_type = 'search_track'
         return result
 
     def get_albums_for_artist(self, artist, full_album_art_uri=False):
@@ -1892,12 +1892,10 @@ class SoCo(_SocoSingletonBase):
         # It is necessary to update the list of items in two places, due to
         # a bug in SearchResult
         result[:] = reduced
-        result._metadata.update({
-            'item_list': reduced,
-            'search_type': 'albums_for_artist',
-            'number_returned': len(reduced),
-            'total_matches': len(reduced)
-        })
+        result.item_list = reduced
+        result.search_type = 'albums_for_artist'
+        result.number_returned = len(reduced)
+        result.total_matches = len(reduced)
         return result
 
     def get_tracks_for_album(self, artist, album, full_album_art_uri=False):
@@ -1919,7 +1917,7 @@ class SoCo(_SocoSingletonBase):
             full_album_art_uri=full_album_art_uri,
             subcategories=subcategories,
             complete_result=True)
-        result._metadata['search_type'] = 'tracks_for_album'
+        result.search_type = 'tracks_for_album'
         return result
 
     @property

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -19,15 +19,13 @@ items such as tracks, playlists, composers, albums etc.
 
 from __future__ import unicode_literals
 
+import collections
+import operator
 import sys
-import warnings
-warnings.simplefilter('always', DeprecationWarning)
-import textwrap
-
-from .xml import XML, ns_tag
 
 from .exceptions import DIDLMetadataError
 from .utils import really_unicode
+from .xml import XML, ns_tag
 
 
 ###############################################################################
@@ -394,6 +392,7 @@ class DidlObject(DidlMetaClass(str('DidlMetaClass'), (object,), {})):
             # way.
             setattr(self, key, value)
 
+    # pylint: disable=too-many-locals
     @classmethod
     def from_element(cls, element):
         """Create an instance of this class from an ElementTree xml Element.
@@ -967,60 +966,98 @@ class DidlMusicGenre(DidlGenre):
 # SPECIAL LISTS                                                               #
 ###############################################################################
 
-class ListOfMusicInfoItems(list):
+class ListOfMusicInfoItems(collections.Sequence):
 
-    """Abstract container class for a list of music information items."""
+    """
+    Base class for various lists of music information items.
+
+    This is a in effect a read only list with additional attributes and
+    extended slicing semantics.
+
+    Example:
+
+        >>> alist = ListOfMusicInfoItems(
+        ...     [1, 2, 3, 4, 5, 6, 7],
+        ...     number_returned=7,
+        ...     total_matches=7,
+        ...     update_id=0
+        ... )
+        >>> alist
+        ListOfMusicInfoItems(items=[1, 2, 3, 4, 5, 6, 7])
+
+        Standard slicing and negative indices
+
+        >>> alist[2]
+        3
+        >>> alist[2:5]
+        [3, 4, 5]
+        >>> alist[-2]
+        6
+
+        Multiple slices
+
+        >>> alist[1:3, 5:6]
+        [2, 3, 6]
+
+        Repetition of indices
+
+        >>> alist[3, 3, 3]
+        [4, 4, 4]
+
+        Steps are supported
+
+        >>> alist[3:7:2]
+        [4, 6]
+
+    """
 
     def __init__(self, items, number_returned, total_matches, update_id):
-        super(ListOfMusicInfoItems, self).__init__(items)
-        self._metadata = {
-            'item_list': list(items),
-            'number_returned': number_returned,
-            'total_matches': total_matches,
-            'update_id': update_id,
-        }
+        self._items = items
+        self.number_returned = number_returned
+        self.total_matches = total_matches
+        self.update_id = update_id
+        # self._metadata = {
+        #     'item_list': list(items),
+        #     'number_returned': number_returned,
+        #     'total_matches': total_matches,
+        #     'update_id': update_id,
+        # }
+
+    def __len__(self):
+        return len(self._items)
 
     def __getitem__(self, key):
-        """Legacy get metadata by string key or list item(s) by index.
-
-        DEPRECATION: This overriding form of __getitem__ will be removed in
-        the 3rd release after 0.8. The metadata can be fetched via the named
-        attributes
-        """
-        if key in self._metadata:
-            if key == 'item_list':
-                message = """
-                Calling [\'item_list\'] on search results to obtain the objects
-                is no longer necessary, since the object returned from searches
-                now is a list. This deprecated way of getting the items will
-                be removed from the third release after 0.8."""
-            else:
-                message = """
-                Getting metadata items by indexing the search result like a
-                dictionary [\'{0}\'] is deprecated. Please use the named
-                attribute {1}.{0} instead. The deprecated way of retrieving the
-                metadata will be removed from the third release after
-                0.8""".format(key, self.__class__.__name__)
-            message = textwrap.dedent(message).replace('\n', ' ').lstrip()
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            return self._metadata[key]
+        # This method is called whenever the list is indexed
+        # i.e. alist[someindex].  key is set to the index sought, so it can
+        # be a slice (alist[1:3] => key = slice(1, 3, None)), or an integer
+        # (alist[3] => key = 3). If multiple indices are provided, key will
+        # be an iterable containing integers and slices
+        # (alist[1, 2:3, 27:9:-1) => key = (1, slice(2, 3, None), slice(27, 9,
+        # -1))
+        result = []
+        # First, check whether we have multiple indices
+        if isinstance(key, collections.Iterable):
+            # For each index, get the item or slice from the underlying list
+            # The result will be a list of lists and integers
+            interim = [operator.getitem(self._items, i) for i in
+                       key]
+            # Flatten that list of lists and integers
+            for entry in interim:
+                if isinstance(entry, list):
+                    for each in entry:
+                        result.append(each)
+                else:
+                    result.append(entry)
         else:
-            return super(ListOfMusicInfoItems, self).__getitem__(key)
+            # Only one index or slice was requested, so get it
+            result = operator.getitem(self._items, key)
+        return result
 
-    @property
-    def number_returned(self):
-        """The number of returned matches."""
-        return self._metadata['number_returned']
-
-    @property
-    def total_matches(self):
-        """The number of total matches."""
-        return self._metadata['total_matches']
-
-    @property
-    def update_id(self):
-        """The update ID."""
-        return self._metadata['update_id']
+    def __repr__(self):
+        return '{0}(items={1})'.format(
+            self.__class__.__name__,
+            self._items.__repr__(),
+        )
 
 
 class SearchResult(ListOfMusicInfoItems):
@@ -1035,31 +1072,16 @@ class SearchResult(ListOfMusicInfoItems):
         super(SearchResult, self).__init__(
             items, number_returned, total_matches, update_id
         )
-        self._metadata['search_type'] = search_type
+        self.search_type = search_type
 
     def __repr__(self):
         return '{0}(items={1}, search_type=\'{2}\')'.format(
             self.__class__.__name__,
-            super(SearchResult, self).__repr__(),
+            self._items.__repr__(),
             self.search_type)
-
-    @property
-    def search_type(self):
-        """The search type."""
-        return self._metadata['search_type']
 
 
 class Queue(ListOfMusicInfoItems):
 
     """Container class that represents a queue."""
-
-    def __init__(self, items, number_returned, total_matches, update_id):
-        super(Queue, self).__init__(
-            items, number_returned, total_matches, update_id
-        )
-
-    def __repr__(self):
-        return '{0}(items={1})'.format(
-            self.__class__.__name__,
-            super(Queue, self).__repr__(),
-        )
+    pass

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the special lists in data_structures
+"""
+
+from __future__ import unicode_literals
+
+import pytest
+
+from soco.data_structures import ListOfMusicInfoItems
+
+
+def test_lomi():
+    lomi = ListOfMusicInfoItems(items=['one', 'two', 3, 4], number_returned=5,
+                                total_matches=5, update_id=12)
+    assert lomi.number_returned == 5
+    assert lomi.total_matches == 5
+    assert lomi.update_id == 12
+    assert len(lomi) == 4
+
+    # Slicing
+    assert lomi[0] == 'one'
+    assert lomi[-1] == 4
+    assert lomi[1:3] == ['two', 3]
+    assert lomi[3:1] == []
+    assert lomi[3:1:-1] == [4, 3]
+    assert lomi[:] == ['one', 'two', 3, 4]
+
+    # Multiple slices
+
+    assert lomi[0, 1:4, 3] == ['one', 'two', 3, 4, 4]
+    assert lomi[0, 0, 1, 1] == ['one', 'one', 'two', 'two']
+
+    # Read only.  Setting is not allowed
+    with pytest.raises(TypeError):
+        lomi[2] = 3


### PR DESCRIPTION
1) deprecated code in data_structures removed, and attribute fetching is streamlined.

2) ListOfMusicInfoItems is no longer a subclass of `list`, but a subclass of `collections.Sequence`. This makes it read only (which is what we want, for the moment), but also allows us do fancy indexing, which will be useful for playlists.

``` python
>>> alist = ListOfMusicInfoItems(
...     [1, 2, 3, 4, 5, 6, 7],
...     number_returned=7,
...     total_matches=7,
...     update_id=0
... )
>>> alist
ListOfMusicInfoItems(items=[1, 2, 3, 4, 5, 6, 7])

# Standard slicing and negative indices

>>> alist[2]
3
>>> alist[2:5]
[3, 4, 5]
>>> alist[-2]
6

# Multiple slices

>>> alist[1:3, 5:6]
[2, 3, 6]

#Repetition of indices

>>> alist[3, 3, 3]
[4, 4, 4]

#Steps are supported

>>> alist[3:7:2]
[4, 6]
```

3) tests - these lists were previously without them
