### PR TITLE
Datastructures for the music services

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -19,8 +19,9 @@ from . import config
 from .compat import UnicodeType
 from .data_structures import (
     DidlObject, DidlPlaylistContainer, DidlResource,
-    Queue, from_didl_string, to_didl_string
+    Queue, to_didl_string
 )
+from .data_structures_entry import from_didl_string
 from .exceptions import (
     SoCoSlaveException, SoCoUPnPException, NotSupportedException,
 )

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -38,6 +38,7 @@ from .utils import really_unicode
 from .xml import (
     XML, ns_tag
 )
+from .music_services import data_structures as ms_data_structures
 
 
 ###############################################################################
@@ -96,7 +97,9 @@ def from_didl_string(string):
                 cls = _DIDL_CLASS_TO_CLASS[item_class]
             except KeyError:
                 raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
-            items.append(cls.from_element(elt))
+            item = cls.from_element(elt)
+            item = ms_data_structures.attempt_datastructure_upgrade(item)
+            items.append(item)
         else:
             # <desc> elements are allowed as an immediate child of <DIDL-Lite>
             # according to the spec, but I have not seen one there in Sonos, so

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -70,12 +70,6 @@ def to_didl_string(*args):
         return XML.tostring(didl, encoding='unicode')
 
 
-
-            # In case this class has an # specified unofficial
-            # subclass, ignore it by stripping it from item_class
-            if '.#' in item_class:
-                item_class = item_class[:item_class.find('.#')]
-
 ###############################################################################
 # DIDL RESOURCE                                                               #
 ###############################################################################

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -38,7 +38,6 @@ from .utils import really_unicode
 from .xml import (
     XML, ns_tag
 )
-from .music_services import data_structures as ms_data_structures
 
 
 ###############################################################################
@@ -71,44 +70,11 @@ def to_didl_string(*args):
         return XML.tostring(didl, encoding='unicode')
 
 
-def from_didl_string(string):
-    """Convert a unicode xml string to a list of `DIDLObjects <DidlObject>`.
-
-    Args:
-        string (str): A unicode string containing an XML representation of one
-            or more DIDL-Lite items (in the form  ``'<DIDL-Lite ...>
-            ...</DIDL-Lite>'``)
-
-    Returns:
-        list: A list of one or more instances of `DidlObject` or a subclass
-    """
-    items = []
-    root = XML.fromstring(string.encode('utf-8'))
-    for elt in root:
-        if elt.tag.endswith('item') or elt.tag.endswith('container'):
-            item_class = elt.findtext(ns_tag('upnp', 'class'))
 
             # In case this class has an # specified unofficial
             # subclass, ignore it by stripping it from item_class
             if '.#' in item_class:
                 item_class = item_class[:item_class.find('.#')]
-
-            try:
-                cls = _DIDL_CLASS_TO_CLASS[item_class]
-            except KeyError:
-                raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
-            item = cls.from_element(elt)
-            item = ms_data_structures.attempt_datastructure_upgrade(item)
-            items.append(item)
-        else:
-            # <desc> elements are allowed as an immediate child of <DIDL-Lite>
-            # according to the spec, but I have not seen one there in Sonos, so
-            # we treat them as illegal. May need to fix this if this
-            # causes problems.
-            raise DIDLMetadataError("Illegal child of DIDL element: <%s>"
-                                    % elt.tag)
-    return items
-
 
 ###############################################################################
 # DIDL RESOURCE                                                               #

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -20,7 +20,7 @@ from .music_services.music_service import desc_from_uri
 
 
 _LOG = logging.getLogger(__name__)
-if not (sys.version_info.major == 2 or sys.version_info.minor == 6):
+if not (sys.version_info[0] == 2 or sys.version_info[1] == 6):
     _LOG.addHandler(logging.NullHandler())
 _LOG.debug('%s imported', __name__)
 

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -1,0 +1,94 @@
+
+"""This module is for parsing and conversion functions that needs
+objects from both music library and music service data structures
+
+"""
+
+from __future__ import absolute_import
+
+from .xml import (
+    XML, ns_tag
+)
+from .data_structures import _DIDL_CLASS_TO_CLASS
+from .exceptions import DIDLMetadataError
+from .compat import urlparse
+from .music_services.data_structures import get_class
+from .music_services.music_service import desc_from_uri
+
+
+def from_didl_string(string):
+    """Convert a unicode xml string to a list of `DIDLObjects <DidlObject>`.
+
+    Args:
+        string (str): A unicode string containing an XML representation of one
+            or more DIDL-Lite items (in the form  ``'<DIDL-Lite ...>
+            ...</DIDL-Lite>'``)
+
+    Returns:
+        list: A list of one or more instances of `DidlObject` or a subclass
+    """
+    items = []
+    root = XML.fromstring(string.encode('utf-8'))
+    for elt in root:
+        if elt.tag.endswith('item') or elt.tag.endswith('container'):
+            item_class = elt.findtext(ns_tag('upnp', 'class'))
+            try:
+                cls = _DIDL_CLASS_TO_CLASS[item_class]
+            except KeyError:
+                raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
+            item = cls.from_element(elt)
+            item = attempt_datastructure_upgrade(item)
+            items.append(item)
+        else:
+            # <desc> elements are allowed as an immediate child of <DIDL-Lite>
+            # according to the spec, but I have not seen one there in Sonos, so
+            # we treat them as illegal. May need to fix this if this
+            # causes problems.
+            raise DIDLMetadataError("Illegal child of DIDL element: <%s>"
+                                    % elt.tag)
+    return items
+
+
+# FIXME, Obviously imcomplete
+DIDL_NAME_TO_QUALIFIED_MS_NAME = {
+    'DidlMusicTrack': 'MediaMetadataTrack'
+}
+def attempt_datastructure_upgrade(didl_item):
+    """Attempt to upgrade a didl_item to a music services data structure
+    if it originates from a music services
+
+    """
+    resource = didl_item.resources[0]
+    # FIXME are we guarantied that there are resources and that they
+    # have a uri????
+    if resource.uri.startswith('x-sonos-http'):
+        # Get data
+        uri = resource.uri
+        # Now we need to create a DIDL item id. It seems to be based on the uri
+        path = urlparse(uri).path
+        # Strip any extensions, eg .mp3, from the end of the path
+        path = path.rsplit('.', 1)[0]
+        # The ID has an 8 (hex) digit prefix. But it doesn't seem to
+        # matter what it is!
+        item_id = '11111111{0}'.format(path)
+
+        # FIXME Ignore other metadata for now, in future ask ms data
+        # structure to upgrade metadata from the service
+        metadata = {}
+        try:
+            metadata['title'] = didl_item.title
+        except AttributeError:
+            pass
+
+        # Get class and instantiate
+        cls = get_class(DIDL_NAME_TO_QUALIFIED_MS_NAME[
+            didl_item.__class__.__name__
+        ])
+        return cls(
+            item_id=item_id,
+            desc=desc_from_uri(resource.uri),
+            resources=didl_item.resources,
+            uri=uri,
+            metadata_dict=metadata,
+        )
+    return didl_item

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -58,7 +58,11 @@ def attempt_datastructure_upgrade(didl_item):
     if it originates from a music services
 
     """
-    resource = didl_item.resources[0]
+    try:
+        resource = didl_item.resources[0]
+    except IndexError:
+        return didl_item
+
     # FIXME are we guarantied that there are resources and that they
     # have a uri????
     if resource.uri.startswith('x-sonos-http'):

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -32,6 +32,12 @@ def from_didl_string(string):
     for elt in root:
         if elt.tag.endswith('item') or elt.tag.endswith('container'):
             item_class = elt.findtext(ns_tag('upnp', 'class'))
+
+            # In case this class has an # specified unofficial
+            # subclass, ignore it by stripping it from item_class
+            if '.#' in item_class:
+                item_class = item_class[:item_class.find('.#')]
+
             try:
                 cls = _DIDL_CLASS_TO_CLASS[item_class]
             except KeyError:

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -83,7 +83,7 @@ def attempt_datastructure_upgrade(didl_item):
     try:
         resource = didl_item.resources[0]
     except IndexError:
-        LOG.debug('Upgrade not possible, no resources')
+        _LOG.debug('Upgrade not possible, no resources')
         return didl_item
 
     if resource.uri.startswith('x-sonos-http'):
@@ -97,7 +97,7 @@ def attempt_datastructure_upgrade(didl_item):
         # matter what it is!
         item_id = '11111111{0}'.format(path)
 
-        # FIXME Ignore other metadata for now, in future ask ms data
+        # Ignore other metadata for now, in future ask ms data
         # structure to upgrade metadata from the service
         metadata = {}
         try:
@@ -130,8 +130,8 @@ def attempt_datastructure_upgrade(didl_item):
             uri=uri,
             metadata_dict=metadata,
         )
-        LOG.debug("Item %s upgraded to %s", didl_item, upgraded_item)
+        _LOG.debug("Item %s upgraded to %s", didl_item, upgraded_item)
         return upgraded_item
 
-    LOG.debug('Upgrade not necessary')
+    _LOG.debug('Upgrade not necessary')
     return didl_item

--- a/soco/events.py
+++ b/soco/events.py
@@ -17,7 +17,7 @@ from . import config
 from .compat import (
     Queue, BaseHTTPRequestHandler, URLError, socketserver, urlopen
 )
-from .data_structures import from_didl_string
+from .data_structures_entry import from_didl_string
 from .exceptions import SoCoException
 from .utils import camel_to_underscore
 from .xml import XML

--- a/soco/events.py
+++ b/soco/events.py
@@ -608,6 +608,7 @@ class Subscription(object):
             time_left = self.timeout - (time.time() - self._timestamp)
             return time_left if time_left > 0 else 0
 
+
 # pylint: disable=C0103
 event_listener = EventListener()
 

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -542,6 +542,7 @@ class MSCollection(MusicServiceItem):
         content.update(kwargs)
         super(MSCollection, self).__init__(**content)
 
+
 MS_TYPE_TO_CLASS = {'artist': MSArtist, 'album': MSAlbum, 'track': MSTrack,
                     'albumList': MSAlbumList, 'favorites': MSFavorites,
                     'collection': MSCollection, 'playlist': MSPlaylist,

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -13,11 +13,11 @@ import logging
 from . import discovery
 from .data_structures import (
     SearchResult,
-    from_didl_string,
     DidlResource,
     DidlObject,
     DidlMusicAlbum
 )
+from .data_structures_entry import from_didl_string
 from .exceptions import SoCoUPnPException
 from .utils import url_escape_path, really_unicode, camel_to_underscore
 

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -56,21 +56,26 @@ Class overview:
 """
 
 from __future__ import print_function, absolute_import
