### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
+  - "pypy" # Run slowest first so as not to hold up the build
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
-  - "pypy"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -17,10 +16,8 @@ install:
   - pip install -e .
 
 script:
-  # flake8 no longer supports Python 2.6, so only run it if not 2.6
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then flake8 soco; fi
-  # Pylint no longer supports Python 2.6, so only run it if not 2.6
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pylint soco; fi
+  - flake8 soco
+  - pylint soco
   - py.test --cov-config .coveragerc --cov soco .
 
 after_script:

--- a/doc/advanced/topology.rst
+++ b/doc/advanced/topology.rst
@@ -13,7 +13,7 @@ Topology is available from each :class:`soco.SoCo` instance.
     ZoneGroup(
         uid='RINCON_000E5879136C01400:58',
         coordinator=SoCo("192.168.1.101"),
-        members=set([SoCo("192.168.1.101"), SoCo("192.168.1.102")])
+        members={SoCo("192.168.1.101"), SoCo("192.168.1.102")}
     )
 
 A group of speakers is represented by a :class:`soco.groups.ZoneGroup`.

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,11 @@ CLASSIFIERS = [
     'License :: OSI Approved :: MIT License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Home Automation',
     'Topic :: Multimedia :: Sound/Audio',
@@ -68,10 +68,6 @@ with io.open('README.rst', encoding='utf-8') as file:
 AUTHOR, EMAIL = re.match(r'(.*) <(.*)>', AUTHOR_EMAIL).groups()
 
 REQUIREMENTS = list(open('requirements.txt'))
-# Python 2.6 does not have importlib or OrderedDicts, so we need to install
-# the backports
-if sys.version_info < (2, 7):
-    REQUIREMENTS.extend(['importlib', 'ordereddict'])
 
 setup(
     name=NAME,

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -11,7 +11,6 @@
 
 import logging
 
-from .compat import NullHandler
 from .core import SoCo
 from .discovery import discover
 from .exceptions import SoCoException, UnknownSoCoException
@@ -36,4 +35,4 @@ __all__ = [
 # http://docs.python.org/2/howto/logging.html#library-config
 # Avoids spurious error messages if no logger is configured by the user
 
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/soco/compat.py
+++ b/soco/compat.py
@@ -35,19 +35,6 @@ try:  # python 2.7 - this has to be done the other way round
 except ImportError:  # python 3
     from pickle import dumps  # noqa
 
-# Support Python 2.6
-try:  # Python 2.7+
-    from logging import NullHandler  # noqa
-except ImportError:
-    import logging
-
-    class NullHandler(logging.Handler):
-
-        """Create a null handler if using Python 2.6"""
-
-        def emit(self, record):
-            pass
-
 
 def with_metaclass(meta, *bases):
     """A Python 2/3 compatible way of declaring a metaclass.

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -6,7 +6,6 @@ objects from both music library and music service data structures
 
 from __future__ import absolute_import
 
-import sys
 import logging
 
 from .xml import (
@@ -20,8 +19,7 @@ from .music_services.music_service import desc_from_uri
 
 
 _LOG = logging.getLogger(__name__)
-if not (sys.version_info[0] == 2 or sys.version_info[1] == 6):
-    _LOG.addHandler(logging.NullHandler())
+_LOG.addHandler(logging.NullHandler())
 _LOG.debug('%s imported', __name__)
 
 

--- a/soco/events.py
+++ b/soco/events.py
@@ -456,11 +456,11 @@ class Subscription(object):
         # pylint: disable=unbalanced-tuple-unpacking
         ip_address, port = event_listener.address
         headers = {
-            'Callback': '<http://{0}:{1}>'.format(ip_address, port),
+            'Callback': '<http://{}:{}>'.format(ip_address, port),
             'NT': 'upnp:event'
         }
         if requested_timeout is not None:
-            headers["TIMEOUT"] = "Second-{0}".format(requested_timeout)
+            headers["TIMEOUT"] = "Second-{}".format(requested_timeout)
         response = requests.request(
             'SUBSCRIBE', service.base_url + service.event_subscription_url,
             headers=headers)
@@ -534,7 +534,7 @@ class Subscription(object):
         if requested_timeout is None:
             requested_timeout = self.requested_timeout
         if requested_timeout is not None:
-            headers["TIMEOUT"] = "Second-{0}".format(requested_timeout)
+            headers["TIMEOUT"] = "Second-{}".format(requested_timeout)
         response = requests.request(
             'SUBSCRIBE',
             self.service.base_url + self.service.event_subscription_url,

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -109,5 +109,5 @@ class ZoneGroup(object):
         group_names = sorted([m.player_name for m in self.members])
         group_label = group_names[0]
         if len(group_names) > 1:
-            group_label += " + {0}".format(len(group_names) - 1)
+            group_label += " + {}".format(len(group_names) - 1)
         return group_label

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -13,7 +13,7 @@ class ZoneGroup(object):
         ZoneGroup(
             uid='RINCON_000FD584236D01400:58',
             coordinator=SoCo("192.168.1.101"),
-            members=set([SoCo("192.168.1.101"), SoCo("192.168.1.102")])
+            members={SoCo("192.168.1.101"), SoCo("192.168.1.102")}
         )
 
 
@@ -25,7 +25,7 @@ class ZoneGroup(object):
         ZoneGroup(
             uid='RINCON_000FD584236D01400:58',
             coordinator=SoCo("192.168.1.101"),
-            members=set([SoCo("192.168.1.101"), SoCo("192.168.1.102")])
+            members={SoCo("192.168.1.101"), SoCo("192.168.1.102")}
         )
 
     From there, you can find the coordinator for the current group::

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -36,7 +36,7 @@ def tags_with_text(xml, tags=None):
         elif len(element) > 0:  # pylint: disable=len-as-condition
             tags_with_text(element, tags)
         else:
-            message = 'Unknown XML structure: {0}'.format(element)
+            message = 'Unknown XML structure: {}'.format(element)
             raise ValueError(message)
     return tags
 
@@ -114,7 +114,7 @@ class MusicServiceItem(object):
             tag = item.tag[len(NAMESPACES['ms']) + 2:]  # Strip namespace
             tag = camel_to_underscore(tag)  # Convert to nice names
             if tag not in cls.valid_fields:
-                message = 'The info tag \'{0}\' is not allowed for this item'.\
+                message = 'The info tag \'{}\' is not allowed for this item'.\
                     format(tag)
                 raise ValueError(message)
             content[tag] = item.text
@@ -139,7 +139,7 @@ class MusicServiceItem(object):
         # Check for all required values
         for key in cls.required_fields:
             if key not in content:
-                message = 'An XML field that correspond to the key \'{0}\' '\
+                message = 'An XML field that correspond to the key \'{}\' '\
                     'is required. See the docstring for help.'.format(key)
 
         return cls.from_dict(content)
@@ -186,9 +186,9 @@ class MusicServiceItem(object):
             middle = self.content['title'].encode('ascii', 'replace')[0:40]
         else:
             middle = str(self.content).encode('ascii', 'replace')[0:40]
-        return '<{0} \'{1}\' at {2}>'.format(self.__class__.__name__,
-                                             middle,
-                                             hex(id(self)))
+        return '<{} \'{}\' at {}>'.format(self.__class__.__name__,
+                                          middle,
+                                          hex(id(self)))
 
     def __str__(self):
         """Return the str value for the item::
@@ -238,7 +238,7 @@ class MusicServiceItem(object):
         # Check if we have the attributes to create the didl metadata:
         for key in ['extended_id', 'title', 'item_class']:
             if not hasattr(self, key):
-                message = 'The property \'{0}\' is not present on this item. '\
+                message = 'The property \'{}\' is not present on this item. '\
                     'This indicates that this item was not meant to create '\
                     'didl_metadata'.format(key)
                 raise DIDLMetadataError(message)
@@ -481,7 +481,7 @@ class MSArtistTracklist(MusicServiceItem):
     def uri(self):
         """Return the URI."""
         # x-rincon-cpcontainer:100f006cartistpopsongsid_1566
-        return 'x-rincon-cpcontainer:100f006c{0}'.format(self.item_id)
+        return 'x-rincon-cpcontainer:100f006c{}'.format(self.item_id)
 
 
 class MSArtist(MusicServiceItem):

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -49,7 +49,7 @@ class Account(object):
         self.key = ''
 
     def __repr__(self):
-        return "<{0} '{1}:{2}:{3}' at {4}>".format(
+        return "<{} '{}:{}:{}' at {}>".format(
             self.__class__.__name__,
             self.serial_number,
             self.service_type,
@@ -77,7 +77,7 @@ class Account(object):
         # This returns an encrypted string, and, so far, we cannot decrypt it
         device = soco or discovery.any_soco()
         log.debug("Fetching account data from %s", device)
-        settings_url = "http://{0}:1400/status/accounts".format(
+        settings_url = "http://{}:1400/status/accounts".format(
             device.ip_address)
         result = requests.get(settings_url).content
         log.debug("Account data: %s", result)

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -216,7 +216,7 @@ class MetadataDictBase(object):
         try:
             return self.metadata[key]
         except KeyError:
-            message = 'Class {0} has no attribute "{1}"'
+            message = 'Class {} has no attribute "{}"'
             raise AttributeError(message.format(self.__class__.__name__, key))
 
 
@@ -268,7 +268,7 @@ class MusicServiceItem(MetadataDictBase):
         # Form the item_id
         quoted_id = quote_url(content_dict['id'].encode('utf-8'))
         # The hex prefix remains a mistery for now
-        item_id = '0fffffff{0}'.format(quoted_id)
+        item_id = '0fffffff{}'.format(quoted_id)
         # Form the uri
         is_track = cls == get_class('MediaMetadataTrack')
         uri = form_uri(item_id, music_service, is_track)
@@ -281,7 +281,7 @@ class MusicServiceItem(MetadataDictBase):
     def __str__(self):
         """Return custom string representation"""
         title = self.metadata.get('title')
-        str_ = '<{0} title="{1}">'
+        str_ = '<{} title="{}">'
         return str_.format(self.__class__.__name__, title)
 
     def to_element(self, include_namespaces=False):

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -68,8 +68,7 @@ from ..compat import quote_url
 
 
 _LOG = logging.getLogger(__name__)
-if not (sys.version_info[0] == 2 and sys.version_info[1] == 6):
-    _LOG.addHandler(logging.NullHandler())
+_LOG.addHandler(logging.NullHandler())
 
 
 # For now we generate classes dynamically. This is shorter, but

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -58,10 +58,7 @@ Class overview:
 from __future__ import print_function, absolute_import
 import sys
 import logging
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
 from ..compat import quote_url

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -606,7 +606,7 @@ class MusicService(object):
         item_id = quote_url(item_id.encode('utf-8'))
         # Add the account info to the end as query params
         account = self.account
-        result = "soco://{0}?sid={1}&sn={2}".format(
+        result = "soco://{}?sid={}&sn={}".format(
             item_id, self.service_id,
             account.serial_number
         )
@@ -619,7 +619,7 @@ class MusicService(object):
         The Sonos descriptor is used as the content of the <desc> tag in
         DIDL metadata, to indicate the relevant music service id and username.
         """
-        desc = "SA_RINCON{0}_{1}".format(
+        desc = "SA_RINCON{}_{}".format(
             self.account.service_type, self.account.username
         )
         return desc
@@ -850,7 +850,7 @@ def desc_from_uri(uri):
         account_serial_number = query_string['sn'][0]
         try:
             account = Account.get_accounts()[account_serial_number]
-            desc = "SA_RINCON{0}_{1}".format(
+            desc = "SA_RINCON{}_{}".format(
                 account.service_type, account.username)
             return desc
         except KeyError:
@@ -867,7 +867,7 @@ def desc_from_uri(uri):
                     break
                 # Use the first account we find
                 account = account[0]
-                desc = "SA_RINCON{0}_{1}".format(
+                desc = "SA_RINCON{}_{}".format(
                     account.service_type, account.username)
                 return desc
     # Nothing found. Default to the standard desc value. Is this the right

--- a/soco/plugins/example.py
+++ b/soco/plugins/example.py
@@ -27,7 +27,7 @@ class ExamplePlugin(SoCoPlugin):
 
     @property
     def name(self):
-        return 'Example Plugin for {0}'.format(self.username)
+        return 'Example Plugin for {}'.format(self.username)
 
     def music_plugin_play(self):
         """Play some music.

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -66,7 +66,7 @@ def _ns_tag(ns_id, tag):
     :param tag: The tag
     :type str: str
     """
-    return '{{{0}}}{1}'.format(NS[ns_id], tag)
+    return '{{{}}}{}'.format(NS[ns_id], tag)
 
 
 def _get_header(soap_action):
@@ -89,7 +89,7 @@ def _get_header(soap_action):
     header = {
         'CONNECTION': 'close',
         'ACCEPT-ENCODING': 'gzip',
-        'ACCEPT-LANGUAGE': '{0}en-US;q=0.9'.format(language),
+        'ACCEPT-LANGUAGE': '{}en-US;q=0.9'.format(language),
         'Content-Type': 'text/xml; charset="utf-8"',
         'SOAPACTION': SOAP_ACTION[soap_action]
     }
@@ -171,7 +171,7 @@ class Wimp(SoCoPlugin):
     @property
     def name(self):
         """Return the human read-able name for the plugin"""
-        return 'Wimp Plugin for {0}'.format(self._username)
+        return 'Wimp Plugin for {}'.format(self._username)
 
     @property
     def username(self):
@@ -187,7 +187,7 @@ class Wimp(SoCoPlugin):
     def description(self):
         """Return the music service description for the DIDL metadata on the
         form ``'SA_RINCON5127_...self.username...'``"""
-        return 'SA_RINCON5127_{0}'.format(self._username)
+        return 'SA_RINCON5127_{}'.format(self._username)
 
     def get_tracks(self, search, start=0, max_items=100):
         """Search for tracks.
@@ -246,11 +246,11 @@ class Wimp(SoCoPlugin):
         """
         # Check input
         if search_type not in ['artists', 'albums', 'tracks', 'playlists']:
-            message = 'The requested search {0} is not valid'\
+            message = 'The requested search {} is not valid'\
                 .format(search_type)
             raise ValueError(message)
         # Transform search: tracks -> tracksearch
-        search_type = '{0}earch'.format(search_type)
+        search_type = '{}earch'.format(search_type)
         parent_id = SEARCH_PREFIX.format(search_type=search_type,
                                          search=search)
 
@@ -492,7 +492,7 @@ class Wimp(SoCoPlugin):
             fault = error_dom.find('.//' + _ns_tag('s', 'Fault'))
             error_description = fault.find('faultstring').text
             error_code = EXCEPTION_STR_TO_CODE[error_description]
-            message = 'UPnP Error {0} received: {1} from {2}'.format(
+            message = 'UPnP Error {} received: {} from {}'.format(
                 error_code, error_description, self._url)
             raise SoCoUPnPException(
                 message=message,

--- a/soco/services.py
+++ b/soco/services.py
@@ -119,14 +119,14 @@ class Service(object):
         self.version = 1
         self.service_id = self.service_type
         #: str: The base URL for sending UPnP Actions.
-        self.base_url = 'http://{0}:1400'.format(self.soco.ip_address)
+        self.base_url = 'http://{}:1400'.format(self.soco.ip_address)
         #: str: The UPnP Control URL.
-        self.control_url = '/{0}/Control'.format(self.service_type)
+        self.control_url = '/{}/Control'.format(self.service_type)
         #: str: The service control protocol description URL.
-        self.scpd_url = '/xml/{0}{1}.xml'.format(
+        self.scpd_url = '/xml/{}{}.xml'.format(
             self.service_type, self.version)
         #: str: The service eventing subscription URL.
-        self.event_subscription_url = '/{0}/Event'.format(self.service_type)
+        self.event_subscription_url = '/{}/Event'.format(self.service_type)
         #: A cache for storing the result of network calls. By default, this is
         #: a `TimedCache` with a default timeout=0.
         self.cache = Cache(default_timeout=0)
@@ -458,7 +458,7 @@ class Service(object):
         if error_code is not None:
             description = self.UPNP_ERRORS.get(int(error_code), '')
             raise SoCoUPnPException(
-                message='UPnP Error {0} received: {1} from {2}'.format(
+                message='UPnP Error {} received: {} from {}'.format(
                     error_code, description, self.soco.ip_address),
                 error_code=error_code,
                 error_description=description,
@@ -547,28 +547,28 @@ class Service(object):
         tree = XML.fromstring(scpd_body)
         # parse the state variables to get the relevant variable types
         vartypes = {}
-        srvStateTables = tree.findall('{0}serviceStateTable'.format(ns))
+        srvStateTables = tree.findall('{}serviceStateTable'.format(ns))
         for srvStateTable in srvStateTables:
-            statevars = srvStateTable.findall('{0}stateVariable'.format(ns))
+            statevars = srvStateTable.findall('{}stateVariable'.format(ns))
             for state in statevars:
-                name = state.findtext('{0}name'.format(ns))
-                vartypes[name] = state.findtext('{0}dataType'.format(ns))
+                name = state.findtext('{}name'.format(ns))
+                vartypes[name] = state.findtext('{}dataType'.format(ns))
         # find all the actions
-        actionLists = tree.findall('{0}actionList'.format(ns))
+        actionLists = tree.findall('{}actionList'.format(ns))
         for actionList in actionLists:
-            actions = actionList.findall('{0}action'.format(ns))
+            actions = actionList.findall('{}action'.format(ns))
             for i in actions:
-                action_name = i.findtext('{0}name'.format(ns))
-                argLists = i.findall('{0}argumentList'.format(ns))
+                action_name = i.findtext('{}name'.format(ns))
+                argLists = i.findall('{}argumentList'.format(ns))
                 for argList in argLists:
-                    args_iter = argList.findall('{0}argument'.format(ns))
+                    args_iter = argList.findall('{}argument'.format(ns))
                     in_args = []
                     out_args = []
                     for arg in args_iter:
-                        arg_name = arg.findtext('{0}name'.format(ns))
-                        direction = arg.findtext('{0}direction'.format(ns))
+                        arg_name = arg.findtext('{}name'.format(ns))
+                        direction = arg.findtext('{}direction'.format(ns))
                         related_variable = arg.findtext(
-                            '{0}relatedStateVariable'.format(ns))
+                            '{}relatedStateVariable'.format(ns))
                         vartype = vartypes[related_variable]
                         if direction == "in":
                             in_args.append(Argument(arg_name, vartype))
@@ -588,13 +588,13 @@ class Service(object):
         scpd_body = requests.get(self.base_url + self.scpd_url).text
         tree = XML.fromstring(scpd_body.encode('utf-8'))
         # parse the state variables to get the relevant variable types
-        statevars = tree.findall('{0}stateVariable'.format(ns))
+        statevars = tree.findall('{}stateVariable'.format(ns))
         for state in statevars:
             # We are only interested if 'sendEvents' is 'yes', i.e this
             # is an eventable variable
             if state.attrib['sendEvents'] == "yes":
-                name = state.findtext('{0}name'.format(ns))
-                vartype = state.findtext('{0}dataType'.format(ns))
+                name = state.findtext('{}name'.format(ns))
+                vartype = state.findtext('{}dataType'.format(ns))
                 yield (name, vartype)
 
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -45,7 +45,7 @@ from .exceptions import (
     SoCoUPnPException, UnknownSoCoException
 )
 from .utils import prettify
-from .xml import XML, illegal_xml_re, PARSEERROR
+from .xml import XML, illegal_xml_re
 
 # UNICODE NOTE
 # UPnP requires all XML to be transmitted/received with utf-8 encoding. All
@@ -268,13 +268,9 @@ class Service(object):
         xml_response = xml_response.encode('utf-8')
         try:
             tree = XML.fromstring(xml_response)
-        except PARSEERROR:
+        except XML.ParseError:
             # Try to filter illegal xml chars (as unicode), in case that is
             # the reason for the parse error
-            # NOTE: The PARSERROR used here is a Python 2.6 compat trick in
-            # our xml module. If we ever drop support for Python 2.6 it should
-            # be replaced with a simple XML.ParseError and the hack in .xml
-            # removed
             filtered = illegal_xml_re.sub('', xml_response.decode('utf-8'))\
                                      .encode('utf-8')
             tree = XML.fromstring(filtered)

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -63,7 +63,7 @@ class SoapFault(SoCoException):
         return '%s: %s' % (self.faultcode, self.faultstring)
 
     def __repr__(self):
-        return "SoapFault(faultcode={0}, faultstring={1}, detail={2})".format(
+        return "SoapFault(faultcode={}, faultstring={}, detail={})".format(
             repr(self.faultcode),
             repr(self.faultstring),
             repr(self.detail)
@@ -157,7 +157,7 @@ class SoapMessage(object):
 
         headers = {'Content-Type': 'text/xml; charset="utf-8"'}
         if soap_action is not None:
-            headers.update({'SOAPACTION': '"{0}"'.format(soap_action)})
+            headers.update({'SOAPACTION': '"{}"'.format(soap_action)})
         if http_headers is not None:
             headers.update(http_headers)
         return headers
@@ -176,7 +176,7 @@ class SoapMessage(object):
         """
 
         if soap_header is not None:
-            return '<s:Header>{0}</s:Header>'.format(soap_header)
+            return '<s:Header>{}</s:Header>'.format(soap_header)
         else:
             return ''
 

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -149,23 +149,23 @@ class deprecated(object):
         @functools.wraps(deprecated_fn)
         def decorated(*args, **kwargs):
 
-            message = "Call to deprecated function {0}.".format(
+            message = "Call to deprecated function {}.".format(
                 deprecated_fn.__name__)
             if self.will_be_removed_in is not None:
-                message += " Will be removed in version {0}.".format(
+                message += " Will be removed in version {}.".format(
                     self.will_be_removed_in)
             if self.alternative is not None:
-                message += " Use {0} instead.".format(self.alternative)
+                message += " Use {} instead.".format(self.alternative)
             warnings.warn(message, stacklevel=2)
 
             return deprecated_fn(*args, **kwargs)
 
-        docs = "\n\n  .. deprecated:: {0}\n".format(self.since_version)
+        docs = "\n\n  .. deprecated:: {}\n".format(self.since_version)
         if self.will_be_removed_in is not None:
-            docs += "\n     Will be removed in version {0}.".format(
+            docs += "\n     Will be removed in version {}.".format(
                 self.will_be_removed_in)
         if self.alternative is not None:
-            docs += "\n     Use `{0}` instead.".format(self.alternative)
+            docs += "\n     Use `{}` instead.".format(self.alternative)
         if decorated.__doc__ is None:
             decorated.__doc__ = ''
         decorated.__doc__ += docs

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -10,10 +10,7 @@ from __future__ import (
 import sys
 import re
 
-try:
-    import xml.etree.cElementTree as XML
-except ImportError:
-    import xml.etree.ElementTree as XML
+import xml.etree.ElementTree as XML
 
 
 # Create regular expression for filtering invalid characters, from:

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -72,4 +72,4 @@ def ns_tag(ns_id, tag):
         >>> xml.ns_tag('dc','author')
         '{http://purl.org/dc/elements/1.1/}author'
     """
-    return '{{{0}}}{1}'.format(NAMESPACES[ns_id], tag)
+    return '{{{}}}{}'.format(NAMESPACES[ns_id], tag)

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -15,17 +15,6 @@ try:
 except ImportError:
     import xml.etree.ElementTree as XML
 
-# This is a Python 2.6 compatbility hack. Pre 2.7 ElementTree raised
-# SyntaxError !!! if it encountered invalid chars in the XML, which is what
-# this exception is used for. It is only used one place in services. If we ever
-# drop support for Python 2.6 this should be removed
-try:
-    PARSEERROR = XML.ParseError
-except AttributeError:
-    # .ParseError did not exist pre 2.7;
-    # https://github.com/s3tools/s3cmd/issues/424
-    PARSEERROR = SyntaxError
-
 
 # Create regular expression for filtering invalid characters, from:
 # http://stackoverflow.com/questions/1707890/
@@ -63,19 +52,8 @@ NAMESPACES = {
 
 # Register common namespaces to assist in serialisation (avoids the ns:0
 # prefixes in XML output )
-try:
-    register_namespace = XML.register_namespace
-except AttributeError:
-    # Python 2.6: see http://effbot.org/zone/element-namespaces.htm
-    import xml.etree.ElementTree as XML2
-
-    def register_namespace(a_prefix, a_uri):
-        """Registers a namespace prefix to assist in serialization."""
-        # pylint: disable=protected-access
-        XML2._namespace_map[a_uri] = a_prefix
-
 for prefix, uri in NAMESPACES.items():
-    register_namespace(prefix, uri)
+    XML.register_namespace(prefix, uri)
 
 
 def ns_tag(ns_id, tag):

--- a/tests/soco_unittest.py
+++ b/tests/soco_unittest.py
@@ -81,7 +81,7 @@ def wait(interval=0.1):
 # Test return strings that are used a lot
 NOT_TRUE = 'The method did not return True'
 NOT_EXP = 'The method did not return the expected value'
-NOT_TYPE = 'The return value of the method did not have the expected type: {0}'
+NOT_TYPE = 'The return value of the method did not have the expected type: {}'
 NOT_IN_RANGE = 'The returned value is not in the expected range'
 
 
@@ -278,7 +278,7 @@ class GetQueue(unittest.TestCase):
                                   'Item in queue is not a dictionary')
             self.assertEqual(sorted(item.keys()), self.qeueu_element_keys,
                              'The keys in the queue element dict are not the '
-                             'expected ones: {0}'.
+                             'expected ones: {}'.
                              format(self.qeueu_element_keys))
 
 
@@ -303,9 +303,9 @@ class GetCurrentTransportInfo(unittest.TestCase):
         self.assertEqual(self.transport_info_keys,
                          sorted(transport_info.keys()),
                          'The keys in the speaker info dict are not the '
-                         'expected ones: {0}'.format(self.transport_info_keys))
+                         'expected ones: {}'.format(self.transport_info_keys))
         for key, value in transport_info.items():
-            self.assertIsNotNone(value, 'The value for the key "{0}" is None '
+            self.assertIsNotNone(value, 'The value for the key "{}" is None '
                                  'which indicate that no value was found for '
                                  'it'.format(key))
 
@@ -331,10 +331,10 @@ class GetSpeakerInfo(unittest.TestCase):
         speaker_info = SOCO.get_speaker_info()
         self.assertIsInstance(speaker_info, dict, NOT_TYPE.format('dict'))
         self.assertEqual(self.info_keys, sorted(speaker_info.keys()), 'The '
-                         'keys in speaker info are not the expected ones: {0}'
+                         'keys in speaker info are not the expected ones: {}'
                          ''.format(self.info_keys))
         for key, value in speaker_info.items():
-            self.assertIsNotNone(value, 'The value for the key "{0}" is None '
+            self.assertIsNotNone(value, 'The value for the key "{}" is None '
                                  'which indicate that no value was found for '
                                  'it'.format(key))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,7 +27,7 @@ def moco():
     services = (
         'AVTransport', 'RenderingControl', 'DeviceProperties',
         'ContentDirectory', 'ZoneGroupTopology')
-    patchers = [mock.patch('soco.core.{0}'.format(service))
+    patchers = [mock.patch('soco.core.{}'.format(service))
                 for service in services]
     for patch in patchers:
         patch.start()
@@ -49,7 +49,7 @@ def moco_only_on_master():
     services = (
         'AVTransport', 'RenderingControl', 'DeviceProperties',
         'ContentDirectory', 'ZoneGroupTopology')
-    patchers = [mock.patch('soco.core.{0}'.format(service))
+    patchers = [mock.patch('soco.core.{}'.format(service))
                 for service in services]
     for patch in patchers:
         patch.start()
@@ -199,10 +199,10 @@ class TestSoco:
         assert moco.speaker_info == {}
 
     def test_soco_str(self, moco):
-        assert str(moco) == "<SoCo object at ip {0}>".format(IP_ADDR)
+        assert str(moco) == "<SoCo object at ip {}>".format(IP_ADDR)
 
     def test_soco_repr(self, moco):
-        assert repr(moco) == 'SoCo("{0}")'.format(IP_ADDR)
+        assert repr(moco) == 'SoCo("{}")'.format(IP_ADDR)
 
     @mock.patch("soco.core.requests")
     @pytest.mark.parametrize('refresh', [None, False, True])
@@ -597,7 +597,7 @@ class TestAVTransport:
         playlist_name = "cool music"
         playlist_id = 1
         moco.avTransport.CreateSavedQueue.return_value = {
-            'AssignedObjectID': 'SQ:{0}'.format(playlist_id)
+            'AssignedObjectID': 'SQ:{}'.format(playlist_id)
         }
         playlist = moco.create_sonos_playlist(playlist_name)
         moco.avTransport.CreateSavedQueue.assert_called_once_with(
@@ -607,7 +607,7 @@ class TestAVTransport:
              ('EnqueuedURIMetaData', '')]
         )
         assert playlist.title == playlist_name
-        expected_uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(
+        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(
             playlist_id)
         assert playlist.resources[0].uri == expected_uri
         assert playlist.parent_id == "SQ:"
@@ -616,7 +616,7 @@ class TestAVTransport:
         playlist_name = "saved queue"
         playlist_id = 1
         moco.avTransport.SaveQueue.return_value = {
-            'AssignedObjectID': 'SQ:{0}'.format(playlist_id)
+            'AssignedObjectID': 'SQ:{}'.format(playlist_id)
         }
         playlist = moco.create_sonos_playlist_from_queue(playlist_name)
         moco.avTransport.SaveQueue.assert_called_once_with(
@@ -625,7 +625,7 @@ class TestAVTransport:
              ('ObjectID', '')]
         )
         assert playlist.title == playlist_name
-        expected_uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(
+        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(
             playlist_id)
         assert playlist.resources[0].uri == expected_uri
         assert playlist.parent_id == "SQ:"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -403,14 +403,13 @@ class TestSonosPlaylist(object):
 
     def test_create(self, soco):
         """Test creating a new empty Sonos playlist."""
-        existing_playlists = set([x.item_id
-                                  for x in soco.get_sonos_playlists()])
+        existing_playlists = {x.item_id for x in soco.get_sonos_playlists()}
         new_playlist = soco.create_sonos_playlist(title=self.playlist_name)
         assert type(new_playlist) is DidlPlaylistContainer
 
-        new_pl = set([x.item_id for x in soco.get_sonos_playlists()])
+        new_pl = {x.item_id for x in soco.get_sonos_playlists()}
         assert new_pl != existing_playlists
-        assert new_pl - existing_playlists == set([new_playlist.item_id])
+        assert new_pl - existing_playlists == {new_playlist.item_id}
 
     def test_create_from_queue(self, soco):
         """Test creating a Sonos playlist from the current queue."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -452,7 +452,7 @@ class TestSonosPlaylist(object):
         hpl_i = max([int(x.item_id.split(':')[1])
                      for x in soco.get_sonos_playlists()])
         with pytest.raises(SoCoUPnPException):
-            soco.remove_sonos_playlist('SQ:{0}'.format(hpl_i + 1))
+            soco.remove_sonos_playlist('SQ:{}'.format(hpl_i + 1))
 
 
 class TestTimer(object):

--- a/tests/test_ms_data_structures.py
+++ b/tests/test_ms_data_structures.py
@@ -186,7 +186,7 @@ class FakeMusicService(object):
     """A fake music service."""
 
     def __init__(self, username):
-        self.description = 'SA_RINCON5127_{0}'.format(username)
+        self.description = 'SA_RINCON5127_{}'.format(username)
         self.service_id = 20
 
     @staticmethod

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -4,10 +4,7 @@
 
 from __future__ import unicode_literals, print_function
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import pytest
 from mock import PropertyMock, Mock, patch
 from soco.music_services import data_structures

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -248,7 +248,7 @@ def test_get_names():
 def test_get_subscribed_names():
     names = MusicService.get_subscribed_services_names()
     assert len(names) == 4
-    assert set(names) == set(['TuneIn', 'Spotify', 'Spreaker', 'radioPup'])
+    assert set(names) == {'TuneIn', 'Spotify', 'Spreaker', 'radioPup'}
 
 
 def test_create_music_service():
@@ -281,7 +281,7 @@ def test_search():
     }
     categories = spotify.available_search_categories
     assert len(categories) == 3
-    assert set(categories) == set(['stations', 'shows', 'hosts'])
+    assert set(categories) == {'stations', 'shows', 'hosts'}
     with pytest.raises(MusicServiceException) as excinfo:
         spotify.search('badcategory')
     assert "support the 'badcategory' search category" in str(excinfo.value)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -99,7 +99,7 @@ def test_method_dispatcher_function_creation(service):
     assert 'testing' in service.__dict__.keys()
     assert service.testing.__name__ == "testing"
     # check that send_command is actually called when we invoke a method
-    service.send_command = lambda x, y: "Hello {0}".format(x)
+    service.send_command = lambda x, y: "Hello {}".format(x)
     assert service.testing(service) == "Hello testing"
 
 

--- a/tests/test_soap.py
+++ b/tests/test_soap.py
@@ -7,8 +7,10 @@ from soco.soap import SoapMessage
 from soco.xml import XML
 
 try:
+    # New in Python 3.3
     from unittest import mock
 except ImportError:
+    # Python 2.7
     import mock
 
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -7,10 +7,6 @@ from __future__ import unicode_literals
 from soco import xml
 
 
-def test_register_namespace():
-    assert xml.register_namespace
-
-
 def test_ns_tag():
     """Test the ns_tag function."""
     namespaces = ['http://purl.org/dc/elements/1.1/',

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -14,5 +14,5 @@ def test_ns_tag():
                   'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/']
     for ns_in, namespace in zip(['dc', 'upnp', ''], namespaces):
         res = xml.ns_tag(ns_in, 'testtag')
-        correct = '{{{0}}}{1}'.format(namespace, 'testtag')
+        correct = '{{{}}}{}'.format(namespace, 'testtag')
         assert res == correct


### PR DESCRIPTION
Fixes #325.

Split out from PR https://github.com/SoCo/SoCo/pull/523 ("Drop support for EOL Python 2.6 & 3.3, add support for 3.6") to allow more granular decision making.