### PR TITLE
Remove the methods that were deprecated in 0.12

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -33,7 +33,7 @@ from .services import (
     zone_group_state_shared_cache,
 )
 from .utils import (
-    really_utf8, camel_to_underscore, deprecated
+    really_utf8, camel_to_underscore
 )
 from .xml import XML
 
@@ -1801,115 +1801,6 @@ class SoCo(_SocoSingletonBase):
                     int(times[2]))
         else:
             return None
-
-    # Deprecated methods - moved to music_library.py
-    # pylint: disable=missing-docstring, too-many-arguments
-    @deprecated('0.12', "soco.music_library.get_artists", '0.14')
-    def get_artists(self, *args, **kwargs):
-        return self.music_library.get_artists(*args, **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_album_artists", '0.14')
-    def get_album_artists(self, *args, **kwargs):
-        return self.music_library.get_album_artists(*args, **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_music_library_information",
-                '0.14')
-    def get_albums(self, *args, **kwargs):
-        return self.music_library.get_music_library_information(*args,
-                                                                **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_music_library_information",
-                '0.14')
-    def get_genres(self, *args, **kwargs):
-        return self.music_library.get_music_library_information(*args,
-                                                                **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_composers", '0.14')
-    def get_composers(self, *args, **kwargs):
-        return self.music_library.get_music_library_information(*args,
-                                                                **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_tracks", '0.14')
-    def get_tracks(self, *args, **kwargs):
-        return self.music_library.get_tracks(*args, **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_playlists", '0.14')
-    def get_playlists(self, *args, **kwargs):
-        return self.music_library.get_music_library_information(*args,
-                                                                **kwargs)
-
-    @deprecated('0.12', "soco.music_library.get_music_library_information",
-                '0.14')
-    def get_music_library_information(self, search_type, start=0,
-                                      max_items=100, full_album_art_uri=False,
-                                      search_term=None, subcategories=None,
-                                      complete_result=False):
-        return self.music_library.get_music_library_information(
-            search_type,
-            start,
-            max_items,
-            full_album_art_uri,
-            search_term,
-            subcategories,
-            complete_result
-        )
-
-    @deprecated('0.12', "soco.music_library.browse", '0.14')
-    def browse(self, ml_item=None, start=0, max_items=100,
-               full_album_art_uri=False, search_term=None, subcategories=None):
-        return self.music_library.browse(ml_item, start, max_items,
-                                         full_album_art_uri, search_term,
-                                         subcategories)
-
-    @deprecated('0.12', "soco.music_library.browse_by_idstring", '0.14')
-    def browse_by_idstring(self, search_type, idstring, start=0,
-                           max_items=100, full_album_art_uri=False):
-        return self.music_library.browse_by_idstring(search_type, idstring,
-                                                     start,
-                                                     max_items,
-                                                     full_album_art_uri)
-
-    @property
-    @deprecated('0.12', "soco.music_library.library_updating", '0.14')
-    def library_updating(self):
-        """.."""
-        return self.music_library.library_updating
-
-    @deprecated('0.12', "soco.music_library.start_library_update", '0.14')
-    def start_library_update(self, album_artist_display_option=''):
-        return self.music_library.start_library_update(
-            album_artist_display_option)
-
-    @deprecated('0.12', "soco.music_library.search_track", '0.14')
-    def search_track(self, artist, album=None, track=None,
-                     full_album_art_uri=False):
-        return self.music_library.search_track(
-            artist, album, track, full_album_art_uri
-        )
-
-    @deprecated('0.12', "soco.music_library.get_albums_for_artist", '0.14')
-    def get_albums_for_artist(self, artist, full_album_art_uri=False):
-        return self.music_library.get_albums_for_artist(
-            artist, full_album_art_uri
-        )
-
-    @deprecated('0.12', "soco.music_library.get_tracks_for_album", '0.14')
-    def get_tracks_for_album(self, artist, album, full_album_art_uri=False):
-        return self.music_library.get_tracks_for_album(
-            artist, album, full_album_art_uri
-        )
-
-    @property
-    @deprecated('0.12', "soco.music_library.album_artist_display", '0.14')
-    def album_artist_display_option(self):
-        """.."""
-        return self.music_library.album_artist_display_option
-
-    def _build_album_art_full_uri(self, url):
-        return self.music_library._build_album_art_full_uri(url)
-
-    def _music_lib_search(self, search, start, max_items):
-        return self.music_library._music_lib_search(search, start, max_items)
 
     @only_on_master
     def reorder_sonos_playlist(self, sonos_playlist, tracks, new_pos,

--- a/soco/core.py
+++ b/soco/core.py
@@ -33,7 +33,7 @@ from .services import (
     zone_group_state_shared_cache,
 )
 from .utils import (
-    really_utf8, camel_to_underscore
+    really_utf8, camel_to_underscore, deprecated
 )
 from .xml import XML
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -682,128 +682,6 @@ class TestAVTransport:
             [('InstanceID', 0), ('CrossfadeMode', '0')]
         )
 
-    def test_soco_get_item_album_art_uri(self, moco):
-        uri = 'x-file-cifs://dummy_uri'
-        title = 'fake-title'
-        parent_id = 'A:TRACKS'
-        item_id = 'fake-id'
-        kwargs = {'album': 'fake-album',
-                  'album_art_uri': '/getaa?r=1&u=track.mp3',
-                  'creator': 'fake-artist',
-                  'original_track_number': 47}
-        content = {'uri': uri, 'title': title, 'parent_id': parent_id}
-        content.update(kwargs)
-        track = DidlMusicTrack(uri, title, parent_id, item_id, **kwargs)
-        full_uri = moco.get_item_album_art_uri(track)
-        assert full_uri == "http://192.168.1.101:1400/getaa?r=1&u=track.mp3"
-
-    def test_search_track_no_result(self, moco):
-        moco.contentDirectory.reset_mock()
-        # Browse returns an exception if the artist can't be found
-        # <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>701</errorCode></UPnPError></detail></s:Fault></s:Body></s:Envelope>
-        moco.contentDirectory.Browse.side_effect = SoCoUPnPException(
-            "No such object", "701", "error XML")
-
-        result = moco.search_track("artist")
-
-        assert len(result) == 0
-
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/artist/'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
-
-    def test_search_track_no_artist_album_track(self, moco):
-        moco.contentDirectory.reset_mock()
-        # Browse returns an empty result set if artist and album and
-        # track cannot be found
-        moco.contentDirectory.Browse.side_effect = None
-        moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '0',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
-            'TotalMatches': '0',
-            'UpdateID': '0'
-        }
-
-        result = moco.search_track("artist", "album", "track")
-
-        assert len(result) == 0
-
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/artist/album:track'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
-
-    def test_search_track_artist_albums(self, moco):
-        moco.contentDirectory.reset_mock()
-        moco.contentDirectory.Browse.side_effect = None
-        moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '2',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/"><container id="A:ALBUMARTIST/The%20Artist/First%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>First Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/First%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container><container id="A:ALBUMARTIST/The%20Artist/Second%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>Second Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container></DIDL-Lite>',
-            'TotalMatches': '2',
-            'UpdateID': '0'
-        }
-        results = moco.search_track("The Artist")
-
-        assert results.number_returned == 2
-
-        album = results[0]
-        assert album.title == 'First Album'
-        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/First%20Album'
-        album = results[1]
-        assert album.title == 'Second Album'
-        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/Second%20Album'
-
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
-
-    def test_search_track_artist_album_tracks(self, moco):
-        moco.contentDirectory.reset_mock()
-        moco.contentDirectory.Browse.side_effect = None
-        moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '3',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 1</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>3</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a&amp;v=432</ns1:albumArtURI><dc:title>Track Title 2</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>4</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 3</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>5</ns1:originalTrackNumber></item></DIDL-Lite>',
-            'TotalMatches': '3',
-            'UpdateID': '0'
-        }
-
-        results = moco.search_track("The Artist", "The Album")
-
-        assert len(results) == 3
-
-        track = results[0]
-        assert track.title == 'Track Title 1'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3'
-        track = results[1]
-        assert track.title == 'Track Title 2'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a'
-        track = results[2]
-        assert track.title == 'Track Title 3'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3'
-
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/The%20Album'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
-
     def test_set_sleep_timer(self, moco):
         moco.avTransport.reset_mock()
         moco.avTransport.ConfigureSleepTimer.return_value = None
@@ -854,23 +732,8 @@ class TestAVTransport:
         result = moco.get_sleep_timer()
         assert result == None
 
+
 class TestContentDirectory:
-
-    def test_soco_library_updating(self, moco):
-        moco.contentDirectory.GetShareIndexInProgress.return_value = {
-            'IsIndexing': '0'}
-        assert not moco.library_updating
-        moco.contentDirectory.reset_mock()
-        moco.contentDirectory.GetShareIndexInProgress.return_value = {
-            'IsIndexing': '1'}
-        assert moco.library_updating
-
-    def test_soco_start_library_update(self, moco):
-        moco.contentDirectory.RefreshShareIndex.return_value = True
-        assert moco.start_library_update()
-        moco.contentDirectory.RefreshShareIndex.assert_called_with([
-            ('AlbumArtistDisplayOption', ''),
-        ])
 
     def test_remove_sonos_playlist_success(self, moco):
         moco.contentDirectory.reset_mock()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -416,7 +416,7 @@ class TestSonosPlaylist(object):
         playlist = soco.create_sonos_playlist_from_queue(self.playlist_name)
         assert type(playlist) is DidlPlaylistContainer
 
-        prslt = soco.browse(ml_item=playlist)
+        prslt = soco.music_library.browse(ml_item=playlist)
         qrslt = soco.get_queue()
         assert len(prslt) == len(qrslt)
         assert prslt.total_matches == qrslt.total_matches

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -1,7 +1,35 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
+import mock
+import pytest
+
+from soco import SoCo
 from soco.exceptions import SoCoUPnPException
-from tests.test_core import moco
+
+IP_ADDR = '192.168.1.101'
+
+
+@pytest.yield_fixture()
+def moco():
+    """A mock soco with fake services and hardcoded is_coordinator.
+
+    Allows calls to services to be tracked. Should not cause any network
+    access
+    """
+    services = (
+        'AVTransport', 'RenderingControl', 'DeviceProperties',
+        'ContentDirectory', 'ZoneGroupTopology')
+    patchers = [mock.patch('soco.core.{}'.format(service))
+                for service in services]
+    for patch in patchers:
+        patch.start()
+    with mock.patch("soco.SoCo.is_coordinator",
+                    new_callable=mock.PropertyMock) as is_coord:
+        is_coord = True
+        yield SoCo(IP_ADDR)
+    for patch in reversed(patchers):
+        patch.stop()
 
 
 class TestMusicLibrary:

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+from soco.exceptions import SoCoUPnPException
+from tests.test_core import moco
+
+
+class TestMusicLibrary:
+
+    def test_search_track_no_result(self, moco):
+        moco.contentDirectory.reset_mock()
+        # Browse returns an exception if the artist can't be found
+        # <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>701</errorCode></UPnPError></detail></s:Fault></s:Body></s:Envelope>
+        moco.contentDirectory.Browse.side_effect = SoCoUPnPException(
+            "No such object", "701", "error XML")
+
+        result = moco.music_library.search_track("artist")
+
+        assert len(result) == 0
+
+        moco.contentDirectory.Browse.assert_called_once_with([
+            ('ObjectID', 'A:ALBUMARTIST/artist/'),
+            ('BrowseFlag', 'BrowseDirectChildren'),
+            ('Filter', '*'),
+            ('StartingIndex', 0),
+            ('RequestedCount', 100000),
+            ('SortCriteria', '')
+        ])
+
+    def test_search_track_no_artist_album_track(self, moco):
+        moco.contentDirectory.reset_mock()
+        # Browse returns an empty result set if artist and album and
+        # track cannot be found
+        moco.contentDirectory.Browse.side_effect = None
+        moco.contentDirectory.Browse.return_value = {
+            'NumberReturned': '0',
+            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
+            'TotalMatches': '0',
+            'UpdateID': '0'
+        }
+
+        result = moco.music_library.search_track("artist", "album", "track")
+
+        assert len(result) == 0
+
+        moco.contentDirectory.Browse.assert_called_once_with([
+            ('ObjectID', 'A:ALBUMARTIST/artist/album:track'),
+            ('BrowseFlag', 'BrowseDirectChildren'),
+            ('Filter', '*'),
+            ('StartingIndex', 0),
+            ('RequestedCount', 100000),
+            ('SortCriteria', '')
+        ])
+
+    def test_search_track_artist_albums(self, moco):
+        moco.contentDirectory.reset_mock()
+        moco.contentDirectory.Browse.side_effect = None
+        moco.contentDirectory.Browse.return_value = {
+            'NumberReturned': '2',
+            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/"><container id="A:ALBUMARTIST/The%20Artist/First%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>First Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/First%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container><container id="A:ALBUMARTIST/The%20Artist/Second%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>Second Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container></DIDL-Lite>',
+            'TotalMatches': '2',
+            'UpdateID': '0'
+        }
+        results = moco.music_library.search_track("The Artist")
+
+        assert results.number_returned == 2
+
+        album = results[0]
+        assert album.title == 'First Album'
+        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/First%20Album'
+        album = results[1]
+        assert album.title == 'Second Album'
+        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/Second%20Album'
+
+        moco.contentDirectory.Browse.assert_called_once_with([
+            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/'),
+            ('BrowseFlag', 'BrowseDirectChildren'),
+            ('Filter', '*'),
+            ('StartingIndex', 0),
+            ('RequestedCount', 100000),
+            ('SortCriteria', '')
+        ])
+
+    def test_search_track_artist_album_tracks(self, moco):
+        moco.contentDirectory.reset_mock()
+        moco.contentDirectory.Browse.side_effect = None
+        moco.contentDirectory.Browse.return_value = {
+            'NumberReturned': '3',
+            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 1</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>3</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a&amp;v=432</ns1:albumArtURI><dc:title>Track Title 2</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>4</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 3</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>5</ns1:originalTrackNumber></item></DIDL-Lite>',
+            'TotalMatches': '3',
+            'UpdateID': '0'
+        }
+
+        results = moco.music_library.search_track("The Artist", "The Album")
+
+        assert len(results) == 3
+
+        track = results[0]
+        assert track.title == 'Track Title 1'
+        assert track.item_id == 'S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3'
+        track = results[1]
+        assert track.title == 'Track Title 2'
+        assert track.item_id == 'S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a'
+        track = results[2]
+        assert track.title == 'Track Title 3'
+        assert track.item_id == 'S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3'
+
+        moco.contentDirectory.Browse.assert_called_once_with([
+            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/The%20Album'),
+            ('BrowseFlag', 'BrowseDirectChildren'),
+            ('Filter', '*'),
+            ('StartingIndex', 0),
+            ('RequestedCount', 100000),
+            ('SortCriteria', '')
+        ])
+
+    def test_soco_library_updating(self, moco):
+        moco.contentDirectory.GetShareIndexInProgress.return_value = {
+            'IsIndexing': '0'}
+        assert not moco.music_library.library_updating
+        moco.contentDirectory.reset_mock()
+        moco.contentDirectory.GetShareIndexInProgress.return_value = {
+            'IsIndexing': '1'}
+        assert moco.music_library.library_updating
+
+    def test_soco_start_library_update(self, moco):
+        moco.contentDirectory.RefreshShareIndex.return_value = True
+        assert moco.music_library.start_library_update()
+        moco.contentDirectory.RefreshShareIndex.assert_called_with([
+            ('AlbumArtistDisplayOption', ''),
+        ])


### PR DESCRIPTION
Lots of methods were moved from core.py to music_library.py and scheduled for deprecation in the upcoming release 0.14 - this PR removes them as planned.
Closes #367.