### PR TITLE
Add multiple items to queue

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -138,6 +138,7 @@ class SoCo(_SocoSingletonBase):
         get_current_transport_info
         add_uri_to_queue
         add_to_queue
+        add_multiple_to_queue
         remove_from_queue
         clear_queue
         get_favorite_radio_shows
@@ -1283,6 +1284,39 @@ class SoCo(_SocoSingletonBase):
             ('EnqueuedURIMetaData', metadata),
             ('DesiredFirstTrackNumberEnqueued', 0),
             ('EnqueueAsNext', 1)
+        ])
+        qnumber = response['FirstTrackNumberEnqueued']
+        return int(qnumber)
+
+    def add_multiple_to_queue(self, items, container=None):
+        """Adds a sequence of items to the queue.
+
+        Args:
+            items (list): A sequence of items to the be added to the queue
+            container (DidlObject, optional): A container object which
+                includes the items.
+
+        Returns:
+            int: The index at which the items were enqueued.
+        """
+        uris = ' '.join([item.resources[0].uri for item in items])
+        uri_metadata = ' '.join([to_didl_string(item) for item in items])
+        if container is not None:
+            container_uri = container.resources[0].uri
+            container_metadata = to_didl_string(container)
+        else:
+            container_uri = ''
+            container_metadata = ''  # pylint: disable=redefined-variable-type
+        response = self.avTransport.AddMultipleURIsToQueue([
+            ('InstanceID', 0),
+            ('UpdateID', 0),
+            ('NumberOfURIs', len(items)),
+            ('EnqueuedURIs', uris),
+            ('EnqueuedURIsMetaData', uri_metadata),
+            ('ContainerURI', container_uri),
+            ('ContainerMetaData', container_metadata),
+            ('DesiredFirstTrackNumberEnqueued', 0),
+            ('EnqueueAsNext', 0)
         ])
         qnumber = response['FirstTrackNumberEnqueued']
         return int(qnumber)


### PR DESCRIPTION
This PR adds a `SoCo.add_multiple_to_queue()` method, which takes a list of queueable items and adds them to the queue with a single request. For spec compatibility, it also has a `container` parameter, which should be the superordinate Didl container, but since it also works without a container, the default is None.