### PR TITLE
Delay object parsing exceptions, reraise on object use

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -22,7 +22,7 @@ from .compat import (
     Queue, BaseHTTPRequestHandler, URLError, socketserver, urlopen
 )
 from .data_structures_entry import from_didl_string
-from .exceptions import SoCoException
+from .exceptions import SoCoException, SoCoFault
 from .utils import camel_to_underscore
 from .xml import XML
 
@@ -136,7 +136,12 @@ def parse_event_xml(xml_event):
                     # If DIDL metadata is returned, convert it to a music
                     # library data structure
                     if value.startswith('<DIDL-Lite'):
-                        value = from_didl_string(value)[0]
+                        # Wrap any parsing exception in a SoCoFault, so the
+                        # user can handle it
+                        try:
+                            value = from_didl_string(value)[0]
+                        except SoCoException as ex:
+                            value = SoCoFault(ex, metadata=value)
                     channel = last_change_var.get('channel')
                     if channel is not None:
                         if result.get(tag) is None:

--- a/soco/events.py
+++ b/soco/events.py
@@ -47,6 +47,7 @@ def parse_event_xml(xml_event):
               :code:`{'Volume': {'LF': '100', 'RF': '100', 'Master': '36'}}`)
             * an instance of a `DidlObject` subclass (eg if it represents
               track metadata).
+            * a `SoCoFault` (if a variable contains illegal metadata)
 
     Example:
 
@@ -173,7 +174,8 @@ class Event(object):
             `time.time` function).
         service (str): the service which is subscribed to the event.
         variables (dict, optional): contains the ``{names: values}`` of the
-            evented variables. Defaults to `None`.
+            evented variables. Defaults to `None`. The values may be
+            `SoCoFault` objects if the metadata could not be parsed.
 
     Raises:
         AttributeError:  Not all attributes are returned with each event. An

--- a/soco/events.py
+++ b/soco/events.py
@@ -141,6 +141,11 @@ def parse_event_xml(xml_event):
                         try:
                             value = from_didl_string(value)[0]
                         except SoCoException as ex:
+                            log.error("Event contains illegal metadata"
+                                      "for '%s'.\n"
+                                      "Error message: '%s'\n"
+                                      "The result will be a SoCoFault.",
+                                      tag, str(ex))
                             value = SoCoFault(ex, metadata=value)
                     channel = last_change_var.get('channel')
                     if channel is not None:

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -85,7 +85,7 @@ class NotSupportedException(SoCoException):
 class SoCoFault(object):
     """Class to represent a failed object instantiation.
 
-    It rethrows the exception on any use.
+    It rethrows the exception on common use.
     """
 
     def __init__(self, exception, **kwargs):

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -82,20 +82,39 @@ class NotSupportedException(SoCoException):
     """Raised when something is not supported by the device"""
 
 
+class EventParseException(SoCoException):
+    """Raised when a parsing exception occurs during event handling."""
+
+    def __init__(self, tag, metadata, cause):
+        """
+        Args:
+            tag (str): The tag for which the exception occured
+            metadata (str): The metadata which failed to parse
+            cause (Exception): The original exception
+        """
+        super(EventParseException, self).__init__()
+        self.tag = tag
+        self.metadata = metadata
+        self.__cause__ = cause
+
+    def __str__(self):
+        return "Invalid metadata for '{}'".format(self.tag)
+
+
 class SoCoFault(object):
     """Class to represent a failed object instantiation.
 
     It rethrows the exception on common use.
+
+    Attributes:
+        exception: The exception which will be thrown on use
     """
 
-    def __init__(self, exception, **kwargs):
+    def __init__(self, exception):
         """
         Args:
             exception (Exception): The exception which should be thrown on use
-            kwargs: Items to add to the object dict, as additional information
-                about the fault.
         """
-        self.__dict__ = kwargs
         self.__dict__['exception'] = exception
 
     def __getattr__(self, name):
@@ -107,10 +126,14 @@ class SoCoFault(object):
     def __getitem__(self, item):
         raise self.exception
 
+    def __setitem__(self, key, value):
+        raise self.exception
+
     def __repr__(self):
         return '<{0}: {1} at {2}>'.format(self.__class__.__name__,
                                           repr(self.exception),
                                           hex(id(self)))
 
     def __str__(self):
-        return self.__repr__()
+        return '<{0}: {1}>'.format(self.__class__.__name__,
+                                   repr(self.exception))

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -107,12 +107,6 @@ class SoCoFault(object):
     def __getitem__(self, item):
         raise self.exception
 
-    def __eq__(self, other):
-        raise self.exception
-
-    def __ne__(self, other):
-        raise self.exception
-
     def __repr__(self):
         return '<{0} ({1}) at {2}>'.format(self.__class__.__name__,
                                            self.exception.__class__.__name__,

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -80,3 +80,43 @@ class SoCoSlaveException(SoCoException):
 
 class NotSupportedException(SoCoException):
     """Raised when something is not supported by the device"""
+
+
+class SoCoFault(object):
+    """Class to represent a failed object instantiation.
+
+    It rethrows the exception on any use.
+    """
+
+    def __init__(self, exception, **kwargs):
+        """
+        Args:
+            exception (Exception): The exception which should be thrown on use
+            kwargs: Items to add to the object dict, as additional information
+                about the fault.
+        """
+        self.__dict__ = kwargs
+        self.__dict__['exception'] = exception
+
+    def __getattr__(self, name):
+        raise self.exception
+
+    def __setattr__(self, name, value):
+        raise self.exception
+
+    def __getitem__(self, item):
+        raise self.exception
+
+    def __eq__(self, other):
+        raise self.exception
+
+    def __ne__(self, other):
+        raise self.exception
+
+    def __repr__(self):
+        return '<{0} ({1}) at {2}>'.format(self.__class__.__name__,
+                                           self.exception.__class__.__name__,
+                                           hex(id(self)))
+
+    def __str__(self):
+        return self.__repr__()

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -83,7 +83,13 @@ class NotSupportedException(SoCoException):
 
 
 class EventParseException(SoCoException):
-    """Raised when a parsing exception occurs during event handling."""
+    """Raised when a parsing exception occurs during event handling.
+
+    Attributes:
+        tag (str): The tag for which the exception occured
+        metadata (str): The metadata which failed to parse
+        __cause__ (Exception): The original exception
+    """
 
     def __init__(self, tag, metadata, cause):
         """

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -108,9 +108,9 @@ class SoCoFault(object):
         raise self.exception
 
     def __repr__(self):
-        return '<{0} ({1}) at {2}>'.format(self.__class__.__name__,
-                                           self.exception.__class__.__name__,
-                                           hex(id(self)))
+        return '<{0}: {1} at {2}>'.format(self.__class__.__name__,
+                                          repr(self.exception),
+                                          hex(id(self)))
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
This catches any exceptions thrown by `from_didl_string` during event handling. Instead a DidlFault is created, which rethrows the exception when the user tries to use it. This avoids an exception in the event thread, instead letting the user handle it when he needs the object. 
Compare with #568 for another implementation of the same proposal.
See #566 for information on why this is needed.
Closes #566, closes #568.