### PR TITLE
Alexa support

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -194,9 +194,14 @@ class DidlResource(object):
         content = {}
         # required
         content['protocol_info'] = element.get('protocolInfo')
-        if content['protocol_info'] is None:
-            raise Exception('Could not create Resource from Element: '
-                            'protocolInfo not found (required).')
+        
+        # With the Alexa update, the 'protocolInfo' tag does not appear on data containers where it 
+        # possibly should and probably did in the past.  This execption should be ignored with the new formats.
+          
+        #if content['protocol_info'] is None:
+        #    raise Exception('Could not create Resource from Element: '
+        #                    'protocolInfo not found (required).')
+        
         # Optional
         content['import_uri'] = element.get('importUri')
         content['size'] = _int_helper('size')

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -488,8 +488,11 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         if parent_id is None:
             raise DIDLMetadataError("Missing parentID attribute")
         restricted = element.get('restricted', None)
-        if restricted is None:
-            raise DIDLMetadataError("Missing restricted attribute")
+        
+        # The Alexa update changed the metadata so that restricted is not always
+        # added to objects you want, and is added to objects you don't want.
+        #if restricted is None:
+        #    raise DIDLMetadataError("Missing restricted attribute")
         restricted = True if restricted in [1, 'true', 'True'] else False
 
         # There must be a title. According to spec, it should be the first

--- a/soco/events.py
+++ b/soco/events.py
@@ -126,8 +126,13 @@ def parse_event_xml(xml_event):
                         value = last_change_var.text
                     # If DIDL metadata is returned, convert it to a music
                     # library data structure
-                    if value.startswith('<DIDL-Lite'):
+                    
+                    # The Alexa updates changed the content of certain tags and they need
+                    # to be ignored for now to prevent continuous exceptions
+                    # This should be improved when there is deeper Soco/Alexa integration needed
+                    if value.startswith('<DIDL-Lite') and tag!='av_transport_uri_meta_data': 
                         value = from_didl_string(value)[0]
+                        
                     channel = last_change_var.get('channel')
                     if channel is not None:
                         if result.get(tag) is None:


### PR DESCRIPTION
The Alexa update added new metadata components and changed the use of several previously mandatory fields.

These new formats seem to only be used when an Alexa request for music has been placed.  Music queued through the apps or through the API like Soco retains the old format.

These changes are used to prevent exceptions on those fields which kill subscription threads.