### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "pypy"

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Visit the `SoCo documentation`_ for a more detailed overview of all the function
 Installation
 ------------
 
-SoCo requires Python 2.7, or 3.3 or newer.
+SoCo requires Python 2.7, or 3.4 or newer.
 
 Use pip:
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Home Automation',


### PR DESCRIPTION
Fixes #525.

Split out from PR https://github.com/SoCo/SoCo/pull/523 ("Drop support for EOL Python 2.6 & 3.3, add support for 3.6") to allow more granular decision making.

Note: README.rst changes assumes #526 ("Drop support for Python 2.6") will be merged to prevent merge conflicts.