### PR TITLE
Didl class for Sonos favorites

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@
 # duplicate code check disabled whilst refactoring of wimp plugin is in
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
-    bad-option-value,no-else-return
+    bad-option-value,no-else-return,cyclic-import
 
 
 [REPORTS]

--- a/soco/core.py
+++ b/soco/core.py
@@ -142,9 +142,6 @@ class SoCo(_SocoSingletonBase):
         add_multiple_to_queue
         remove_from_queue
         clear_queue
-        get_favorite_radio_shows
-        get_favorite_radio_stations
-        get_sonos_favorites
         create_sonos_playlist
         create_sonos_playlist_from_queue
         remove_sonos_playlist
@@ -1450,6 +1447,7 @@ class SoCo(_SocoSingletonBase):
             ('InstanceID', 0),
         ])
 
+    @deprecated('0.13', "soco.music_library.get_favorite_radio_shows", '0.15')
     def get_favorite_radio_shows(self, start=0, max_items=100):
         """Get favorite radio shows from Sonos' Radio app.
 
@@ -1468,6 +1466,7 @@ class SoCo(_SocoSingletonBase):
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(RADIO_SHOWS, start, max_items)
 
+    @deprecated('0.13', "soco.music_library.get_favorite_radio_stations", '0.15')
     def get_favorite_radio_stations(self, start=0, max_items=100):
         """Get favorite radio stations from Sonos' Radio app.
 
@@ -1486,6 +1485,7 @@ class SoCo(_SocoSingletonBase):
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(RADIO_STATIONS, start, max_items)
 
+    @deprecated('0.13', "soco.music_library.get_sonos_favorites", '0.15')
     def get_sonos_favorites(self, start=0, max_items=100):
         """Get Sonos favorites.
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -1466,7 +1466,8 @@ class SoCo(_SocoSingletonBase):
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(RADIO_SHOWS, start, max_items)
 
-    @deprecated('0.13', "soco.music_library.get_favorite_radio_stations", '0.15')
+    @deprecated('0.13', "soco.music_library.get_favorite_radio_stations",
+                '0.15')
     def get_favorite_radio_stations(self, start=0, max_items=100):
         """Get favorite radio stations from Sonos' Radio app.
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -61,6 +61,7 @@ def to_didl_string(*args):
             'xmlns': "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
             'xmlns:dc': "http://purl.org/dc/elements/1.1/",
             'xmlns:upnp': "urn:schemas-upnp-org:metadata-1-0/upnp/",
+            'xmlns:r': "urn:schemas-rinconnetworks-com:metadata-1-0/"
         })
     for arg in args:
         didl.append(arg.to_element())
@@ -799,15 +800,22 @@ class DidlFavorite(DidlItem):
         }
     )
 
-    # The resMD tag contains the metadata of the Didl object referenced by this favorite.
-    # For user convenience, we will parse this metadata and make the object available via the 'reference' attribute.
-    # The resMD metadata lacks a <res> tag, so we use the resources from the favorite to make 'reference' playable.
-    def __init__(self, title, parent_id, item_id, restricted=True,
-                 resources=None, desc='RINCON_AssociatedZPUDN', **kwargs):
-        super(DidlFavorite, self).__init__(title, parent_id, item_id, restricted, resources, desc, **kwargs)
-        if hasattr(self, 'resource_meta_data'):
-            reference = from_didl_string(self.resource_meta_data)[0]
-            reference.resources = self.resources
+    # The resMD tag contains the metadata of the Didl object referenced by this
+    # favorite. For user convenience, we will parse this metadata and make the
+    # object available via the 'reference' property.
+    @property
+    def reference(self):
+        """The Didl object this favorite refers to."""
+        ref = from_didl_string(getattr(self, 'resource_meta_data'))[0]
+        # The resMD metadata lacks a <res> tag, so we use the resources from
+        # the favorite to make 'reference' playable.
+        ref.resources = self.resources
+        return ref
+
+    @reference.setter
+    def reference(self, value):
+        setattr(self, 'resource_meta_data', to_didl_string(value))
+        self.resources = value.resources
 
 
 ###############################################################################
