### PR TITLE
Ignore .# specified subclasses in Didl xml

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -86,6 +86,12 @@ def from_didl_string(string):
     for elt in root:
         if elt.tag.endswith('item') or elt.tag.endswith('container'):
             item_class = elt.findtext(ns_tag('upnp', 'class'))
+
+            # In case this class has an # specified unofficial
+            # subclass, ignore it by stripping it from item_class
+            if '.#' in item_class:
+                item_class = item_class[:item_class.find('.#')]
+
             try:
                 cls = _DIDL_CLASS_TO_CLASS[item_class]
             except KeyError:
@@ -474,6 +480,12 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
                     tag, cls.item_class))
         # and that the upnp matches what we are expecting
         item_class = element.find(ns_tag('upnp', 'class')).text
+
+        # In case this class has an # specified unofficial
+        # subclass, ignore it by stripping it from item_class
+        if '.#' in item_class:
+            item_class = item_class[:item_class.find('.#')]
+
         if item_class != cls.item_class:
             raise DIDLMetadataError(
                 "UPnP class is incorrect. Expected '{0}',"


### PR DESCRIPTION
Several music services seem to use a scheme for subclassing Didl classes by writing a subclass after the real class separated by .# e.g. object.container.album.musicAlbum.#AlbumView. This is not part of the Didl spec and so our implementation fails. This commit fixes this by stripping the sub-class, hence completely ignoring it. Fixes #399 and #388.

If anyone ever needs this information it should be simple enough to store it on the object while still using the real Didl class.

I consider this a bugfix, so it could be pulled without review, but since this has a bit of a design component to it, I though I would make a PR anyway. Also to allow the bug reporters to try the fix.