### PR TITLE
Make Subscription a context manager

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -617,6 +617,14 @@ class Subscription(object):
             time_left = self.timeout - (time.time() - self._timestamp)
             return time_left if time_left > 0 else 0
 
+    def __enter__(self):
+        if not self.is_subscribed:
+            self.subscribe()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.unsubscribe()
+
 
 # pylint: disable=C0103
 event_listener = EventListener()


### PR DESCRIPTION
This adds `__enter__` and `__exit__` methods to `Subscription`, to make the following idiom possible:
```python
with player.AVTransport.subscribe() as subscription:
    # Dummy
    event = subscription.events.get()
```
The subscription is automatically unsubscribed when exiting the `with` block.