+import sys
+import logging
 from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
 from ..compat import quote_url
-from ..xml import XML
-from ..discovery import discover
-from ..compat import urlparse
-from pprint import pprint
+
+
+_LOG = logging.getLogger(__name__)
+if not (sys.version_info.major == 2 or sys.version_info.minor == 6):
+    _LOG.addHandler(logging.NullHandler())
 
 
 # For now we generate classes dynamically. This is shorter, but
 # provides no custom documentation for all the different types.
 CLASSES = {}
+
+
 def get_class(class_key):
-    """Form a class from the class key
+    """Form a music service data structure class from the class key
 
     Args:
         class_key (str): A concatenation of the base class (e.g. MediaMetadata)
@@ -85,29 +90,51 @@ def get_class(class_key):
                 # So MediaMetadataTrack turns into MSTrack
                 class_name = 'MS' + class_key.replace(basecls.__name__, '')
                 CLASSES[class_key] = type(class_name, (basecls,), {})
+                _LOG.info('Class %s created', CLASSES[class_key])
     return CLASSES[class_key]
 
 
 def parse_response(service, response, search_type):
-    """Parse the query response"""
+    """Parse the response to a music service query and return a SearchResult
+
+    Args:
+        service (MusicService): The music service that produced the response
+        response (OrderedDict): The response from the soap client call
+        search_type (str): A string that indicates the search type that the
+            response is from
+
+    Returns:
+        SearchResult: A SearchResult object
+    """
+    _LOG.debug('Parse response "%s" from service "%s" of type "%s"', response,
+               service, search_type)
     items = []
+    # The result to be parsed is in either searchResult or getMetadataResult
     if 'searchResult' in response:
         response = response['searchResult']
     elif 'getMetadataResult' in response:
         response = response['getMetadataResult']
+
+    # Form the search metadata
     search_metadata = {
         'number_returned': response['count'],
         'total_matches': None,
         'search_type': search_type,
         'update_id': None,
     }
+
     for result_type in ('mediaCollection', 'mediaMetadata'):
+        # Upper case the first letter (used for the class_key)
         result_type_proper = result_type[0].upper() + result_type[1:]
         raw_items = response.get(result_type, [])
         # If there is only 1 result, it is not put in an array
         if isinstance(raw_items, OrderedDict):
             raw_items = [raw_items]
+
         for raw_item in raw_items:
+            # Form the class_key, which is a unique string for this type,
+            # formed by concatenating the result type with the item type. Turns
+            # into e.g: MediaMetadataTrack
             class_key = result_type_proper + raw_item['itemType'].title()
             cls = get_class(class_key)
             items.append(cls.from_music_service(service, raw_item))
@@ -115,7 +142,16 @@ def parse_response(service, response, search_type):
 
 
 def form_uri(item_id, service, is_track):
-    """Form and return uri from item_id, service and is_track info"""
+    """Form and return a music service item uri
+
+    Args:
+        item_id (str): The item id
+        service (MusicService): The music service that the item originates from
+        is_track (bool): Whether the item_id is from a track or not
+
+    Returns:
+        str: The music service item uri
+    """
     if is_track:
         uri = service.sonos_uri_from_id(item_id)
     else:
@@ -123,16 +159,18 @@ def form_uri(item_id, service, is_track):
     return uri
 
 
-### Type Helper
+# Type Helper
 BOOL_STRS = {'true', 'false'}
+
+
 def bool_str(string):
     """Returns a boolean from a string imput of 'true' or 'false'"""
     if string not in BOOL_STRS:
         raise ValueError('Invalid boolean string: "{}"'.format(string))
-    return True if string == "true" else False
+    return True if string == 'true' else False
 
 
-### Music Service item base classes
+# Music Service item base classes
 class MetadataDictBase(object):
     """Class used to parse metadata from kwargs"""
 
@@ -141,42 +179,30 @@ class MetadataDictBase(object):
     # _valid_fields is a set of valid fields
     _valid_fields = {}
 
-    # _types is a dict of fields with non-string types and their
-    # convertion callables
+    # _types is a dict of fields with non-string types and their convertion
+    # callables
     _types = {}
-    
+
     def __init__(self, metadata_dict):
         """Initialize local variables"""
-        # Check for invalid fields
+        _LOG.debug('MetadataDictBase.__init__ with: %s', metadata_dict)
         for key in metadata_dict:
+            # Check for invalid fields
             if key not in self._valid_fields:
-                message = ('Field: "{0}" with value "{1}" is not valid for '
-                           'class "{2}"')
+                message = ('%s instantiated with invalid field "%s" and '
+                           'value: %s')
                 # Really wanted to raise exceptions here, but as it
                 # turns out I have already encountered invalid fields
