### PR TITLE
Event listener thread safety

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -228,8 +228,10 @@ class EventNotifyHandler(BaseHTTPRequestHandler):
             variables = parse_event_xml(content)
             # Build the Event object
             event = Event(sid, seq, service, timestamp, variables)
-            # pass the event details on to the service so it can update its cache.
-            if service is not None:  # It might have been removed by another thread
+            # pass the event details on to the service so it can update its
+            # cache.
+            if service is not None:
+                # It might have been removed by another thread
                 # pylint: disable=protected-access
                 service._update_cache_on_event(event)
             # Find the right queue, and put the event on it
@@ -317,7 +319,8 @@ class EventListener(object):
         with self._start_lock:
             if not self.is_running:
                 temp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                temp_sock.connect((any_zone.ip_address, config.EVENT_LISTENER_PORT))
+                temp_sock.connect((any_zone.ip_address,
+                                   config.EVENT_LISTENER_PORT))
                 ip_address = temp_sock.getsockname()[0]
                 temp_sock.close()
                 # Start the event listener server in a separate thread.

--- a/soco/events.py
+++ b/soco/events.py
@@ -220,6 +220,7 @@ class EventNotifyHandler(BaseHTTPRequestHandler):
         # find the relevant service from the sid
         with _sid_to_service_lock:
             service = _sid_to_service.get(sid)
+        # It might have been removed by another thread
         if service:
             log.info(
                 "Event %s received for %s service on thread %s at %s", seq,
@@ -230,7 +231,6 @@ class EventNotifyHandler(BaseHTTPRequestHandler):
             event = Event(sid, seq, service, timestamp, variables)
             # pass the event details on to the service so it can update its
             # cache.
-            # It might have been removed by another thread
             # pylint: disable=protected-access
             service._update_cache_on_event(event)
             # Find the right queue, and put the event on it

--- a/soco/events.py
+++ b/soco/events.py
@@ -230,10 +230,9 @@ class EventNotifyHandler(BaseHTTPRequestHandler):
             event = Event(sid, seq, service, timestamp, variables)
             # pass the event details on to the service so it can update its
             # cache.
-            if service is not None:
-                # It might have been removed by another thread
-                # pylint: disable=protected-access
-                service._update_cache_on_event(event)
+            # It might have been removed by another thread
+            # pylint: disable=protected-access
+            service._update_cache_on_event(event)
             # Find the right queue, and put the event on it
             with _sid_to_event_queue_lock:
                 try:


### PR DESCRIPTION
EventListener.start would sometimes blow up if attempting to subscribe to multiple services from different threads. This happens when for example you have a thread per-speaker subscribing to events. This also fixes a thread crash that would occur when receiving events that you have not subscribed for (no service for sid). This may happen when restarting applications based on SoCo.