### PR TITLE
Updated links to point to SoCo/Soco repository

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -3,7 +3,7 @@ Tutorial
 
 *SoCo* allows you to control your Sonos sound system from a Python program. For
 a quick start have a look at the `example applications
-<https://github.com/rahims/SoCo/tree/master/examples>`_ that come with the
+<https://github.com/SoCo/SoCo/tree/master/examples>`_ that come with the
 library.
 
 

--- a/examples/webapp/README.md
+++ b/examples/webapp/README.md
@@ -1,7 +1,7 @@
 # SoCo Web App
 This example demonstrates a basic web-based Sonos controller built with SoCo.
 
-![Screenshot of web app](https://github.com/rahims/SoCo/raw/master/examples/webapp/screenshot.png)
+![Screenshot of web app](https://github.com/SoCo/SoCo/raw/master/examples/webapp/screenshot.png)
 
 ## Set up
 This example depends on several external libraries. The easiest way to install everything is by running the following command:


### PR DESCRIPTION
The remaining links to rahims/Soco appear to be ok. One is to the
original repository in the README, the rest are to historic issues.