### PR TITLE
Add playbar dialog mode support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ SoCo supports the following controls amongst others:
 -  Get or set the speaker’s bass EQ
 -  Get or set the speaker’s treble EQ
 -  Toggle the speaker’s loudness compensation
+-  Toggle the speaker's dialog mode
 -  Turn on (or off) the white status light on the unit
 -  Switch the speaker’s source to line-in or TV input (if the Zone Player
    supports it)

--- a/soco/core.py
+++ b/soco/core.py
@@ -20,7 +20,9 @@ from .data_structures import (
     DidlObject, DidlPlaylistContainer, DidlResource,
     Queue, from_didl_string, to_didl_string
 )
-from .exceptions import SoCoSlaveException
+from .exceptions import (
+    SoCoSlaveException, NotSupportedException
+)
 from .groups import ZoneGroup
 from .music_library import MusicLibrary
 from .services import (
@@ -162,6 +164,7 @@ class SoCo(_SocoSingletonBase):
         bass
         treble
         loudness
+        dialog_mode
         cross_fade
         status_light
         player_name
@@ -688,6 +691,45 @@ class SoCo(_SocoSingletonBase):
             ('InstanceID', 0),
             ('Channel', 'Master'),
             ('DesiredLoudness', loudness_value)
+        ])
+
+    @property
+    def dialog_mode(self):
+        """Get the Sonos speaker's dialog mode. True if on, False if off,
+        None if not supported.
+
+        :returns bool or None
+        """
+        if not self.speaker_info:
+            self.get_speaker_info()
+        if 'PLAYBAR' not in self.speaker_info['model_name']:
+            return None
+
+        response = self.renderingControl.GetEQ([
+            ('InstanceID', 0),
+            ('EQType', 'DialogLevel')
+        ])
+        return bool(int(response['CurrentValue']))
+
+    @dialog_mode.setter
+    def dialog_mode(self, dialog_mode):
+        """Switch on/off the speaker's dialog mode.
+
+        :param dialog_mode: Enable or disable dialog mode
+        :type dialog_mode: bool
+        :raises NotSupportedException: If the device does not support
+        dialog mode.
+        """
+        if not self.speaker_info:
+            self.get_speaker_info()
+        if 'PLAYBAR' not in self.speaker_info['model_name']:
+            message = 'This device does not support dialog mode'
+            raise NotSupportedException(message)
+
+        self.renderingControl.SetEQ([
+            ('InstanceID', 0),
+            ('EQType', 'DialogLevel'),
+            ('DesiredValue', int(dialog_mode))
         ])
 
     def _parse_zone_group_state(self):

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -76,3 +76,7 @@ class UnknownXMLStructure(SoCoException):
 
 class SoCoSlaveException(SoCoException):
     """Raised when a master command is called on a slave."""
+
+
+class NotSupportedException(SoCoException):
+    """Raised when something is not supported by the device"""


### PR DESCRIPTION
This PR adds dialog mode for Sonos players that support this feature. Dialog mode will make dialogue easier to hear, which can be especially useful during action movies.

https://sonos.custhelp.com/app/answers/detail/a_id/1959/~/improving-speech-clarity-and-night-time-listening-through-the-playbar