-                # from music services. We should think about how to
-                # handle those. Raising warnings will only annoy the
-                # user. The easy thing is to just allow them in, and
-                # ignore type conversion, so we only guaranty the
-                # correct type for valid fields. Alternative, we might
-                # also start to collect a list of invalid fields.
-                #
-                # For new we just print the warning message
-                print(message.format(key, metadata_dict[key], self.__class__))
-                #raise ValueError(message.format(key, metadata_dict[key], self.__class__))
+                # from music services.
+                _LOG.debug(message, self.__class__, key, metadata_dict[key])
 
         # Convert names and create metadata dict
         self.metadata = {}
         for key, value in metadata_dict.items():
             if key in self._types:
-                convertion_callable = self._types[key] 
+                convertion_callable = self._types[key]
                 value = convertion_callable(value)
             self.metadata[camel_to_underscore(key)] = value
-
-    @classmethod
-    def from_dict(cls, content_dict):
-        """Init cls from a dict (alternative initializer)"""
-        return cls(content_dict)
 
     def __getattr__(self, key):
         """Return item from metadata in case of unknown attribute"""
@@ -190,12 +216,12 @@ class MetadataDictBase(object):
 class MusicServiceItem(MetadataDictBase):
     """A base class for all music service items"""
 
-    # See comment in MetadataDictBase for these two attributes
+    # See comment in MetadataDictBase for explanation of these two attributes
     _valid_fields = {}
     _types = {}
 
-    def __init__(self, item_id, desc, resources, uri, metadata_dict,
-                 music_service = None):
+    def __init__(self, item_id, desc,  # pylint: disable=too-many-arguments
+                 resources, uri, metadata_dict, music_service=None):
         """Init music service item
 
         Args:
@@ -204,8 +230,13 @@ class MusicServiceItem(MetadataDictBase):
             resources (list): List of DidlResource
             uri (str): The uri for the location of the item
             metdata_dict (dict): Mapping of metadata
-            music_service (MusicService): The MusicService instance the item originates from
+            music_service (MusicService): The MusicService instance the item
+                originates from
         """
+        _LOG.debug('%s.__init__ with item_id=%s, desc=%s, resources=%s, '
+                   'uri=%s, metadata_dict=..., music_service=%s',
+                   self.__class__.__name__, item_id, desc, resources, uri,
+                   music_service)
         super(MusicServiceItem, self).__init__(metadata_dict)
         self.item_id = item_id
         self.desc = desc
@@ -216,11 +247,20 @@ class MusicServiceItem(MetadataDictBase):
     @classmethod
     def from_music_service(cls, music_service, content_dict):
         """Return an element instantiated from the information that a music
-        service has
+        service has (alternative constructor)
 
+        Args:
+            music_service (MusicService): The music service that content_dict
+                originated from
+            content_dict (OrderedDict): The data to instantiate the music
+                service item from
+
+        Returns:
+            MusicServiceItem: A MusicServiceItem instance
         """
         # Form the item_id
         quoted_id = quote_url(content_dict['id'].encode('utf-8'))
+        # The hex prefix remains a mistery for now
         item_id = '0fffffff{0}'.format(quoted_id)
         # Form the uri
         is_track = cls == get_class('MediaMetadataTrack')
@@ -245,7 +285,8 @@ class MusicServiceItem(MetadataDictBase):
                 namespace attributes on the root element
 
         Return:
-            ~xml.etree.ElementTree.Element: an Element.
+            ~xml.etree.ElementTree.Element: The (XML) Element representation of
+                this object
         """
         # We piggy back on the implementation in DidlItem
         didl_item = DidlItem(
@@ -256,8 +297,6 @@ class MusicServiceItem(MetadataDictBase):
             desc=self.desc,
             resources=self.resources
         )
-        # FIXME think about separating to_element code out into function
-        # in soco.data_structures
         return didl_item.to_element(include_namespaces=include_namespaces)
 
 
@@ -299,7 +338,7 @@ class TrackMetadata(MetadataDictBase):
 
 
 class StreamMetadata(MetadataDictBase):
-    """Track metadata class"""
+    """Stream metadata class"""
 
     # _valid_fields is a set of valid fields
     _valid_fields = {
@@ -343,11 +382,10 @@ class MediaMetadata(MusicServiceItem):
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'trackMetadata': TrackMetadata.from_dict,
-        'streamMetadata': StreamMetadata.from_dict,
-        # FIXME Think about what to do about dynamic. Is it possible
-        # to type convert, is it even helpful?
-        #'dynamic': ???, 
+        'trackMetadata': TrackMetadata,  #.from_dict,
+        'streamMetadata': StreamMetadata,  #.from_dict,
+        # We ignore types on the dynamic field
+        # 'dynamic': ???,
     }
 
 

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -58,14 +58,17 @@ Class overview:
 from __future__ import print_function, absolute_import
 import sys
 import logging
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
 from ..compat import quote_url
 
 
 _LOG = logging.getLogger(__name__)
-if not (sys.version_info.major == 2 and sys.version_info.minor == 6):
+if not (sys.version_info[0] == 2 and sys.version_info[1] == 6):
     _LOG.addHandler(logging.NullHandler())
 
 
@@ -89,6 +92,8 @@ def get_class(class_key):
             if class_key.startswith(basecls.__name__):
                 # So MediaMetadataTrack turns into MSTrack
                 class_name = 'MS' + class_key.replace(basecls.__name__, '')
+                if sys.version_info[0] == 2:
+                    class_name = class_name.encode('ascii')
                 CLASSES[class_key] = type(class_name, (basecls,), {})
                 _LOG.info('Class %s created', CLASSES[class_key])
     return CLASSES[class_key]
@@ -163,7 +168,7 @@ def form_uri(item_id, service, is_track):
 
 
 # Type Helper
-BOOL_STRS = {'true', 'false'}
+BOOL_STRS = set(('true', 'false'))
 
 
 def bool_str(string):
@@ -307,7 +312,7 @@ class TrackMetadata(MetadataDictBase):
     """Track metadata class"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = {
+    _valid_fields = set((
         'artistId',
         'artist',
         'composerId',
@@ -326,7 +331,7 @@ class TrackMetadata(MetadataDictBase):
         'rating',
         'trackNumber',
         'isFavorite',
-    }
+    ))
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
@@ -344,7 +349,7 @@ class StreamMetadata(MetadataDictBase):
     """Stream metadata class"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = {
+    _valid_fields = set((
         'currentHost',
         'currentShowId',
         'currentShow',
@@ -355,7 +360,7 @@ class StreamMetadata(MetadataDictBase):
         'hasOutOfBandMetadata',
         'description',
         'isEphemeral',
-    }
+    ))
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
@@ -371,7 +376,7 @@ class MediaMetadata(MusicServiceItem):
     """Base class for all media metadata items"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = {
