### PR TITLE
Add playbar night mode support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ SoCo supports the following controls amongst others:
 -  Get or set the speaker’s bass EQ
 -  Get or set the speaker’s treble EQ
 -  Toggle the speaker’s loudness compensation
+-  Toggle the speaker's night mode
 -  Turn on (or off) the white status light on the unit
 -  Switch the speaker’s source to line-in or TV input (if the Zone Player
    supports it)

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -76,3 +76,7 @@ class UnknownXMLStructure(SoCoException):
 
 class SoCoSlaveException(SoCoException):
     """Raised when a master command is called on a slave."""
+
+
+class NotSupportedException(SoCoException):
+    """Raised when something is not supported by the device"""


### PR DESCRIPTION
This PR adds night mode for Sonos players that support this feature. Night mode will make the dialogue more clear, while reducing the intensity of loud sounds.

https://sonos.custhelp.com/app/answers/detail/a_id/1959/~/improving-speech-clarity-and-night-time-listening-through-the-playbar
