### PR TITLE
Delay object parsing exceptions, reraise on object retrieval

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -28,6 +28,7 @@ helpful.
 
 from __future__ import unicode_literals
 
+import collections
 import sys
 import textwrap
 import warnings
@@ -1171,3 +1172,38 @@ class Queue(ListOfMusicInfoItems):
             self.__class__.__name__,
             super(Queue, self).__repr__(),
         )
+
+
+###############################################################################
+# SPECIAL DICTS                                                               #
+###############################################################################
+
+class DescriptorDict(collections.MutableMapping, dict):
+
+    """A dict which handles descriptor items like descriptor attributes."""
+
+    def __getitem__(self, key):
+        item = dict.__getitem__(self, key)
+        if hasattr(item, '__get__'):
+            return item.__get__(self)
+        return item
+
+    def __setitem__(self, key, value):
+        if key in self.keys():
+            item = dict.__getitem__(self, key)
+            if hasattr(item, '__set__'):
+                return item.__set__(self, value)
+        return dict.__setitem__(self, key, value)
+
+    def __delitem__(self, key):
+        if key in self.keys():
+            item = dict.__getitem__(self, key)
+            if hasattr(item, '__del__'):
+                return item.__del__(self)
+        return dict.__delitem__(self, key)
+
+    def __iter__(self):
+        return dict.__iter__(self)
+
+    def __len__(self):
+        return dict.__len__(self)

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1178,6 +1178,7 @@ class Queue(ListOfMusicInfoItems):
 # SPECIAL DICTS                                                               #
 ###############################################################################
 
+# pylint: disable=too-many-ancestors
 class DescriptorDict(collections.MutableMapping, dict):
 
     """A dict which handles descriptor items like descriptor attributes."""

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -80,3 +80,13 @@ class SoCoSlaveException(SoCoException):
 
 class NotSupportedException(SoCoException):
     """Raised when something is not supported by the device"""
+
+
+class ErrorDescriptor(object):
+    """Descriptor which raises an error on __get__."""
+
+    def __init__(self, exception):
+        self._exception = exception
+
+    def __get__(self, obj, obj_type=None):
+        raise self._exception


### PR DESCRIPTION
This catches any exceptions thrown by from_didl_string during event handling. Instead an ErrorDescriptor is created, which rethrows the exception when the user tries to retrieve it from the variable dict. This avoids an exception in the event thread, instead letting the user handle it when he needs the object. To make this possible, a DescriptorDict data structure is created, which handles descriptor items like descriptor attributes.
Compare with #567 for another implementation of the same proposal.
See #566 for information on why this is needed.
Closes #566, closes #567.