### PR TITLE
Prevent error when queue started from Alexa

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -97,8 +97,8 @@ class Snapshot(object):
         if self.media_uri.split(':')[0] != 'x-rincon':
             self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':
-            if self.media_uri.split('#')[1] \
-                    == '0':  # pylint: disable=simplifiable-if-statement
+            # pylint: disable=simplifiable-if-statement
+            if self.media_uri.split('#')[1] == '0':
                 # playing local queue
                 self.is_playing_queue = True
             else:

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -93,7 +93,16 @@ class Snapshot(object):
         media_info = self.device.avTransport.GetMediaInfo([('InstanceID', 0)])
         self.media_uri = media_info['CurrentURI']
 
-        # extract source from media uri
+        # Extract source from media uri - below some media URI value examples:
+        #  'x-rincon-queue:RINCON_000E5859E49601400#0'
+        #       - playing a local queue always #0 for local queue)
+        #
+        #  'x-rincon-queue:RINCON_000E5859E49601400#6'
+        #       - playing a cloud queue where #x changes with each queue)
+        #
+        #  -'x-rincon:RINCON_000E5859E49601400'
+        #       - a slave player pointing to coordinator player
+
         if self.media_uri.split(':')[0] != 'x-rincon':
             self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -7,6 +7,12 @@ This is useful for scenarios such as when you want to switch to radio
 or an announcement and then back again to what was playing previously.
 
 Warning:
+    Sonos has introduced control via Amazon Alexa. A new cloud queue is
+    created and at present there appears no way to restart this
+    queue from snapshot. Currently if a cloud queue was playing it will
+    not restart.
+
+Warning:
     This class is designed to be created used and destroyed. It is not
     designed to be reused or long lived. The init sets up defaults for
     one use.
@@ -50,6 +56,7 @@ class Snapshot(object):
         self.media_uri = None
         self.is_coordinator = False
         self.is_playing_queue = False
+        self.is_playing_cloud_queue = False
 
         self.volume = None
         self.mute = None
@@ -90,7 +97,12 @@ class Snapshot(object):
         if self.media_uri.split(':')[0] != 'x-rincon':
             self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':
-            self.is_playing_queue = True
+            if self.media_uri.split('#')[1] == '0':
+                # playing local queue
+                self.is_playing_queue = True
+            else:
+                # playing cloud queue - started from Alexa
+                self.is_playing_cloud_queue = True
 
         # Save the volume, mute and other sound settings
         self.volume = self.device.volume
@@ -176,6 +188,12 @@ class Snapshot(object):
                 # Need to make sure there is a proper track selected first
                 self.device.play_mode = self.play_mode
                 self.device.cross_fade = self.cross_fade
+
+            elif self.is_playing_cloud_queue:
+                # was playing a cloud queue started by Alexa
+                # No way found yet to re-start this so prevent it throwing an error!
+                pass
+
             else:
                 # was playing a stream (radio station, file, or nothing)
                 # reinstate uri and meta data

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -97,7 +97,7 @@ class Snapshot(object):
         if self.media_uri.split(':')[0] != 'x-rincon':
             self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':
-            if self.media_uri.split('#')[1] == '0':
+            if self.media_uri.split('#')[1] == '0':  # pylint: disable=simplifiable-if-statement
                 # playing local queue
                 self.is_playing_queue = True
             else:
@@ -172,7 +172,6 @@ class Snapshot(object):
                 # was playing from playlist
 
                 if self.playlist_position is not None:
-
                     # The position in the playlist returned by
                     # get_current_track_info starts at 1, but when
                     # playing from playlist, the index starts at 0

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -88,7 +88,10 @@ class Snapshot(object):
             bool: `True` if the device is a coordinator, `False` otherwise.
                 Useful for determining whether playing an alert on a device
                 will ungroup it.
-        """
+         """
+        # get if device coordinator (or slave) True (or False)
+        self.is_coordinator = self.device.is_coordinator
+
         # Get information about the currently playing media
         media_info = self.device.avTransport.GetMediaInfo([('InstanceID', 0)])
         self.media_uri = media_info['CurrentURI']
@@ -103,8 +106,6 @@ class Snapshot(object):
         #  -'x-rincon:RINCON_000E5859E49601400'
         #       - a slave player pointing to coordinator player
 
-        if self.media_uri.split(':')[0] != 'x-rincon':
-            self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':
             # pylint: disable=simplifiable-if-statement
             if self.media_uri.split('#')[1] == '0':

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -97,7 +97,8 @@ class Snapshot(object):
         if self.media_uri.split(':')[0] != 'x-rincon':
             self.is_coordinator = True
         if self.media_uri.split(':')[0] == 'x-rincon-queue':
-            if self.media_uri.split('#')[1] == '0':  # pylint: disable=simplifiable-if-statement
+            if self.media_uri.split('#')[1] \
+                    == '0':  # pylint: disable=simplifiable-if-statement
                 # playing local queue
                 self.is_playing_queue = True
             else:

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -88,7 +88,7 @@ class Snapshot(object):
             bool: `True` if the device is a coordinator, `False` otherwise.
                 Useful for determining whether playing an alert on a device
                 will ungroup it.
-         """
+        """
         # get if device coordinator (or slave) True (or False)
         self.is_coordinator = self.device.is_coordinator
 

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -191,7 +191,7 @@ class Snapshot(object):
 
             elif self.is_playing_cloud_queue:
                 # was playing a cloud queue started by Alexa
-                # No way found yet to re-start this so prevent it throwing an error!
+                # No way yet to re-start this so prevent it throwing an error!
                 pass
 
             else:


### PR DESCRIPTION
Sonos can now be controlled by Amazon Alexa, which creates 'cloud queues'. 
However, when playing a cloud queue started by Alexa, there is no was to restart that queue from SoCo.
This PR prevents the error, by not restarting cloud queues #521 
This will hopefully reduce support queries.

Over time I trust we can find a way to make this work. 
Have written to Sonos about it, but got their typical response of not a supported function!

Cheers David