+    _valid_fields = set((
         'id',
         'title',
         'mimeType',
@@ -381,7 +386,7 @@ class MediaMetadata(MusicServiceItem):
         'trackMetadata',
         'streamMetadata',
         'dynamic',
-    }
+    ))
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
@@ -396,7 +401,7 @@ class MediaCollection(MusicServiceItem):
     """Base class for all mediaCollection items"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = {
+    _valid_fields = set((
         'id',
         'title',
         'itemType',
@@ -412,7 +417,7 @@ class MediaCollection(MusicServiceItem):
         'canScroll',
         'canSkip',
         'isFavorite',
-    }
+    ))
 
     # _types is a dict of fields with non-string types and their
     # convertion callables

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -65,7 +65,7 @@ from ..compat import quote_url
 
 
 _LOG = logging.getLogger(__name__)
-if not (sys.version_info.major == 2 or sys.version_info.minor == 6):
+if not (sys.version_info.major == 2 and sys.version_info.minor == 6):
     _LOG.addHandler(logging.NullHandler())
 
 
@@ -114,6 +114,9 @@ def parse_response(service, response, search_type):
         response = response['searchResult']
     elif 'getMetadataResult' in response:
         response = response['getMetadataResult']
+    else:
+        raise ValueError('"response" should contain either the key '
+                         '"searchResult" or "getMetadataResult"')
 
     # Form the search metadata
     search_metadata = {
@@ -382,8 +385,8 @@ class MediaMetadata(MusicServiceItem):
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'trackMetadata': TrackMetadata,  #.from_dict,
-        'streamMetadata': StreamMetadata,  #.from_dict,
+        'trackMetadata': TrackMetadata,
+        'streamMetadata': StreamMetadata,
         # We ignore types on the dynamic field
         # 'dynamic': ???,
     }

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -35,9 +35,9 @@ NOTE: "Other" is allowed under both.
 
 Class overview:
 
-+----------+   +----------------+   +---------------+
-|KwargsBase+-->+MusicServiceItem+-->+MediaCollection|
-+-----+-----   +--------------+-+   +---------------+
++----------------+   +----------------+   +---------------+
+|MetadataDictBase+-->+MusicServiceItem+-->+MediaCollection|
++-----+----------+   +--------+-------+   +---------------+
       |                       |
       |                       |     +------------------+
       |                       +---->+  MediaMetadata   |
@@ -57,11 +57,14 @@ Class overview:
 
 from __future__ import print_function, absolute_import
 from collections import OrderedDict
-from ..data_structures import DidlResource, DidlItem, SearchResult
+#from ..data_structures import DidlResource, DidlItem, SearchResult
+from ..  import data_structures
 from ..utils import camel_to_underscore
 from ..compat import quote_url
 from ..xml import XML
 from ..discovery import discover
+from ..compat import urlparse
+from . import music_service
 from pprint import pprint
 
 
@@ -76,7 +79,7 @@ def get_class(class_key):
             and the class name
 
     Returns:
-        MusicServiceItem
+        class: Subclass of MusicServiceItem
     """
     if class_key not in CLASSES:
         for basecls in (MediaMetadata, MediaCollection):
@@ -109,8 +112,58 @@ def parse_response(service, response, search_type):
         for raw_item in raw_items:
             class_key = result_type_proper + raw_item['itemType'].title()
             cls = get_class(class_key)
-            items.append(cls.from_dict(service, raw_item))
-    return SearchResult(items, **search_metadata)
+            items.append(cls.from_music_service(service, raw_item))
+    return data_structures.SearchResult(items, **search_metadata)
+
+
+# FIXME, Obviously imcomplete 
+DIDL_NAME_TO_QUALIFIED_MS_NAME = {
+    'DidlMusicTrack': 'MediaMetadataTrack'
+}
+def attempt_datastructure_upgrade(didl_item):
+    """Attempt to upgrade a didl_item to a music services data structure
+    if it originates from a music services
+
+    """
+    resource = didl_item.resources[0]
+    # FIXME are we guarantied that there are resources and that they have a uri????
+    if resource.uri.startswith('x-sonos-http'):
+        # Get data
+        uri = resource.uri
+        # Now we need to create a DIDL item id. It seems to be based on the uri
+        path = urlparse(uri).path
+        # Strip any extensions, eg .mp3, from the end of the path
+        path = path.rsplit('.', 1)[0]
+        # The ID has an 8 (hex) digit prefix. But it doesn't seem to matter what it is!
+        item_id = '11111111{0}'.format(path)
+        
+        # FIXME Ignore other metadata for now, in future ask ms data
+        # structure to upgrade metadata from the service
+        metadata = {}
+        try:
+            metadata['title'] = didl_item.title
+        except AttributeError:
+            pass
+
+        # Get class and instantiate
+        cls = get_class(DIDL_NAME_TO_QUALIFIED_MS_NAME[didl_item.__class__.__name__])
+        return cls(
+            item_id=item_id,
+            desc=music_service.desc_from_uri(resource.uri),
+            resources=didl_item.resources,
+            uri=uri,
+            metadata_dict=metadata,
+        )
+    return didl_item
+
+
+def form_uri(item_id, service, is_track):
+    """Form and return uri from item_id, service and is_track info"""
+    if is_track:
+        uri = service.sonos_uri_from_id(item_id)
+    else:
+        uri = 'x-rincon-cpcontainer:' + item_id
+    return uri
 
 
 ### Type Helper
@@ -123,7 +176,7 @@ def bool_str(string):
 
 
 ### Music Service item base classes
-class KwargsBase(object):
+class MetadataDictBase(object):
     """Class used to parse metadata from kwargs"""
 
     # The following two fields should be overwritten in subclasses
@@ -135,10 +188,10 @@ class KwargsBase(object):
     # convertion callables
     _types = {}
     
-    def __init__(self, **kwargs):
+    def __init__(self, metadata_dict):
         """Initialize local variables"""
         # Check for invalid fields
-        for key in kwargs:
+        for key in metadata_dict:
             if key not in self._valid_fields:
                 message = ('Field: "{0}" with value "{1}" is not valid for '
                            'class "{2}"')
@@ -152,12 +205,12 @@ class KwargsBase(object):
                 # also start to collect a list of invalid fields.
                 #
                 # For new we just print the warning message
-                print(message.format(key, kwargs[key], self.__class__))
-                #raise ValueError(message.format(key, kwargs[key], self.__class__))
+                print(message.format(key, metadata_dict[key], self.__class__))
+                #raise ValueError(message.format(key, metadata_dict[key], self.__class__))
 
         # Convert names and create metadata dict
         self.metadata = {}
-        for key, value in kwargs.items():
+        for key, value in metadata_dict.items():
             if key in self._types:
                 convertion_callable = self._types[key] 
                 value = convertion_callable(value)
@@ -166,7 +219,7 @@ class KwargsBase(object):
     @classmethod
     def from_dict(cls, content_dict):
         """Init cls from a dict (alternative initializer)"""
-        return cls(**content_dict)
+        return cls(content_dict)
 
     def __getattr__(self, key):
         """Return item from metadata in case of unknown attribute"""
@@ -177,57 +230,49 @@ class KwargsBase(object):
             raise AttributeError(message.format(self.__class__.__name__, key))
 
 
-class MusicServiceItem(KwargsBase):
-    """A base class for all music service items
+class MusicServiceItem(MetadataDictBase):
+    """A base class for all music service items"""
 
-    Attributes:
-        service (soco.music_service.MusicService): The music service that this
-            item originates from
-        resources (list): List of DidlResource
-        desc (str): A DIDL descriptor, default ``'RINCON_AssociatedZPUDN'
-    """
-
-    # See comment in KwargsBase for these two attributes
+    # See comment in MetadataDictBase for these two attributes
     _valid_fields = {}
     _types = {}
 
-    def __init__(self, service, **kwargs):
-        """Init music service item"""
-        super(MusicServiceItem, self).__init__(**kwargs)
-        self.service = service
-        self.resources = [DidlResource(uri=self.uri, protocol_info="DUMMY")]
-        self.desc = self.service.desc
-
-    @classmethod
-    def from_dict(cls, service, content_dict):
-        """Return an element instantiated from a dict and the service
-        (alternative constructor)
+    def __init__(self, item_id, desc, resources, uri, metadata_dict,
+                 music_service = None):
+        """Init music service item
 
         Args:
