### PR TITLE
Add explicit return statements to appease pylint

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1310,6 +1310,7 @@ class SoCo(_SocoSingletonBase):
             self.speaker_info['mac_address'] = mac
 
             return self.speaker_info
+        return None
 
     def get_current_transport_info(self):
         """Get the current playback state.

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -226,3 +226,4 @@ def by_name(name):
     for device in discover():
         if device.player_name == name:
             return device
+    return None

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=star-args
+# pylint: disable=star-args,too-many-locals
 
 """Plugin for the Wimp music service (Service ID 20)"""
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -409,6 +409,7 @@ class Service(object):
             # Something else has gone wrong. Probably a network error. Let
             # Requests handle it
             response.raise_for_status()
+        return None
 
     def handle_upnp_error(self, xml_error):
         """Disect a UPnP error, and raise an appropriate exception.

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -312,3 +312,5 @@ class SoapMessage(object):
             # Something else has gone wrong. Probably a network error. Let
             # Requests handle it
             response.raise_for_status()
+
+        return None


### PR DESCRIPTION
pylint has been updated on TravisCI, which means that currently the checks fail.

The new check, is one that checks for inconsistent return statements, basically, if there is an explicit return statement anywhere in a function, we should never rely on an implicite one (the `return None` that is always at the end of a function).

Therefore, this PR just adds a few explicit `return None` statements (and disables another warning in the wimp plugin, which should be deprecated soon anyway).

I'm merging immediately and posting here just for information. If you have string opinions against, let me know and we can revert.