### PR TITLE
don't throw exception if alarm is not associated to any room

### DIFF
--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -307,7 +307,7 @@ def get_alarms(zone=None):
         instance.recurrence = values['Recurrence']
         instance.enabled = values['Enabled'] == '1'
         instance.zone = next((z for z in zone.all_zones
-                         if z.uid == values['RoomUUID']), None)
+                              if z.uid == values['RoomUUID']), None)
         # some alarms are not associated to zones -> filter these out
         if instance.zone is None:
             continue

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -306,8 +306,11 @@ def get_alarms(zone=None):
             datetime.strptime(values['Duration'], "%H:%M:%S").time()
         instance.recurrence = values['Recurrence']
         instance.enabled = values['Enabled'] == '1'
-        instance.zone = [z for z in zone.all_zones
-                         if z.uid == values['RoomUUID']][0]
+        instance.zone = next((z for z in zone.all_zones
+                         if z.uid == values['RoomUUID']), None)
+        # some alarms are not associated to zones -> filter these out
+        if instance.zone is None:
+            continue
         instance.program_uri = None if values['ProgramURI'] ==\
             "x-rincon-buzzer:0" else values['ProgramURI']
         instance.program_metadata = values['ProgramMetaData']


### PR DESCRIPTION
I got this error:

```
/usr/local/lib/python3.5/dist-packages/soco/alarms.py in get_alarms(zone)
    308         instance.enabled = values['Enabled'] == '1'
    309         instance.zone = [z for z in zone.all_zones
--> 310                          if z.uid == values['RoomUUID']][0]
    311         instance.program_uri = None if values['ProgramURI'] ==\
    312             "x-rincon-buzzer:0" else values['ProgramURI']
IndexError: list index out of range
```

The problem is that some of my alarms have no rooms associated. This PR now skips all alarms with no associated room because in `save()` you do `self.zone.uid` which requires every room to have a zone. If you'd like to also allow alarms without zone, then please add a comment and I'll try to rework my PR.