-            service (soco.music_service.MusicService): The music service that
-                this element originates from
-            content_dict (dict): Content to create the instance from. For
-                information about valid elements and types see _valid_fields
-                and _types
+            item_id (str): This is the Didl compatible id NOT the music item id
+            desc (str): A DIDL descriptor, default ``'RINCON_AssociatedZPUDN'
+            resources (list): List of DidlResource
+            uri (str): The uri for the location of the item
+            metdata_dict (dict): Mapping of metadata
+            music_service (MusicService): The MusicService instance the item originates from
         """
-        return cls(service, **content_dict)
+        super(MusicServiceItem, self).__init__(metadata_dict)
+        self.item_id = item_id
+        self.desc = desc
+        self.resources = resources
+        self.uri = uri
+        self.music_service = music_service
 
-    @property
-    def item_id(self):
-        """Return the DIDL Lite compatible item_id"""
-        quoted_id = quote_url(self.metadata['id'].encode('utf-8'))
-        return '0fffffff{0}'.format(quoted_id)
-    
-    @property
-    def uri(self):
-        """Return the uri"""
-        # For an album
-        if not isinstance(self, get_class('MediaMetadataTrack')):
-            uri = 'x-rincon-cpcontainer:' + self.item_id
-        # For a track
-        else:
-            uri = self.service.sonos_uri_from_id(self.item_id)
-        return uri
+    @classmethod
+    def from_music_service(cls, music_service, content_dict):
+        """Return an element instantiated from the information that a music
+        service has
+
+        """
+        # Form the item_id
+        quoted_id = quote_url(content_dict['id'].encode('utf-8'))
+        item_id = '0fffffff{0}'.format(quoted_id)
+        # Form the uri
+        is_track = cls == get_class('MediaMetadataTrack')
+        uri = form_uri(item_id, music_service, is_track)
+        # Form resources and get desc
+        resources = [data_structures.DidlResource(uri=uri, protocol_info="DUMMY")]
+        desc = music_service.desc
+        return cls(item_id, desc, resources, uri, content_dict,
+                   music_service=music_service)
 
     def __str__(self):
         """Return custom string representation"""
@@ -246,7 +291,7 @@ class MusicServiceItem(KwargsBase):
             ~xml.etree.ElementTree.Element: an Element.
         """
         # We piggy back on the implementation in DidlItem
-        didl_item = DidlItem(
+        didl_item = data_structures.DidlItem(
             title="DUMMY",
             # This is ignored. Sonos gets the title from the item_id
             parent_id="DUMMY",  # Ditto
@@ -254,10 +299,12 @@ class MusicServiceItem(KwargsBase):
             desc=self.desc,
             resources=self.resources
         )
+        # FIXME think about separating to_element code out into function
+        # in soco.data_structures
         return didl_item.to_element(include_namespaces=include_namespaces)
 
 
-class TrackMetadata(KwargsBase):
+class TrackMetadata(MetadataDictBase):
     """Track metadata class"""
 
     # _valid_fields is a set of valid fields
@@ -294,7 +341,7 @@ class TrackMetadata(KwargsBase):
     }
 
 
