### PR TITLE
Added support for sonos playlist container UPnP class

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1009,6 +1009,12 @@ class DidlSameArtist(DidlPlaylistContainer):
     item_class = 'object.container.playlistContainer.sameArtist'
 
 
+class DidlSonosFavorite(DidlPlaylistContainer):
+
+    """Class that represents a Sonos favorite play list."""
+    item_class = 'object.container.playlistContainer.sonos-favorite'
+
+
 class DidlGenre(DidlContainer):
 
     """A content directory class representing a general genre."""

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1009,7 +1009,7 @@ class DidlSameArtist(DidlPlaylistContainer):
     item_class = 'object.container.playlistContainer.sameArtist'
 
 
-class DidlSonosFavorite(DidlPlaylistContainer):
+class DidlPlaylistContainerFavorite(DidlPlaylistContainer):
 
     """Class that represents a Sonos favorite play list."""
     item_class = 'object.container.playlistContainer.sonos-favorite'


### PR DESCRIPTION
Ran into a problem when subscribing to events on avTransport:

Traceback (most recent call last):
  File "/usr/lib/python3.4/socketserver.py", line 613, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.4/socketserver.py", line 344, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.4/socketserver.py", line 669, in __init__
    self.handle()
  File "/usr/lib/python3.4/http/server.py", line 398, in handle
    self.handle_one_request()
  File "/usr/lib/python3.4/http/server.py", line 386, in handle_one_request
    method()
  File "/usr/lib/python3.4/site-packages/soco/events.py", line 227, in do_NOTIFY
    variables = parse_event_xml(content)
  File "/usr/lib/python3.4/site-packages/soco/events.py", line 130, in parse_event_xml
    value = from_didl_string(value)[0]
  File "/usr/lib/python3.4/site-packages/soco/data_structures.py", line 98, in from_didl_string
    raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
soco.exceptions.DIDLMetadataError: Unknown UPnP class: object.container.playlistContainer.sonos-favorite

This PR adds support for the unknown UPnP class.