### PR TITLE
Added by_name function to discovery, with test and doc changes

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -49,18 +49,14 @@ one e.g. to query for music library information::
 Getting a named device
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Getting a device by name is done by searching through the devices
-returned by :func:`soco.discover`::
+Getting a device by player name can be done with the
+:func:`soco.discovery.by_name` function::
 
-  >>> import soco
-  >>> for device in soco.discover():
-  ...     if device.player_name == 'Office':
-  ...         break
-  ... else:
-  ...     device = None
-  ... 
+  >>> from soco.discovery import by_name
+  >>> device = by_name("Living Room")
   >>> device
-  SoCo("192.168.1.8")
+  SoCo("192.168.1.18")
+
 
 .. _examples_playback_control:
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -211,3 +211,18 @@ def any_soco():
         return None if devices is None else devices.pop()
 
     return device
+
+
+def by_name(name):
+    """Return a device by name
+
+    Args:
+        name (str): The name of the device to return
+
+    Returns:
+        :class:`~.SoCo`: The first device encountered among all zone with the
+            given player name. If none is found `None` is returned.
+    """
+    for device in discover():
+        if device.player_name == name:
+            return device

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -214,14 +214,14 @@ def any_soco():
 
 
 def by_name(name):
-    """Return a device by name
+    """Return a device by name.
 
     Args:
-        name (str): The name of the device to return
+        name (str): The name of the device to return.
 
     Returns:
         :class:`~.SoCo`: The first device encountered among all zone with the
-            given player name. If none is found `None` is returned.
+            given player name. If none are found `None` is returned.
     """
     for device in discover():
         if device.player_name == name:


### PR DESCRIPTION
This PR adds a very simple `by_name` function to discovery that returns a device by its name.

```python
from soco.discovery import by_name
device = by_name("Kitchen")
```

I don't know why I haven't done this earlier, since the code that it contains, I have been writing by hand a lot of time while testing different things.

Let me know what you think.