-class StreamMetadata(KwargsBase):
+class StreamMetadata(MetadataDictBase):
     """Track metadata class"""
 
     # _valid_fields is a set of valid fields

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+"""Data structures for music service items
+
+The basis for this implementation is this page in the Sonos API
+documentation: http://musicpartners.sonos.com/node/83
+
+A note about naming. The Sonos API uses camel case with starting lower
+case. These names have been adapted to match general Python class
+naming conventions.
+
+MediaMetadata:
+    Track
+    Stream
+    Show
+    Other
+
+MediaCollection:
+    Artist
+    Album
+    Genre
+    Playlist
+    Search
+    Program
+    Favorites
+    Favorite
+    Collection
+    Container
+    AlbumList
+    TrackList
+    StreamList
+    ArtistTrackList
+    Other
+
+NOTE: "Other" is allowed under both.
+
+Class overview:
+
++----------+   +----------------+   +---------------+
+|KwargsBase+-->+MusicServiceItem+-->+MediaCollection|
++-----+-----   +--------------+-+   +---------------+
+      |                       |
+      |                       |     +------------------+
+      |                       +---->+  MediaMetadata   |
+      |                             |                  |
+      |                             | +-------------+  |
+      +------------------------------>+TrackMetadata|  |
+      |                             | +-------------+  |
+      |                             |                  |
+      |                             | +--------------+ |
+      +------------------------------>+StreamMetadata| |
+                                    | +--------------+ |
+                                    |                  |
+                                    +------------------+
+
+
+"""
+
+from __future__ import print_function, absolute_import
+from collections import OrderedDict
+from ..data_structures import DidlResource, DidlItem, SearchResult
+from ..utils import camel_to_underscore
+from ..compat import quote_url
+from ..xml import XML
+from ..discovery import discover
+from pprint import pprint
+
+
+# For now we generate classes dynamically. This is shorter, but
+# provides no custom documentation for all the different types.
+CLASSES = {}
+def get_class(class_key):
+    """Form a class from the class key
+
+    Args:
+        class_key (str): A concatenation of the base class (e.g. MediaMetadata)
+            and the class name
+
+    Returns:
+        MusicServiceItem
+    """
+    if class_key not in CLASSES:
+        for basecls in (MediaMetadata, MediaCollection):
+            if class_key.startswith(basecls.__name__):
+                # So MediaMetadataTrack turns into MSTrack
+                class_name = 'MS' + class_key.replace(basecls.__name__, '')
+                CLASSES[class_key] = type(class_name, (basecls,), {})
+    return CLASSES[class_key]
+
+
+def parse_response(service, response, search_type):
+    """Parse the query response"""
+    items = []
+    if 'searchResult' in response:
+        response = response['searchResult']
+    elif 'getMetadataResult' in response:
+        response = response['getMetadataResult']
+    search_metadata = {
+        'number_returned': response['count'],
+        'total_matches': None,
+        'search_type': search_type,
+        'update_id': None,
+    }
+    for result_type in ('mediaCollection', 'mediaMetadata'):
+        result_type_proper = result_type[0].upper() + result_type[1:]
+        raw_items = response.get(result_type, [])
+        # If there is only 1 result, it is not put in an array
+        if isinstance(raw_items, OrderedDict):
+            raw_items = [raw_items]
+        for raw_item in raw_items:
+            class_key = result_type_proper + raw_item['itemType'].title()
+            cls = get_class(class_key)
+            items.append(cls.from_dict(service, raw_item))
+    return SearchResult(items, **search_metadata)
+
+
+### Type Helper
+BOOL_STRS = {'true', 'false'}
+def bool_str(string):
+    """Returns a boolean from a string imput of 'true' or 'false'"""
+    if string not in BOOL_STRS:
+        raise ValueError('Invalid boolean string: "{}"'.format(string))
+    return True if string == "true" else False
+
+
+### Music Service item base classes
+class KwargsBase(object):
+    """Class used to parse metadata from kwargs"""
+
+    # The following two fields should be overwritten in subclasses
+
+    # _valid_fields is a set of valid fields
+    _valid_fields = {}
+
+    # _types is a dict of fields with non-string types and their
+    # convertion callables
+    _types = {}
+    
+    def __init__(self, **kwargs):
+        """Initialize local variables"""
+        # Check for invalid fields
+        for key in kwargs:
+            if key not in self._valid_fields:
+                message = ('Field: "{0}" with value "{1}" is not valid for '
+                           'class "{2}"')
+                # Really wanted to raise exceptions here, but as it
+                # turns out I have already encountered invalid fields
+                # from music services. We should think about how to
+                # handle those. Raising warnings will only annoy the
+                # user. The easy thing is to just allow them in, and
+                # ignore type conversion, so we only guaranty the
+                # correct type for valid fields. Alternative, we might
+                # also start to collect a list of invalid fields.
+                #
+                # For new we just print the warning message
+                print(message.format(key, kwargs[key], self.__class__))
+                #raise ValueError(message.format(key, kwargs[key], self.__class__))
+
+        # Convert names and create metadata dict
+        self.metadata = {}
+        for key, value in kwargs.items():
+            if key in self._types:
+                convertion_callable = self._types[key] 
+                value = convertion_callable(value)
+            self.metadata[camel_to_underscore(key)] = value
+
+    @classmethod
+    def from_dict(cls, content_dict):
+        """Init cls from a dict (alternative initializer)"""
+        return cls(**content_dict)
+
+    def __getattr__(self, key):
+        """Return item from metadata in case of unknown attribute"""
+        try:
+            return self.metadata[key]
+        except KeyError:
+            message = 'Class {0} has no attribute "{1}"'
+            raise AttributeError(message.format(self.__class__.__name__, key))
+
+
+class MusicServiceItem(KwargsBase):
+    """A base class for all music service items
+
+    Attributes:
+        service (soco.music_service.MusicService): The music service that this
+            item originates from
+        resources (list): List of DidlResource
+        desc (str): A DIDL descriptor, default ``'RINCON_AssociatedZPUDN'
+    """
+
+    # See comment in KwargsBase for these two attributes
+    _valid_fields = {}
+    _types = {}
+
+    def __init__(self, service, **kwargs):
+        """Init music service item"""
+        super(MusicServiceItem, self).__init__(**kwargs)
+        self.service = service
+        self.resources = [DidlResource(uri=self.uri, protocol_info="DUMMY")]
+        self.desc = self.service.desc
+
+    @classmethod
+    def from_dict(cls, service, content_dict):
+        """Return an element instantiated from a dict and the service
+        (alternative constructor)
+
+        Args:
+            service (soco.music_service.MusicService): The music service that
+                this element originates from
+            content_dict (dict): Content to create the instance from. For
+                information about valid elements and types see _valid_fields
+                and _types
+        """
+        return cls(service, **content_dict)
+
+    @property
+    def item_id(self):
+        """Return the DIDL Lite compatible item_id"""
+        quoted_id = quote_url(self.metadata['id'].encode('utf-8'))
+        return '0fffffff{0}'.format(quoted_id)
+    
+    @property
+    def uri(self):
+        """Return the uri"""
+        # For an album
+        if not isinstance(self, get_class('MediaMetadataTrack')):
+            uri = 'x-rincon-cpcontainer:' + self.item_id
+        # For a track
+        else:
+            uri = self.service.sonos_uri_from_id(self.item_id)
+        return uri
+
+    def __str__(self):
+        """Return custom string representation"""
+        title = self.metadata.get('title')
+        str_ = '<{0} title="{1}">'
+        return str_.format(self.__class__.__name__, title)
+
+    def to_element(self, include_namespaces=False):
+        """Return an ElementTree Element representing this instance.
+
+        Args:
+            include_namespaces (bool, optional): If True, include xml
+                namespace attributes on the root element
+
+        Return:
+            ~xml.etree.ElementTree.Element: an Element.
+        """
+        # We piggy back on the implementation in DidlItem
+        didl_item = DidlItem(
+            title="DUMMY",
+            # This is ignored. Sonos gets the title from the item_id
+            parent_id="DUMMY",  # Ditto
+            item_id=self.item_id,
+            desc=self.desc,
+            resources=self.resources
+        )
+        return didl_item.to_element(include_namespaces=include_namespaces)
+
+
+class TrackMetadata(KwargsBase):
+    """Track metadata class"""
+
+    # _valid_fields is a set of valid fields
+    _valid_fields = {
+        'artistId',
+        'artist',
+        'composerId',
+        'composer',
+        'albumId',
+        'album',
+        'albumArtURI',
+        'albumArtistId',
+        'albumArtist',
+        'genreId',
+        'genre',
+        'duration',
+        'canPlay',
+        'canSkip',
+        'canAddToFavorites',
+        'rating',
+        'trackNumber',
+        'isFavorite',
+    }
+    # _types is a dict of fields with non-string types and their
+    # convertion callables
+    _types = {
+        'duration': int,
+        'canPlay': bool_str,
+        'canSkip': bool_str,
+        'canAddToFavorites': bool_str,
+        'rating': int,
+        'trackNumber': int,
+        'isFavorite': bool_str,
+    }
+
+
+class StreamMetadata(KwargsBase):
+    """Track metadata class"""
+
+    # _valid_fields is a set of valid fields
+    _valid_fields = {
+        'currentHost',
+        'currentShowId',
+        'currentShow',
+        'secondsRemaining',
+        'secondsToNextShow',
+        'bitrate',
+        'logo',
+        'hasOutOfBandMetadata',
+        'description',
+        'isEphemeral',
+    }
+    # _types is a dict of fields with non-string types and their
+    # convertion callables
+    _types = {
+        'secondsRemaining': int,
+        'secondsToNextShow': int,
+        'bitrate': int,
+        'hasOutOfBandMetadata': bool_str,
+        'isEphemeral': bool_str,
+    }
+
+
+class MediaMetadata(MusicServiceItem):
+    """Base class for all media metadata items"""
+
+    # _valid_fields is a set of valid fields
+    _valid_fields = {
+        'id',
+        'title',
+        'mimeType',
+        'itemType',
+        'displayType',
+        'summary',
+        'trackMetadata',
+        'streamMetadata',
+        'dynamic',
+    }
+    # _types is a dict of fields with non-string types and their
+    # convertion callables
+    _types = {
+        'trackMetadata': TrackMetadata.from_dict,
+        'streamMetadata': StreamMetadata.from_dict,
+        # FIXME Think about what to do about dynamic. Is it possible
+        # to type convert, is it even helpful?
+        #'dynamic': ???, 
+    }
+
+
+class MediaCollection(MusicServiceItem):
+    """Base class for all mediaCollection items"""
+
+    # _valid_fields is a set of valid fields
+    _valid_fields = {
+        'id',
+        'title',
+        'itemType',
+        'displayType',
+        'summary',
+        'artistId',
+        'artist',
+        'albumArtURI',
+        'canPlay',
+        'canEnumerate',
+        'canAddToFavorites',
+        'containsFavorite',
+        'canScroll',
+        'canSkip',
+        'isFavorite',
+    }
+
+    # _types is a dict of fields with non-string types and their
+    # convertion callables
+    _types = {
+        'canPlay': bool_str,
+        'canEnumerate': bool_str,
+        'canAddToFavorites': bool_str,
+        'containsFavorite': bool_str,
+        'canScroll': bool_str,
+        'canSkip': bool_str,
+        'isFavorite': bool_str,
+    }

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -18,7 +18,7 @@ from .. import discovery
 from ..compat import parse_qs, quote_url, urlparse
 from ..exceptions import MusicServiceException
 from ..music_services.accounts import Account
