### PR TITLE
add_to_queue() at given position

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1264,15 +1264,7 @@ class SoCo(_SocoSingletonBase):
     def add_uri_to_queue(self, uri, position=0, as_next=False):
         """Adds the URI to the queue.
 
-        :param uri: The URI to be added to the queue
-        :type uri: str
-        :param position: The index (1-based) at which the URI should be added.
-            Default is 0 (add URI at the end of the queue).
-        :type position: int
-        :param as_next: Whether this URI should be played as the next track.
-            This can be used to set the next track even when
-            `play_mode=SHUFFLE`.
-        :type as_next: bool
+        For Arguments see `add_to_queue`.
         """
         # FIXME: The res.protocol_info should probably represent the mime type
         # etc of the uri. But this seems OK.
@@ -1283,7 +1275,15 @@ class SoCo(_SocoSingletonBase):
     @only_on_master
     def add_to_queue(self, queueable_item, position=0, as_next=False):
         """Adds a queueable item to the queue.
-        For Arguments see `add_uri_to_queue`"""
+
+        Args:
+            queueable_item (DidlObject or MusicServiceItem): The item to be
+                added to the queue
+            position (int): The index (1-based) at which the URI should be
+                added. Default is 0 (add URI at the end of the queue).
+            as_next (bool): Whether this URI should be played as the next
+                track in shuffle mode. This only works if `play_mode=SHUFFLE`.
+        """
         metadata = to_didl_string(queueable_item)
         response = self.avTransport.AddURIToQueue([
             ('InstanceID', 0),


### PR DESCRIPTION
This PR adds optional `position` and `as_next` arguments to `add_uri_to_queue()` and `add_to_queue()` to specify at which position the item should be inserted into the queue and whether this item should be played next.