### PR TITLE
Add support for Python 3.6 and dev branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ python:
   - "3.7-dev"
   - "nightly"
 
+matrix:
+  allow_failures:
+    - python: "3.7-dev"
+    - python: "nightly"
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
 python:
   - "pypy" # Run slowest first so as not to hold up the build
+  - "pypy3"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.5-dev"
+  - "3.6-dev"
+  - "3.7-dev"
+  - "nightly"
 
 cache:
   directories:

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Home Automation',


### PR DESCRIPTION
Split out from PR https://github.com/SoCo/SoCo/pull/523 ("Drop support for EOL Python 2.6 & 3.3, add support for 3.6") to allow more granular decision making.