-from ..music_services.data_structures import parse_response, MusicServiceItem
+from .data_structures import parse_response, MusicServiceItem
 from ..soap import SoapFault, SoapMessage
 from ..xml import XML
 

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -678,7 +678,7 @@ class MusicService(object):
 
         """
         if isinstance(item, MusicServiceItem):
-            item_id = item.id
+            item_id = item.id  # pylint: disable=no-member
         else:
             item_id = item
         response = self.soap_client.call(

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -18,6 +18,7 @@ from .. import discovery
 from ..compat import parse_qs, quote_url, urlparse
 from ..exceptions import MusicServiceException
 from ..music_services.accounts import Account
+from ..music_services.data_structures import parse_response
 from ..soap import SoapFault, SoapMessage
 from ..xml import XML
 
@@ -713,6 +714,7 @@ class MusicService(object):
             [
                 ('id', search_category), ('term', term), ('index', index),
                 ('count', count)])
+        parse_response(response)
         return response.get('searchResult', None)
 
     def get_media_metadata(self, item_id):

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -18,7 +18,7 @@ from .. import discovery
 from ..compat import parse_qs, quote_url, urlparse
 from ..exceptions import MusicServiceException
 from ..music_services.accounts import Account
-from ..music_services.data_structures import parse_response
+from ..music_services.data_structures import parse_response, MusicServiceItem
 from ..soap import SoapFault, SoapMessage
 from ..xml import XML
 
@@ -656,12 +656,13 @@ class MusicService(object):
     #    setPlayedSeconds(id id, xs:int seconds)
 
     def get_metadata(
-            self, item_id='root', index=0, count=100, recursive=False):
+            self, item='root', index=0, count=100, recursive=False):
         """Get metadata for a container or item.
 
         Args:
-            item_id (str): The container or item to browse. Defaults to the
-                root item.
+            item (str or MusicServiceItem): The container or item to browse
+                given either as a MusicServiceItem instance or as a str.
+                Defaults to the root item.
             index (int): The starting index. Default 0.
             count (int): The maximum number of items to return. Default 100.
             recursive (bool): Whether the browse should recurse into sub-items
@@ -676,13 +677,17 @@ class MusicService(object):
             <http://musicpartners.sonos.com/node/83>`_.
 
         """
+        if isinstance(item, MusicServiceItem):
+            item_id = item.id
+        else:
+            item_id = item
         response = self.soap_client.call(
             'getMetadata', [
                 ('id', item_id),
                 ('index', index), ('count', count),
                 ('recursive', 1 if recursive else 0)]
         )
-        return response.get('getMetadataResult', None)
+        return parse_response(self, response, 'browse')
 
     def search(self, category, term='', index=0, count=100):
         """Search for an item in a category.
@@ -714,8 +719,8 @@ class MusicService(object):
             [
                 ('id', search_category), ('term', term), ('index', index),
                 ('count', count)])