@@ -1033,6 +1041,7 @@ class DidlRadioShow(DidlContainer):
     # the DIDL Lite class for this object.
     item_class = 'object.container.radioShow'
     # A radio show doesn't seem to have any special attributes
+
 
 ###############################################################################
 # SPECIAL LISTS                                                               #

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1027,6 +1027,13 @@ class DidlMusicGenre(DidlGenre):
     tag = 'item'
 
 
+class DidlRadioShow(DidlContainer):
+    """Class that represents a radio show."""
+
+    # the DIDL Lite class for this object.
+    item_class = 'object.container.radioShow'
+    # A radio show doesn't seem to have any special attributes
+
 ###############################################################################
 # SPECIAL LISTS                                                               #
 ###############################################################################

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -37,7 +37,8 @@ class MusicLibrary(object):
                           'playlists': 'A:PLAYLISTS',
                           'share': 'S:',
                           'sonos_playlists': 'SQ:',
-                          'categories': 'A:'}
+                          'categories': 'A:',
+                          'sonos_favorites': 'FV:2'}
 
     # pylint: disable=invalid-name, protected-access
     def __init__(self, soco=None):

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -142,6 +142,34 @@ class MusicLibrary(object):
         args = tuple(['playlists'] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
+
+    def get_sonos_favorites(self, *args, **kwargs):
+        """Convenience method for `get_music_library_information`
+        with ``search_type='sonos_favorites'``. For details of other arguments,
+        see `that method
+        <#soco.music_library.MusicLibrary.get_music_library_information>`_.
+        """
+        args = tuple(['sonos_favorites'] + list(args))
+        return self.get_music_library_information(*args, **kwargs)
+
+    def get_favorite_radio_stations(self, *args, **kwargs):
+        """Convenience method for `get_music_library_information`
+        with ``search_type='radio_stations'``. For details of other arguments,
+        see `that method
+        <#soco.music_library.MusicLibrary.get_music_library_information>`_.
+        """
+        args = tuple(['radio_stations'] + list(args))
+        return self.get_music_library_information(*args, **kwargs)
+
+    def get_favorite_radio_shows(self, *args, **kwargs):
+        """Convenience method for `get_music_library_information`
+        with ``search_type='radio_stations'``. For details of other arguments,
+        see `that method
+        <#soco.music_library.MusicLibrary.get_music_library_information>`_.
+        """
+        args = tuple(['radio_shows'] + list(args))
+        return self.get_music_library_information(*args, **kwargs)
+
         # pylint: disable=too-many-locals, too-many-arguments,
         # too-many-branches
 

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -142,7 +142,6 @@ class MusicLibrary(object):
         args = tuple(['playlists'] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
-
     def get_sonos_favorites(self, *args, **kwargs):
         """Convenience method for `get_music_library_information`
         with ``search_type='sonos_favorites'``. For details of other arguments,

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -38,7 +38,9 @@ class MusicLibrary(object):
                           'share': 'S:',
                           'sonos_playlists': 'SQ:',
                           'categories': 'A:',
-                          'sonos_favorites': 'FV:2'}
+                          'sonos_favorites': 'FV:2',
+                          'radio_stations': 'R:0/0',
+                          'radio_shows': 'R:0/1'}
 
     # pylint: disable=invalid-name, protected-access
     def __init__(self, soco=None):


### PR DESCRIPTION
This PR makes browsing Sonos favorites with the existing music library methods possible.
This is archieved by adding a data structure for the `object.itemobject.item.sonos_favorite` Didl class. The metadata of the favorites contains a `<resMD>`  tag, which encloses the metadata of the item to which the favorite refers. I have added a `reference` property to make this metadata accessible as a Didl object.
Unlike the existing implementation, one can now handle Sonos and radio favorites just like other music items - the specific methods are no longer required.
I would really like to integrate this functionality into SoCo, so please let me know if I should change something to get this merged!