### PR TITLE
Pylint fixes for new version

### DIFF
--- a/soco/compat.py
+++ b/soco/compat.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=unused-import,import-error,no-name-in-module
+# pylint: disable=unused-import,import-error,no-name-in-module,
+# pylint: disable=ungrouped-imports
 
 """This module contains various compatibility definitions and imports.
 

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable = star-args, too-many-arguments
+# pylint: disable = star-args, too-many-arguments, unsupported-membership-test
+# pylint: disable = not-an-iterable
 
 """This module contains all the data structures for music service plugins."""
 

--- a/soco/plugins/__init__.py
+++ b/soco/plugins/__init__.py
@@ -25,7 +25,7 @@ class SoCoPlugin(object):
     @property
     def name(self):
         """ human-readable name of the plugin """
-        raise NotImplemented('Plugins should overwrite the name property')
+        raise NotImplementedError('Plugins should overwrite the name property')
 
     @classmethod
     def from_name(cls, fullname, soco, *args, **kwargs):

--- a/soco/plugins/spotify.py
+++ b/soco/plugins/spotify.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable = redefined-variable-type
 
 """Spotify Plugin."""
 

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,wrong-import-position
 
 """This class contains XML related utility functions."""
 


### PR DESCRIPTION
It seems there is a new pylint in town, and its out to clean up the stre... code.

Joking aside. Fixes for new pylint warnings. Most are actually disables, either for legitimate reasons or because they were in more of less obsolete code like ms_data_structures or the old spotify plugin.

I consider this a minor fix, so I will merge immediately. Just posting it here for reference.

Any pull requests with failing Travis CI checks can rebase of master after I have merged. 