-        parse_response(response)
-        return response.get('searchResult', None)
+
+        return parse_response(self, response, category)
 
     def get_media_metadata(self, item_id):
         """Get metadata for a media item.

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -1,8 +1,13 @@
+# -*- coding: utf-8 -*-
+
 """Test for music_services/data_structures"""
 
 from __future__ import unicode_literals, print_function
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 import pytest
 from mock import PropertyMock, Mock, patch
 from soco.music_services import data_structures

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -1,0 +1,269 @@
+"""Test for music_services/data_structures"""
+
+from __future__ import unicode_literals, print_function
+
+from collections import OrderedDict
+import pytest
+from mock import PropertyMock, Mock, patch
+from soco.music_services import data_structures
+from soco.data_structures import DidlResource
+
+# DATA
+RESPONSES = []
+RESPONSES.append(OrderedDict([('searchResult',
+    OrderedDict([('index', '0'),
+                 ('count', '2'),
+                 ('total', '17230'),
+                 ('mediaCollection',
+        [OrderedDict([('id', 'album/43820695'),
+                      ('itemType', 'album'),
+                      ('title', 'Black Mosque'),
+                      ('artist', 'Black Mosque'),
+                      ('artistId', 'artist/6689314'),
+                      ('canPlay', 'true'),
+                      ('canEnumerate', 'true'),
+                      ('canAddToFavorites', 'true'),
+                      ('canSkip', 'true'),
+                      ('albumArtURI', 'http://resources.wimpmusic.com/images/'
+                       '2238a5cd/ed4d/4ad0/848d/40356f11bda0/640x640.jpg'),
+                      ('canAddToFavorite', 'true')]),
+         OrderedDict([('id', 'album/50340580'),
+                      ('itemType', 'album'),
+                      ('title', 'Black Hippy 2'),
+                      ('artist', 'Black Hippy'),
+                      ('artistId', 'artist/3882538'),
+                      ('canPlay', 'true'),
+                      ('canEnumerate', 'true'),
+                      ('canAddToFavorites', 'true'),
+                      ('canSkip', 'true'),
+                      ('albumArtURI',
+                       'http://resources.wimpmusic.com/images/eefb1532/dfe9/'
+                       '46bd/8775/c583844bc098/640x640.jpg'),
+                      ('canAddToFavorite', 'true')])
+        ])
+    ]))
+]))
+RESPONSES.append(
+OrderedDict([('getMetadataResult',
+    OrderedDict([('mediaMetadata',
+        OrderedDict([('id', 'Track@catalog:/tracks/104655624'),
+                     ('title', 'Take Me Into Your Skin'),
+                     ('itemType', 'track'),
+                     ('mimeType', 'audio/aac'),
+                     ('trackMetadata',
+            OrderedDict([('albumArtURI', 'http://artwork.cdn.247e.com/covers/104655587/256x256'),
+                         ('artistId', 'Artist@catalog:/artists/219591'),
+                         ('artist', 'Trentemøller'),
+                         ('album', 'The Last Resort'),
+                         ('duration', '464'),
+                         ('canPlay', 'true'),
+                         ('canSkip', 'true'),
+                         ('canAddToFavorites', 'true'),
+                         ('trackNumber', '1')])
+                     )])),
+                 ('count', '1'),
+                 ('index', '0'),
+                 ('total', '13')])
+)])
+)
+PARSE_RESULTS = (
+    {
+        'number_of_results': 2,
+        'type': 'searchResult',
+        'class_key': 'MediaCollectionAlbum',
+        
+    },
+    {
+        'number_of_results': 1,
+        'type': 'getMetadataResult',
+        'class_key': 'MediaMetadataTrack',
+    },
+)
+
+
+def test_get_class():
+    """Test the get_class function"""
+    # Test core functionality for base class MediaMetadata
+    cls = data_structures.get_class('MediaMetadataTrack')
+    assert cls.__name__ == 'MSTrack'
+    assert issubclass(cls, data_structures.MediaMetadata)
+
+    # Test core functionality for base class Mediacolection
+    cls = data_structures.get_class('MediaCollectionArtist')
+    assert cls.__name__ == 'MSArtist'
+    assert issubclass(cls, data_structures.MediaCollection)
+
+    # Test the caching function
+    cls2 = data_structures.get_class('MediaCollectionArtist')
+    assert cls is cls2
+
+    # Asking for bad class should raise KeyError
+    with pytest.raises(KeyError):
+        cls = data_structures.get_class('Nonsense')
+
+
+@pytest.mark.parametrize("response, correct",
+                         zip(RESPONSES, PARSE_RESULTS))
+def test_parse_response(response, correct):
+    """Test the parse_response function"""
+    music_service = Mock()
+    music_service.desc = 'DESC'
+    results = data_structures.parse_response(music_service, response, 'albums')
+
+    # Check the search result metadata
+    response_data = response[correct['type']]
+    assert results.number_returned == response_data['count']
+    assert results.search_type == 'albums'
+
+    # Check the result
+    assert len(results) == correct['number_of_results']
+    klass = data_structures.get_class(correct['class_key'])
+    for result in results:
+        assert isinstance(result, klass)
+        assert result.music_service is music_service
+
+
+def test_parse_response_bad_type():
+    """Test parse reponse bad code"""
+    with pytest.raises(ValueError) as exp:
+        data_structures.parse_response(None, {}, 'albums')
+    print(exp)
+
+
+def test_form_uri():
+    """Test the form uri function"""
+    music_service = Mock()
+    music_service.sonos_uri_from_id.return_value = '99'
+
+    # Test non track uri
+    non_track_uri = data_structures.form_uri('dummy_id', None, False)
+    assert non_track_uri == 'x-rincon-cpcontainer:dummy_id'
+
+    # Test track uri
+    track_uri = data_structures.form_uri('dummy_id', music_service, True)
+    music_service.sonos_uri_from_id.assert_called_once_with('dummy_id')
+
+
+def test_bool_str():
+    """Test the bool_str function"""
+    assert data_structures.bool_str('true') is True
+    assert data_structures.bool_str('false') is False
+    with pytest.raises(ValueError):
+        data_structures.bool_str('dummy')
+
+
+class TestMetadataDictBase(object):
+    """Tests for the MetadataDictBase class"""
+
+    def test_init(self):
+        """Test normal __init__ functionality; metadata stored and camel case
+        names coverted
+
+        """
+        metadata_dict = {
+            'superTitle': 'Dummy Title',
+        }
+        metadata = data_structures.MetadataDictBase(metadata_dict)
+        # Assert only metadata element, name conversion and value
+        assert len(metadata.metadata) == 1
+        assert metadata.super_title == 'Dummy Title'
+
+    def test_conversion(self):
+        """Test the type conversion of fields in metadata"""
+        conversion_mock = Mock()
+        conversion_mock.return_value = 47
+
+        # MetadataDictBase is meant to ve overwritten, to supply
+        # valid_fields and conversion functions
+        class MyClass(data_structures.MetadataDictBase):
+            _types = {'trackDuration': conversion_mock}
+
+        metadata_dict = {
+            'title': 'Dummy Title',
+            'trackDuration': '47',
+        }
+        metadata = MyClass(metadata_dict)
+        # Check that the duration has been properly type converted
+        conversion_mock.assert_called_once_with('47')
+        assert metadata.track_duration == 47
+        # And that title has been left unchanged
+        assert metadata.title == 'Dummy Title'
+
+    def test_get_attr(self):
+        """Test the __getattr__ method"""
+        metadata_dict = {
+            'superTitle': 'Dummy Title',
+        }
+        metadata = data_structures.MetadataDictBase(metadata_dict)
+        # Test normal lookup
+        assert metadata.super_title == 'Dummy Title'
+        # Test raise attribute error when the key is not in metadata
+        with pytest.raises(AttributeError):
+            metadata.nonexistent_key
+
+
+class TestMusicServiceItem(object):
+    """Test the MusicServiceItem class"""
+
+    @patch('soco.music_services.data_structures.MetadataDictBase.__init__')
+    def test_init(self, metadata_dict_base_init):
+        """Test the __init__ method"""
+        kwargs = {
+            'item_id': 'some_item_id', 'desc': 'the_desc',
+            'resources': 'the ressources', 'uri': 'https://the_uri',
+            'metadata_dict': {'some': 'dict'}, 'music_service': 'the music service',
+
+            }
+
+        music_service_item = data_structures.MusicServiceItem(**kwargs)
+        # Test call to super class init
+        metadata_dict_base_init.assert_called_once_with({'some': 'dict'})
+        # Test that all but the metadata_dict arg have been set as
+        # attributes with the same names as the arguments
+        kwargs.pop('metadata_dict')
+        for arg_name, arg_value in kwargs.items():
+            assert getattr(music_service_item, arg_name) == arg_value
+
+    @patch('soco.music_services.data_structures.MusicServiceItem.__init__')
+    @patch('soco.music_services.data_structures.form_uri')
+    @patch('soco.music_services.data_structures.DidlResource')
+    def test_from_music_service(self, didl_resource, form_uri, music_service_init):
+        """Test th from music service class method"""
+        # Setup mock music service with mocked desc property
+        ms = Mock()
+        desc = PropertyMock(return_value='fake_desc')
+        type(ms).desc = desc
+
+        # Setup content dict
+        id_ = 'fakeid1234'
+        item_id = '0fffffff' + id_
+        content_dict = {'id': id_, 'title': 'fake title'}
+
+        # Setup return values of mocks
+        didl_resource.return_value = Mock()
+        form_uri.return_value = 'x-rincon-whatever:' + id_
+        music_service_init.return_value = None
+
+        # Call the class method and assert init called
+        data_structures.MusicServiceItem.from_music_service(ms, content_dict)
+        music_service_init.assert_called_once_with(
+            item_id, 'fake_desc', [didl_resource.return_value],
+            form_uri.return_value, content_dict, music_service=ms
+        )
+        form_uri.assert_called_once_with(item_id, ms, False)
+
+    def test_str_(self):
+        """Test the __str__ method"""
+        content_dict = {'title': 'fake title'}
+        item = data_structures.MusicServiceItem('fake_id', 'desc', 'ressources', 'uri', content_dict)
+        assert item.__str__() == '<MusicServiceItem title="fake title">'
+
+    @patch('soco.music_services.data_structures.DidlItem.to_element')
+    def test_to_element(self, didl_item_to_element):
+        """Test the to_element method"""
+        didl_item_to_element.return_value = object()
+        content_dict = {'title': 'fake title'}
+        item = data_structures.MusicServiceItem('fake_id', 'desc', 'ressources', 'uri', content_dict)
+        assert item.to_element() == didl_item_to_element.return_value
+        
+        


### PR DESCRIPTION
Ok, so I had a request for comments PR open for a while, but did not get any feedback, so I continued and finished the implementation.

The work includes complete test coverage but no docs yet. I wanted to see this in before I added to the docs.

Quick summary:

My initial purpose was:
1. To have data structures similar to the ones we have for music library items
   i.e. that can be browsed and added as is to the queue.
2. To expose the metadata
3. (Optionally) To have the metadata in the correct types

Initially I was planning on doing only the minimal to get them queue-able
(1. and 2. and just one class with the type as a attribute), but it turned out
to be only very little extra work to get a fully spec[1] compliant
implementation with classes for all the types.

The work is based on the spec[1] and two gists from @lawrenceakka [2][3].

Note: The types here seem to be completely independent from the DidlItem
hierarchy which is why I choose a new implementation. Trying to shoehorn it
into the Didl hierarchy and types is in my view not a good idea.

The final status is:
- I have an implementation of the class hierarchy and metadata parsing and
  type conversion, that I am very satisfied with. It does what it is supposed
  to and is straight forward and easy to read (3 levels on inheritance and no
  fancy object oriented tricks).
- The changes for integration with the rest of the code base is minimal (only few changes to
  music_service.py and soco/data_structure.py), though that is of course not a goal in itself, see below:

The code can be tested along the lines of these examples of usage:

```python
zone = any_soco()
ym = MusicService('YouSee Musik')

# Search for an album
items = ym.search('albums', 'the last resort', 0, 1)
for item in items:
    print(item)
album = items[0]
zone.add_to_queue(album)

tracks = ym.get_metadata(album)
last_track = tracks[-1]
zone.add_to_queue(last_track)
# And enjoy some electronic music from a Danish DJ

# Visualize the content tree (note the music service is hardcoded)
def tree(browse_item='root', indent=0, max_depth=10):
    if indent > max_depth:
        return
    if isinstance(browse_item, track_class):
        return
    for item in ym.get_metadata(browse_item):
        print("*" * indent + ' ', item.title, sep='')
        tree(item, indent=indent+1, max_depth=max_depth)
tree(max_depth=2)
```

There is of course still more work to be done (there is a lot more information on that and further thoughts in the request for comments PR #412), but this seems like the right place to make a cut.

So please, comments, questions?

[1] http://musicpartners.sonos.com/node/83
[2] https://gist.github.com/lawrenceakka/2d21dca590b4fa7e3af2
[3] https://gist.github.com/lawrenceakka/c8597d2533b6cc3e0d18
