### PR TITLE
Minor fix because ordereddict.values in py3 return ValuesView

### DIFF
--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -181,10 +181,10 @@ class MusicServiceSoapClient(object):
 
         # The top key in the OrderedDict will be the methodResult. Its
         # value may be None if no results were returned.
-        result = parse(
+        result = list(parse(
             XML.tostring(result_elt), process_namespaces=True,
             namespaces={'http://www.sonos.com/Services/1.1': None}
-        ).values()[0]
+        ).values())[0]
 
         return result if result is not None else {}
 


### PR DESCRIPTION
This is just a minor bugfix to the music services code. The xmltodict.parse returns an ordereddict and asking it for its values on python2 return a list but on python3 returns a valuesview. The latter does not support indexing, so simply turn it into a list first.