### PR TITLE
Hard deprecation of spotify plugin. Fixes #401.

### DIFF
--- a/soco/plugins/spotify.py
+++ b/soco/plugins/spotify.py
@@ -1,238 +1,34 @@
 # -*- coding: utf-8 -*-
-# pylint: disable = redefined-variable-type
 
-"""Spotify Plugin."""
+"""The Spotify plugin has been DEPRECATED
 
-from __future__ import unicode_literals
+The Spotify Plugin has been immediately deprecated (August 2016),
+because the API it was based on (The Spotify Metadata API) has been
+ended. Since this rendered the plug-in broken, there was no need to
+forewarn of the deprecation.
 
-import requests
+Please consider moving to the new general music services code (in
+soco.music_services.music_service), that makes it possible to
+retrived information about the available media from all music
+services. A short intro for how to use the new code is available
+in the API documentation:
 
-from . import SoCoPlugin
-from ..compat import quote_plus
-from ..xml import XML
+ * http://docs.python-soco.com/en/latest/api/\
+soco.music_services.music_service.html
 
-__all__ = ['Spotify']
+and for some information about how to add items from the music
+services to the queue, see this gist:
 
+ * https://gist.github.com/lawrenceakka/2d21dca590b4fa7e3af2"
 
-class SpotifyTrack(object):
+This deprecation notification will be deleted for the second release
+after 0.12.
 
-    """Class that represents a Spotify track.
+"""
 
-    usage example: SpotifyTrack('spotify:track:20DfkHC5grnKNJCzZQB6KC')
-    """
-
-    def __init__(self, spotify_uri):
-        self.data = {}
-        self.data['spotify_uri'] = spotify_uri
-
-    @property
-    def spotify_uri(self):
-        """The track's Spotify URI."""
-        return self.data['spotify_uri']
-
-    @spotify_uri.setter
-    def spotify_uri(self, uri):
-        """Set the track's Spotify URI."""
-        self.data['spotify_uri'] = uri
-
-    @property
-    def album_uri(self):
-        """The album's URI."""
-        return self.data['album_uri']
-
-    @album_uri.setter
-    def album_uri(self, uri):
-        """Set the album's URI."""
-        self.data['album_uri'] = uri
-
-    @property
-    def title(self):
-        """The track's title."""
-        return self.data['title']
-
-    @title.setter
-    def title(self, title):
-        """Set the track's title."""
-        self.data['title'] = title.encode('utf-8')
-
-    @property
-    def didl_metadata(self):
-        """DIDL Metadata."""
-        if ('spotify_uri' in self.data and 'title' in self.data and
-                'album_uri' in self.data):
-
-            didl_metadata = """\
-<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"
-           xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
-           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"
-           xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
-    <item id="{0}" parentID="{1}" restricted="true">
-        <dc:title>{2}</dc:title>
-        <upnp:class>object.item.audioItem.musicTrack</upnp:class>
-        <desc id="cdudn"
-            nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">
-            SA_RINCON2311_X_#Svc2311-0-Token
-        </desc>
-    </item>
-</DIDL-Lite>""".format(quote_plus(self.data['spotify_uri']),
-                       quote_plus(self.data['album_uri']),
-                       quote_plus(self.data['title']))
-            didl_metadata = didl_metadata.encode('utf-8')
-            return XML.fromstring(didl_metadata)
-        else:
-            return None
-
-    @property
-    def uri(self):
-        """ Sonos-Spotify URI """
-        if 'spotify_uri' in self.data:
-            track = self.data['spotify_uri']
-            track = track.encode('utf-8')
-            track = quote_plus(track)
-            return 'x-sonos-spotify:' + track
-        else:
-            return ''
-
-    def satisfied(self):
-        """Checks if necessary track data is available."""
-        return 'title' in self.data and 'didl_metadata' in self.data
-
-
-class SpotifyAlbum(object):
-
-    """Class that represents a Spotifyalbum.
-
-    usage example: SpotifyAlbum('spotify:album:6a50SaJpvdWDp13t0wUcPU')
-    """
-
-    def __init__(self, spotify_uri):
-        self.data = {}
-        self.data['spotify_uri'] = spotify_uri
-
-    @property
-    def spotify_uri(self):
-        """The album's Spotify URI."""
-        return self.data['spotify_uri']
-
-    @spotify_uri.setter
-    def spotify_uri(self, uri):
-        """Set the album's Spotify URI."""
-        self.data['spotify_uri'] = uri
-
-    @property
-    def artist_uri(self):
-        """The artist's URI."""
-        return self.data['artist_uri']
-
-    @artist_uri.setter
-    def artist_uri(self, artist_uri):
-        """Set the artist's URI."""
-        self.data['artist_uri'] = artist_uri
-
-    @property
-    def title(self):
-        """The album's title."""
-        return self.data['title']
-
-    @title.setter
-    def title(self, title):
-        """Set the album's title."""
-        self.data['title'] = title.encode('utf-8')
-
-    @property
-    def uri(self):
-        """ Sonos-Spotify URI """
-        if 'spotify_uri' in self.data:
-            album = self.data['spotify_uri']
-            album = album.encode('utf-8')
-            album = quote_plus(album)
-            return "x-rincon-cpcontainer:" + album
-        else:
-            return ""
-
-    @property
-    def didl_metadata(self):
-        """DIDL Metadata."""
-        if self.satisfied:
-            didl_metadata = """\
-<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"
-           xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
-           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"
-           xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
-    <item id="{0}" parentID="{1}" restricted="true">
-        <dc:title>{2}</dc:title>
-        <upnp:class>object.container.album.musicAlbum</upnp:class>
-        <desc id="cdudn"
-              nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">
-            SA_RINCON2311_X_#Svc2311-0-Token
-        </desc>
-    </item>
-</DIDL-Lite>""".format(quote_plus(self.data['spotify_uri']),
-                       quote_plus(self.data['artist_uri']),
-                       quote_plus(self.data['title']))
-            didl_metadata = didl_metadata.encode('utf-8')
-            return XML.fromstring(didl_metadata)
-        else:
-            return None
-
-    def satisfied(self):
-        """Checks if necessary album data is available."""
-        return ('spotify_uri' in self.data and
-                'artist' in self.data and
-                'title' in self.data)
-
-
-class Spotify(SoCoPlugin):
-
-    """Class that implements spotify plugin."""
-
-    sid = '9'
-    api_lookup_url = 'http://ws.spotify.com/lookup/1/.json'
-
-    def __init__(self, soco):
-        """Initialize the plugin."""
-        super(Spotify, self).__init__(soco)
-
-    @property
-    def name(self):
-        return 'Spotify plugin'
-
-    def _add_track_metadata(self, spotify_track):
-        """Adds metadata by using the spotify public API."""
-        track = SpotifyTrack(spotify_track.spotify_uri)
-        params = {'uri': spotify_track.spotify_uri}
-        res = requests.get(self.api_lookup_url, params=params)
-        data = res.json()
-
-        if 'track' in data:
-            track.title = data['track']['name']
-            track.album_uri = data['track']['album']['href']
-
-        return track
-
-    def _add_album_metadata(self, spotify_album):
-        """Adds metadata by using the spotify public API."""
-        album = SpotifyAlbum(spotify_album.spotify_uri)
-        params = {'uri': spotify_album.spotify_uri}
-        res = requests.get(self.api_lookup_url, params=params)
-        data = res.json()
-
-        if 'album' in data:
-            album.title = data['album']['name']
-            album.artist_uri = data['album']['artist-id']
-
-        return album
-
-    def add_track_to_queue(self, spotify_track):
-        """Add a spotify track to the queue using the SpotifyTrack class."""
-        if not spotify_track.satisfied():
-            spotify_track = self._add_track_metadata(spotify_track)
-
-        return self.soco.add_to_queue(spotify_track)
-
-    def add_album_to_queue(self, spotify_album):
-        """Add a spotify album to the queue using the SpotifyAlbum class."""
-        if not spotify_album.satisfied():
-            spotify_album = self._add_album_metadata(spotify_album)
-
-        return self.soco.add_to_queue(spotify_album)
+import sys
+import os
+# Only raise this import error if we are not building the docs
+if not (os.environ.get('READTHEDOCS', None) == 'True' or
+        'sphinx' in sys.modules):
+    raise RuntimeError(__doc__)


### PR DESCRIPTION
This PR is for the hard deprecation of the Spotify plugin. By hard deprecation I mean replacing all the code in the module with a RuntimeError describing the situation. The API docs will also show the text from the error.

The reason for this move is that the metadata API from Spotify, that this was originally written for, has reached end-of-life (see #401 for details). Given that we now have general code in the music_services sub-package that makes it possible to search Spotify, I think it is better to focus on that.

If anyone wishes to bring the dedicated plugin up to date with the newer  API (and fix a few bugs) then they can always pull it out of git.

In any case, as the current state of things are, the plugin is completely broken and we have a substitute, so I proposed this hard deprecation.