### PR TITLE
Property for DidlObject.resources[0].uri

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -692,7 +692,12 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
 
     @property
     def uri(self):
+        """The uri to use for playing this item. This is currently the uri of
+        the first resource."""
         return self.resources[0].uri
+        # According to the spec, a DidlObject can have multiple resources and
+        # consequently multiple uri's, but since we have never seen an object
+        # with more than one resource, we can just use the first one.
 
 
 ###############################################################################

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -690,6 +690,10 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
 
         return elt
 
+    @property
+    def uri(self):
+        return self.resources[0].uri
+
 
 ###############################################################################
 # OBJECT.ITEM HIERARCHY                                                       #


### PR DESCRIPTION
I have noticed that I use DidlObject.resources[0].uri quite often and it is also present in the SoCo code multiple times. Hardcoding the index [0] in so many places does not seem very good practice to me.

Therefore, I have added a uri property to DidlObject which returns resources[0].uri.

> Note: This was discussed before in #472.