### PR TITLE
Add to the git revision number to the version string when in developm…

### DIFF
--- a/doc/development/release-howto.rst
+++ b/doc/development/release-howto.rst
@@ -27,7 +27,8 @@ Create and Publish
 * Verify that all tests pass.
 
 * Update the version number in ``__init__.py`` (see
-  `example <https://github.com/SoCo/SoCo/commit/d35171213eabbc4>`_).
+  `example <https://github.com/SoCo/SoCo/commit/d35171213eabbc4>`_)
+  and set _RELEASE to ``True``.
 
 * Tag the current commit, eg
 
@@ -57,6 +58,9 @@ Create and Publish
 
 Wrap-Up
 -------
+
+* In ``__init__.py`` set _RELEASE back to ``False`` and commit and
+  push the change to github.
 
 * Create the milestone for the next release (with the most likely version
   number) and close the milestone for the current release.

--- a/doc/development/release-howto.rst
+++ b/doc/development/release-howto.rst
@@ -27,8 +27,7 @@ Create and Publish
 * Verify that all tests pass.
 
 * Update the version number in ``__init__.py`` (see
-  `example <https://github.com/SoCo/SoCo/commit/d35171213eabbc4>`_)
-  and set _RELEASE to ``True``.
+  `example <https://github.com/SoCo/SoCo/commit/d35171213eabbc4>`_).
 
 * Tag the current commit, eg
 
@@ -46,11 +45,20 @@ Create and Publish
   using the release notes from the documentation. The release notes can be
   abbreviated if a link to the documentation is provided.
 
+* In ``__init__.py`` set _RELEASE to ``True`` (but do not commit) and
+  re-run tests for (just in case)
+
 * Upload the release to PyPI.
 
 .. code-block:: bash
 
     python setup.py sdist bdist_wheel upload
+
+* Revert change in ``__init__.py``, so as to leave a clean git archive.
+
+.. code-block:: bash
+
+    git checkout __init__.py
 
 * Enable doc builds for the newly released version on `Read the Docs
   <https://readthedocs.org/dashboard/soco/versions/>`_.

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -15,14 +15,20 @@ from .compat import NullHandler
 from .core import SoCo
 from .discovery import discover
 from .exceptions import SoCoException, UnknownSoCoException
+from .utils import get_git_revision
 
 # Will be parsed by setup.py to determine package metadata
 __author__ = 'The SoCo-Team <python-soco@googlegroups.com>'
-# Please add the suffix "+" to the version after release, to make it
-# possible infer whether in development code from the version string
-__version__ = '0.12+'
+__version__ = '0.12'
 __website__ = 'https://github.com/SoCo/SoCo'
 __license__ = 'MIT License'
+
+# Use this to indicate that a release is about to be built, should always be
+# False in development
+_RELEASE = False
+
+if not _RELEASE:
+    __version__ += '+ (git ' + get_git_revision() + ')'
 
 # You really should not `import *` - it is poor practice
 # but if you do, here is what you get:

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -8,6 +8,8 @@ from __future__ import (
 
 import functools
 import re
+import os
+import subprocess
 import warnings
 
 from .compat import (
@@ -186,3 +188,55 @@ def url_escape_path(path):
     """
     # Using 'safe' arg does not seem to work for python 2.6
     return quote_url(path.encode('utf-8')).replace('/', '%2F')
+
+
+def get_git_revision():
+    """Return the git revision as a string"""
+    # The first part of this function is borrowed from numpy
+    # https://github.com/numpy/numpy/blob/master/setup.py#L70-L92)
+    def _minimal_ext_cmd(cmd):
+        """Execute a command in a minimal environment"""
+        # construct minimal environment
+        env = {}
+        for key in ['SYSTEMROOT', 'PATH']:
+            value = os.environ.get(key)
+            if value is not None:
+                env[key] = value
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, env=env
+        ).communicate()[0]
+        return out
+
+    try:
+        out = _minimal_ext_cmd(['dgit', 'rev-parse', 'HEAD'])
+        git_revision = out.strip().decode('ascii')
+        return git_revision
+    except OSError:
+        pass
+
+    # If we cannot call git, try and read the revision from git files directly
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    git_dir = os.path.join(current_dir, '..', '.git')
+    try:
+        # Read the content of HEAD
+        with open(os.path.join(git_dir, 'HEAD'), 'rb') as file_:
+            head = file_.read().decode('ascii').strip()
+
+        # If on a branch, HEAD points to another ref
+        if head.startswith('ref: '):
+            ref = head.replace('ref: ', '')
+            # Assume the content of git refs are always unix style
+            ref_components = ref.split('/')
+            # Read the content of the ref
+            with open(os.path.join(git_dir, *ref_components), 'rb') as file_:
+                git_revision = file_.read().decode('ascii').strip()
+        else:
+            git_revision = head
+    except:  # pylint: disable=bare-except
+        return 'Unknown'
+
+    return git_revision


### PR DESCRIPTION
…ent.

With more and more issues it has become necessary to know what version of the code (even in development) is being used. This PR adds the git revision (if it can be detected) to the version string.

This change means that when releasing, beside from changing the ``__version__`` in ``__init__.py``, it is also required to set ``_RELEASE`` to ``True``. This has been documented in release howto in the docs.

This closes #486.

I do need one little bit of information from someone on Windows, so shout of if you can help with a test on that platform.

Let me know what you think.

