### PR TITLE
Replace http(s) prefix in URIs to play with x-rincon-mp3radio://. Fixes #434.

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -450,18 +450,21 @@ class SoCo(_SocoSingletonBase):
         created. This is often the case if you have a custom stream, it will
         need at least the title in the metadata in order to play.
 
-        Arguments:
-        uri -- URI of a stream to be played.
-        meta -- The track metadata to show in the player, DIDL format.
-        title -- The track title to show in the player
-        start -- If the URI that has been set should start playing
+        .. note:: A change in Sonos® (as of at least version 6.4.2) means that
+           the devices no longer accepts ordinary "http://" and "https://"
+           URIs. This method automatically replaces these prefixes with the
+           one that Sonos® expects: "x-rincon-mp3radio://".
 
-        Returns:
-        True if the Sonos speaker successfully started playing the track.
-        False if the track did not start (this may be because it was not
-        requested to start because "start=False")
+        Args:
+            uri (str): URI of the stream to be played.
+            meta (str): The track metadata to show in the player, DIDL format.
+            title (str): The track title to show in the player
+            start (bool): If the URI that has been set should start playing
+            convert_internet_uris (bool): FIXME
 
-        Raises SoCoException (or a subclass) upon errors.
+        Raises:
+            SoCoException: (or a subclass) upon errors.
+
         """
         if meta == '' and title != '':
             meta_template = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'\
@@ -476,6 +479,11 @@ class SoCo(_SocoSingletonBase):
             tunein_service = 'SA_RINCON65031_'
             # Radio stations need to have at least a title to play
             meta = meta_template.format(title=title, service=tunein_service)
+
+        for prefix in ('http://', 'https://'):
+            if uri.startswith(prefix):
+                # Replace only the first instance
+                uri = uri.replace(prefix, 'x-rincon-mp3radio://', 1)
 
         self.avTransport.SetAVTransportURI([
             ('InstanceID', 0),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -350,14 +350,24 @@ class TestAVTransport:
             [('InstanceID', 0), ('Speed', 1)]
         )
 
-    def test_soco_play_uri(self, moco):
-        uri = 'http://archive.org/download/TenD2005-07-16.flac16/TenD2005-07-16t10Wonderboy_64kb.mp3'
-        moco.play_uri(uri)
+    # Test that in internet uris (that starts with http:// or https:// the
+    # prefic is replaced with x-rincon-mp3radion://
+    @pytest.mark.parametrize("uri_in, uri_passed", [
+        ('x-file-cifs://server/MyNiceRing.mp3',
+         'x-file-cifs://server/MyNiceRing.mp3'),
+        ('http://archive.org/download/TenD2005-07-16t_64kb.mp3',
+         'x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3'),
+        ('https://archive.org/download/TenD2005-07-16t_64kb.mp3',
+         'x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3'),
+    ])
+    def test_soco_play_uri(self, moco, uri_in, uri_passed):
+        moco.play_uri(uri_in)
         moco.avTransport.SetAVTransportURI.assert_called_once_with([
             ('InstanceID', 0),
-            ('CurrentURI', uri),
+            ('CurrentURI', uri_passed),
             ('CurrentURIMetaData', '')
         ])
+        moco.avTransport.reset_mock()
 
     def test_soco_play_uri_calls_play(self, moco):
         uri = 'http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3'


### PR DESCRIPTION
This is a fix for #434. It replaces 'https://' and 'http://' in the beginning of the uri that is requested to play with Sonos® own prefix 'x-rincon-mp3radio://'. This should not affect people using this method for playing other types of uris e.g. 'x-file-cifs://'.

Also the unittests are updated.

Comments/questions?