### PR TITLE
Filter invalid chars in xml fixes

### DIFF
--- a/soco/services.py
+++ b/soco/services.py
@@ -45,7 +45,7 @@ from .exceptions import (
     SoCoUPnPException, UnknownSoCoException
 )
 from .utils import prettify
-from .xml import XML, illegal_xml_re
+from .xml import XML, illegal_xml_re, PARSEERROR
 
 # UNICODE NOTE
 # UPnP requires all XML to be transmitted/received with utf-8 encoding. All
@@ -268,9 +268,13 @@ class Service(object):
         xml_response = xml_response.encode('utf-8')
         try:
             tree = XML.fromstring(xml_response)
-        except XML.ParseError:
+        except PARSEERROR:
             # Try to filter illegal xml chars (as unicode), in case that is
             # the reason for the parse error
+            # NOTE: The PARSERROR used here is a Python 2.6 compat trick in
+            # our xml module. If we ever drop support for Python 2.6 it should
+            # be replaced with a simple XML.ParseError and the hack in .xml
+            # removed
             filtered = illegal_xml_re.sub('', xml_response.decode('utf-8'))\
                                      .encode('utf-8')
             tree = XML.fromstring(filtered)

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name,wrong-import-position
+# pylint: disable=invalid-name,wrong-import-position,redefined-builtin
 
 """This class contains XML related utility functions."""
 
@@ -7,10 +7,39 @@ from __future__ import (
     absolute_import, unicode_literals
 )
 
+import sys
+import re
+
 try:
     import xml.etree.cElementTree as XML
 except ImportError:
     import xml.etree.ElementTree as XML
+
+
+# Create regular expression for filtering invalid characters, from:
+# http://stackoverflow.com/questions/1707890/
+# fast-way-to-filter-illegal-xml-unicode-chars-in-python
+if sys.version_info.major >= 3:
+    unichr = chr
+
+illegal_unichrs = [
+    (0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F), (0x7F, 0x84),
+    (0x86, 0x9F), (0xD800, 0xDFFF), (0xFDD0, 0xFDDF),
+    (0xFFFE, 0xFFFF),
+    (0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF), (0x3FFFE, 0x3FFFF),
+    (0x4FFFE, 0x4FFFF), (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
+    (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF), (0x9FFFE, 0x9FFFF),
+    (0xAFFFE, 0xAFFFF), (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
+    (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF), (0xFFFFE, 0xFFFFF),
+    (0x10FFFE, 0x10FFFF)
+]
+
+illegal_ranges = ["%s-%s" % (unichr(low), unichr(high))
+                  for (low, high) in illegal_unichrs
+                  if low < sys.maxunicode]
+
+illegal_xml_re = re.compile(u'[%s]' % u''.join(illegal_ranges))
+
 
 #: Commonly used namespaces, and abbreviations, used by `ns_tag`.
 NAMESPACES = {

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -15,6 +15,17 @@ try:
 except ImportError:
     import xml.etree.ElementTree as XML
 
+# This is a Python 2.6 compatbility hack. Pre 2.7 ElementTree raised
+# SyntaxError !!! if it encountered invalid chars in the XML, which is what
+# this exception is used for. It is only used one place in services. If we ever
+# drop support for Python 2.6 this should be removed
+try:
+    PARSEERROR = XML.ParseError
+except AttributeError:
+    # .ParseError did not exist pre 2.7;
+    # https://github.com/s3tools/s3cmd/issues/424
+    PARSEERROR = SyntaxError
+
 
 # Create regular expression for filtering invalid characters, from:
 # http://stackoverflow.com/questions/1707890/

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -19,7 +19,7 @@ except ImportError:
 # Create regular expression for filtering invalid characters, from:
 # http://stackoverflow.com/questions/1707890/
 # fast-way-to-filter-illegal-xml-unicode-chars-in-python
-if sys.version_info.major >= 3:
+if sys.version_info[0] >= 3:
     unichr = chr
 
 illegal_unichrs = [

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -137,6 +137,16 @@ def test_unwrap(service):
         "Unicode": "μИⅠℂ☺ΔЄ💋"}
 
 
+def test_unwrap_invalid_char(service):
+    """Test unwrapping args from XML with invalid char"""
+    responce_with_invalid_char = DUMMY_VALID_RESPONSE.replace(
+        'μИⅠℂ☺ΔЄ💋', 'AB'
+    )
+    # Note, the invalid ^D (code point 0x04) should be filtered out
+    assert service.unwrap_arguments(responce_with_invalid_char) == {
+        "CurrentLEDState": "On",
+        "Unicode": "AB"}
+
 def test_build_command(service):
     """Test creation of SOAP body and headers from a command."""
     headers, body = service.build_command('SetAVTransportURI', [


### PR DESCRIPTION
Apparently, certain radio stations sometimes sends invalid XML in the form of XML with disallowed characters in it (#386). This PR attempts for fix that. If the XML parsing in services.unwrap_arguments fail, we now try to filter out disallowed chars and retry the parsing.

I consider this a bug fix, so I will merge within a couple of days if there are no objections.