### PR TITLE
Bug in from_didl_string causes incomplete information to be returned by soco.get_queue()

### DIFF
--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -50,7 +50,10 @@ def from_didl_string(string):
             except KeyError:
                 raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
             item = cls.from_element(elt)
-            item = attempt_datastructure_upgrade(item)
+            # The following line has been commented out because
+            # it results in soco.get_queue() returning incomplete
+            # information and likely has other unintended consequences
+            #item = attempt_datastructure_upgrade(item)
             items.append(item)
         else:
             # <desc> elements are allowed as an immediate child of <DIDL-Lite>

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -52,8 +52,8 @@ def from_didl_string(string):
             item = cls.from_element(elt)
             # The following line has been commented out because
             # it results in soco.get_queue() returning incomplete
-            # information and likely has other unintended consequences
-            #item = attempt_datastructure_upgrade(item)
+            # information and likely has other unintended consequences:
+            # item = attempt_datastructure_upgrade(item)
             items.append(item)
         else:
             # <desc> elements are allowed as an immediate child of <DIDL-Lite>


### PR DESCRIPTION
One line of code should be commented out until it has been adequately tested and is bug free.
Closes #552.