### PR TITLE
Add playmodes REPEAT_ONE and SHUFFLE_REPEAT_ONE 

### DIFF
--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -113,7 +113,8 @@ class Alarm(object):
                 `program_uri`. Defaults to ''.
             play_mode(str, optional): The play mode for the alarm. Can be one
                 of ``NORMAL``, ``SHUFFLE_NOREPEAT``, ``SHUFFLE``,
-                ``REPEAT_ALL``. Defaults to ``NORMAL``.
+                ``REPEAT_ALL``, ``REPEAT_ONE``, ``SHUFFLE_REPEAT_ONE``.
+                Defaults to ``NORMAL``.
             volume (int, optional): The alarm's volume (0-100). Defaults to 20.
             include_linked_zones (bool, optional): `True` if the alarm should
                 be played on the other speakers in the same group, `False`
@@ -153,7 +154,7 @@ class Alarm(object):
         `str`: The play mode for the alarm.
 
             Can be one of ``NORMAL``, ``SHUFFLE_NOREPEAT``, ``SHUFFLE``,
-            ``REPEAT_ALL``.
+            ``REPEAT_ALL``, ``REPEAT_ONE``, ``SHUFFLE_REPEAT_ONE``.
         """
         return self._play_mode
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -1850,7 +1850,8 @@ NS = {'dc': '{http://purl.org/dc/elements/1.1/}',
       'upnp': '{urn:schemas-upnp-org:metadata-1-0/upnp/}',
       '': '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}'}
 # Valid play modes
-PLAY_MODES = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL', 'SHUFFLE_REPEAT_ONE', 'REPEAT_ONE')
+PLAY_MODES = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL',
+              'SHUFFLE_REPEAT_ONE', 'REPEAT_ONE')
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo

--- a/soco/core.py
+++ b/soco/core.py
@@ -1850,7 +1850,7 @@ NS = {'dc': '{http://purl.org/dc/elements/1.1/}',
       'upnp': '{urn:schemas-upnp-org:metadata-1-0/upnp/}',
       '': '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}'}
 # Valid play modes
-PLAY_MODES = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL')
+PLAY_MODES = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL', 'SHUFFLE_REPEAT_ONE', 'REPEAT_ONE')
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -305,7 +305,7 @@ class TestSoco:
 class TestAVTransport:
 
     @pytest.mark.parametrize('playmode', [
-        "NORMAL", "REPEAT_ALL", "SHUFFLE", "SHUFFLE_NOREPEAT"
+        "NORMAL", "SHUFFLE_NOREPEAT", "SHUFFLE", "REPEAT_ALL", "SHUFFLE_REPEAT_ONE", "REPEAT_ONE"
     ])
     def test_soco_play_mode_values(self, moco, playmode):
         moco.avTransport.GetTransportSettings.return_value = {


### PR DESCRIPTION
As of version 6.0, Sonos supports playmodes REAPEAT_ONE and SHUFFLE_REPEAT_ONE (http://www.sonos.com/software/release/6-0).

The commits add the new playmodes to soco/alarms.py, soco/core.py, and tests/test_core.py.