### PR TITLE
Fix tests raising unwanted Deprecation Warnings

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -659,7 +659,7 @@ class TestAVTransport:
         moco.contentDirectory.Browse.side_effect = SoCoUPnPException(
             "No such object", "701", "error XML")
 
-        result = moco.search_track("artist")
+        result = moco.music_library.search_track("artist")
 
         assert len(result) == 0
 
@@ -684,7 +684,7 @@ class TestAVTransport:
             'UpdateID': '0'
         }
 
-        result = moco.search_track("artist", "album", "track")
+        result = moco.music_library.search_track("artist", "album", "track")
 
         assert len(result) == 0
 
@@ -706,7 +706,7 @@ class TestAVTransport:
             'TotalMatches': '2',
             'UpdateID': '0'
         }
-        results = moco.search_track("The Artist")
+        results = moco.music_library.search_track("The Artist")
 
         assert results.number_returned == 2
 
@@ -736,7 +736,7 @@ class TestAVTransport:
             'UpdateID': '0'
         }
 
-        results = moco.search_track("The Artist", "The Album")
+        results = moco.music_library.search_track("The Artist", "The Album")
 
         assert len(results) == 3
 
@@ -765,15 +765,15 @@ class TestContentDirectory:
     def test_soco_library_updating(self, moco):
         moco.contentDirectory.GetShareIndexInProgress.return_value = {
             'IsIndexing': '0'}
-        assert not moco.library_updating
+        assert not moco.music_library.library_updating
         moco.contentDirectory.reset_mock()
         moco.contentDirectory.GetShareIndexInProgress.return_value = {
             'IsIndexing': '1'}
-        assert moco.library_updating
+        assert moco.music_library.library_updating
 
     def test_soco_start_library_update(self, moco):
         moco.contentDirectory.RefreshShareIndex.return_value = True
-        assert moco.start_library_update()
+        assert moco.music_library.start_library_update()
         moco.contentDirectory.RefreshShareIndex.assert_called_with([
             ('AlbumArtistDisplayOption', ''),
         ])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -417,7 +417,7 @@ class TestSonosPlaylist(object):
         playlist = soco.create_sonos_playlist_from_queue(self.playlist_name)
         assert type(playlist) is DidlPlaylistContainer
 
-        prslt = soco.browse(ml_item=playlist)
+        prslt = soco.music_library.browse(ml_item=playlist)
         qrslt = soco.get_queue()
         assert len(prslt) == len(qrslt)
         assert prslt.total_matches == qrslt.total_matches


### PR DESCRIPTION
fixed up tests that were calling recently moved .music_library methods. Closes issue #366.
