### PR TITLE
Services extensions

### DIFF
--- a/soco/services.py
+++ b/soco/services.py
@@ -77,19 +77,21 @@ class Action(namedtuple('ActionBase', 'name, in_args, out_args')):
 class Argument(namedtuple('ArgumentBase', 'name, vartype')):
     """A UPnP Argument and its type."""
     def __str__(self):
-        argument, datatype = self.name, self.vartype.datatype
+        argument = self.name
         if self.vartype.default:
             argument = "{0}={1}".format(self.name, self.vartype.default)
-        if self.vartype.list:
-            datatype = '[{0}]'.format(', '.join(self.vartype.list))
-        if self.vartype.range:
-            datatype = '[{0}..{1}]'.format(self.vartype.range[0],
-                                           self.vartype.range[1])
-        return '{0}: {1}'.format(argument, datatype)
+        return '{0}: {1}'.format(argument, str(self.vartype))
 
 
-#: An argument type with default value and range.
-Vartype = namedtuple('Vartype', 'datatype, default, list, range')
+class Vartype(namedtuple('VartypeBase', 'datatype, default, list, range')):
+    """An argument type with default value and range."""
+    def __str__(self):
+        if self.list:
+            return '[{0}]'.format(', '.join(self.list))
+        if self.range:
+            return '[{0}..{1}]'.format(self.range[0], self.range[1])
+        return self.datatype
+
 
 # A shared cache for ZoneGroupState. Each zone has the same info, so when a
 # SoCo instance is asked for group info, we can cache it and return it when
@@ -154,6 +156,11 @@ class Service(object):
         #: a `TimedCache` with a default timeout=0.
         self.cache = Cache(default_timeout=0)
 
+        # Caching variables for actions and event_vars, will be filled when
+        # they are requested for the first time
+        self._actions = None
+        self._event_vars = None
+
         # From table 3.3 in
         # http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf
         # This list may not be complete, but should be good enough to be going
@@ -184,7 +191,7 @@ class Service(object):
             611: 'Invalid Control URL',
             612: 'No Such Session',
         }
-        self.DEFAULT_ARGS = OrderedDict()
+        self.DEFAULT_ARGS = {}
 
     def __getattr__(self, action):
         """Called when a method on the instance cannot be found.
@@ -307,29 +314,70 @@ class Service(object):
             "{http://schemas.xmlsoap.org/soap/envelope/}Body")[0]
         return dict((i.tag, i.text or "") for i in action_response)
 
-    def compose_args(self, args, kwargs):
+    def compose_args(self, action_name, in_arglist, in_argdict):
         """Compose the argument list from list of tuples or dictionary form.
 
         Args:
-            args (list): Arguments as a list of ``(name, value)`` tuples
-                specifying the name of each argument and its value, eg
+            action_name (str): The name of the action to be performed.
+            in_arglist (list): Arguments as a list of ``(name, value)``
+                tuples specifying the name of each argument and its value, eg
                 ``[('InstanceID', 0), ('Speed', 1)]``. The value
                 can be a string or something with a string representation.
-            kwargs (dict): Arguments as a dict, eg
+            in_argdict (dict): Arguments as a dict, eg
                 ``{'InstanceID': 0, 'Speed': 1}.
 
         This merges args and kwargs into a single argument list, with
         ``DEFAULT_ARGS`` as default values.
-        The ``kwargs`` take precedence over the ``args``.
+        The ``argdict`` takes precedence over the ``arglist``.
 
         Returns:
             list: a list of ``(name, value)`` tuples.
+
+        Raises:
+            `AttributeError`: If this service does not support the action.
+            `ValueError`: If the argument lists do not match the action
+                signature.
         """
-        # TODO: Use the information from iter_actions() to select default args
-        composed = self.DEFAULT_ARGS.copy()
-        composed.update(args or ())
-        composed.update(kwargs or ())
-        return list(composed.items())
+        in_argdict2 = dict(in_arglist or ())
+
+        action = None
+        for act in self.actions:
+            if act.name == action_name:
+                action = act
+                break
+        if action is None:
+            raise AttributeError('Unknown Action: {0}'.format(action_name))
+
+        # Check for given argument names which do not occur in the expected
+        # argument list
+        unexpected = (set(in_argdict) | set(in_argdict2)) - \
+            set(argument.name for argument in action.in_args)
+        if unexpected:
+            raise ValueError(
+                "Unexpected argument '{0}'. Method signature: {1}"
+                .format(next(iter(unexpected)), str(action))
+            )
+
+        # List the (name, value) tuples for each argument in the argument list
+        composed = []
+        for argument in action.in_args:
+            name = argument.name
+            if name in in_argdict:
+                composed.append((name, in_argdict[name]))
+                continue
+            if name in in_argdict2:
+                composed.append((name, in_argdict2[name]))
+                continue
+            if name in self.DEFAULT_ARGS:
+                composed.append((name, self.DEFAULT_ARGS[name]))
+                continue
+            if argument.vartype.default is not None:
+                composed.append((name, argument.vartype.default))
+            raise ValueError(
+                "Missing argument '{0}'. Method signature: {1}"
+                .format(argument.name, str(action))
+            )
+        return composed
 
     def build_command(self, action, args=None):
         """Build a SOAP request.
@@ -411,12 +459,15 @@ class Service(object):
              dict: a dict of ``{argument_name, value}`` items.
 
         Raises:
+            `AttributeError`: If this service does not support the action.
+            `ValueError`: If the argument lists do not match the action
+                signature.
             `SoCoUPnPException`: if a SOAP error occurs.
             `UnknownSoCoException`: if an unknonwn UPnP error occurs.
-            `requests.exceptions.HTTPError`: if an http error.
+            `requests.exceptions.HTTPError`: if an http error occurs.
 
         """
-        args = self.compose_args(args, kwargs)
+        args = self.compose_args(action, args, kwargs)
         if cache is None:
             cache = self.cache
         result = cache.get(action, args)
@@ -569,6 +620,43 @@ class Service(object):
         """
         pass
 
+    @property
+    def actions(self):
+        """The service's actions with their arguments.
+
+        Returns:
+            list(`Action`): A list of Action namedtuples, consisting of
+            action_name (str), in_args (list of Argument namedtuples,
+            consisting of name and argtype), and out_args (ditto).
+
+        The return value looks like this::
+            [
+                Action(
+                    name='GetMute',
+                    in_args=[
+                        Argument(name='InstanceID', ...),
+                        Argument(
+                            name='Channel',
+                            vartype='string',
+                            list=['Master', 'LF', 'RF', 'SpeakerOnly'],
+                            range=None
+                        )
+                    ],
+                    out_args=[
+                        Argument(name='CurrentMute, ...)
+                    ]
+                )
+                Action(...)
+            ]
+
+        Its string representation will look like this::
+            GetMute(InstanceID: ui4, Channel: [Master, LF, RF, SpeakerOnly]) \
+            -> {CurrentMute: boolean}
+        """
+        if self._actions is None:
+            self._actions = list(self.iter_actions())
+        return self._actions
+
     def iter_actions(self):
         """Yield the service's actions with their arguments.
 
@@ -582,8 +670,8 @@ class Service(object):
             Action(
                 name='SetFormat',
                 in_args=[
-                    Argument(name='DesiredTimeFormat', vartype='string'),
-                    Argument(name='DesiredDateFormat', vartype='string')],
+                    Argument(name='DesiredTimeFormat', vartype=<Vartype>),
+                    Argument(name='DesiredDateFormat', vartype=<Vartype>)],
                 out_args=[]
             )
         """
@@ -633,6 +721,17 @@ class Service(object):
                         else:
                             out_args.append(Argument(arg_name, vartype))
                     yield Action(action_name, in_args, out_args)
+
+    @property
+    def event_vars(self):
+        """The service's eventable variables.
+
+        Returns:
+            list(tuple): A list of (variable name, data type) tuples.
+        """
+        if self._event_vars is None:
+            self._event_vars = list(self.iter_event_vars())
+        return self._event_vars
 
     def iter_event_vars(self):
         """Yield the services eventable variables.

--- a/soco/services.py
+++ b/soco/services.py
@@ -64,16 +64,16 @@ log = logging.getLogger(__name__)  # pylint: disable=C0103
 # log.setLevel(logging.INFO)
 
 
-#: A UPnP Action and its arguments.
 class Action(namedtuple('ActionBase', 'name, in_args, out_args')):
+    """A UPnP Action and its arguments."""
     def __str__(self):
         args = ', '.join(str(arg) for arg in self.in_args)
         returns = ', '.join(str(arg) for arg in self.out_args)
         return '{0}({1}) -> {{{2}}}'.format(self.name, args, returns)
 
 
-#: A UPnP Argument and its type.
 class Argument(namedtuple('ArgumentBase', 'name, vartype')):
+    """A UPnP Argument and its type."""
     def __str__(self):
         argument, datatype = self.name, self.vartype.datatype
         if self.vartype.default:
@@ -81,7 +81,7 @@ class Argument(namedtuple('ArgumentBase', 'name, vartype')):
         if self.vartype.list:
             datatype = '[{0}]'.format(', '.join(self.vartype.list))
         if self.vartype.range:
-            datatype = '[{0}..{0}]'.format(self.vartype.range[0],
+            datatype = '[{0}..{1}]'.format(self.vartype.range[0],
                                            self.vartype.range[1])
         return '{0}: {1}'.format(argument, datatype)
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -34,7 +34,9 @@ from __future__ import (
 )
 
 import logging
-from collections import namedtuple
+from collections import (
+    namedtuple, OrderedDict
+)
 from xml.sax.saxutils import escape
 
 import requests
@@ -182,7 +184,7 @@ class Service(object):
             611: 'Invalid Control URL',
             612: 'No Such Session',
         }
-        self.DEFAULT_ARGS = {}
+        self.DEFAULT_ARGS = OrderedDict()
 
     def __getattr__(self, action):
         """Called when a method on the instance cannot be found.

--- a/soco/services.py
+++ b/soco/services.py
@@ -760,6 +760,7 @@ class RenderingControl(Service):
         super(RenderingControl, self).__init__(soco)
         self.control_url = "/MediaRenderer/RenderingControl/Control"
         self.event_subscription_url = "/MediaRenderer/RenderingControl/Event"
+        self.DEFAULT_ARGS.update({'InstanceID': 0})
 
 
 class MR_ConnectionManager(Service):  # pylint: disable=invalid-name
@@ -831,3 +832,4 @@ class GroupRenderingControl(Service):
         self.control_url = "/MediaRenderer/GroupRenderingControl/Control"
         self.event_subscription_url = \
             "/MediaRenderer/GroupRenderingControl/Event"
+        self.DEFAULT_ARGS.update({'InstanceID': 0})

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -193,14 +193,14 @@ def test_compose(service):
         service.compose_args('Test', None, dict(DUMMY_ARGS+[('Error', 3)]))
 
     assert service.compose_args('Test', DUMMY_ARGS, {}) == DUMMY_ARGS
-    assert service.compose_args('Test', None, **dict(DUMMY_ARGS)) == DUMMY_ARGS
+    assert service.compose_args('Test', None, dict(DUMMY_ARGS)) == DUMMY_ARGS
 
     service.DEFAULT_ARGS = dict(DUMMY_ARGS[:1])
 
     assert service.compose_args('Test', DUMMY_ARGS, {}) == DUMMY_ARGS
-    assert service.compose_args('Test', None, **dict(DUMMY_ARGS)) == DUMMY_ARGS
+    assert service.compose_args('Test', None, dict(DUMMY_ARGS)) == DUMMY_ARGS
     assert service.compose_args('Test', DUMMY_ARGS[1:], {}) == DUMMY_ARGS
-    assert service.compose_args('Test', None, **dict(DUMMY_ARGS[1:])) \
+    assert service.compose_args('Test', None, dict(DUMMY_ARGS[1:])) \
         == DUMMY_ARGS
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -159,7 +159,7 @@ def test_compose(service):
     service.DEFAULT_ARGS = {'third': 'default'}
     assert set(service.compose_args(TEST_ARGS, None)) == \
            set(TEST_ARGS + [('third', 'default')])
-    assert service.compose_args(TEST_ARGS + [('third', 3)], None) == \
+    assert set(service.compose_args(TEST_ARGS + [('third', 3)], None)) == \
            set(TEST_ARGS + [('third', 3)])
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -67,6 +67,7 @@ DUMMY_VALID_ACTION = "".join([
         '</s:Body>'
     '</s:Envelope>'])  # noqa PEP8
 
+TEST_ARGS = [('first', 'one'), ('second', 2)]
 
 @pytest.fixture()
 def service():
@@ -146,6 +147,21 @@ def test_unwrap_invalid_char(service):
     assert service.unwrap_arguments(responce_with_invalid_char) == {
         "CurrentLEDState": "On",
         "Unicode": "AB"}
+
+
+def test_compose(service):
+    """Test argument composition."""
+    service.DEFAULT_ARGS = {}
+    assert set(service.compose_args(TEST_ARGS, None)) == set(TEST_ARGS)
+    assert set(service.compose_args(None, dict(TEST_ARGS))) == set(TEST_ARGS)
+    assert set(service.compose_args(TEST_ARGS, {'third': 3})) == \
+           set(TEST_ARGS + [('third', 3)])
+    service.DEFAULT_ARGS = {'third': 'default'}
+    assert set(service.compose_args(TEST_ARGS, None)) == \
+           set(TEST_ARGS + [('third', 'default')])
+    assert service.compose_args(TEST_ARGS + [('third', 3)], None) == \
+           set(TEST_ARGS + [('third', 3)])
+
 
 def test_build_command(service):
     """Test creation of SOAP body and headers from a command."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -94,6 +94,8 @@ DUMMY_ACTIONS = [
 
 DUMMY_ARGS = [('Argument1', 1), ('Argument2', 2)]
 
+DUMMY_ARGS_ALTERNATIVE = [('Argument1', 3), ('Argument2', 2)]
+
 @pytest.fixture()
 def service():
     """A mock Service, for use as a test fixture."""
@@ -180,9 +182,11 @@ def test_compose(service):
     """Test argument composition."""
     service.DEFAULT_ARGS = {}
 
+    # Detect unknown action
     with pytest.raises(AttributeError):
         service.compose_args('Error', None, {})
 
+    # Detect missing / unknown arguments
     with pytest.raises(ValueError):
         service.compose_args('Test', [('Argument1', 1)], {})
     with pytest.raises(ValueError):
@@ -192,16 +196,24 @@ def test_compose(service):
     with pytest.raises(ValueError):
         service.compose_args('Test', None, dict(DUMMY_ARGS+[('Error', 3)]))
 
+    # Check correct output
     assert service.compose_args('Test', DUMMY_ARGS, {}) == DUMMY_ARGS
+    assert service.compose_args('Test', reversed(DUMMY_ARGS), {}) == DUMMY_ARGS
     assert service.compose_args('Test', None, dict(DUMMY_ARGS)) == DUMMY_ARGS
 
+    # Set Argument1 = 1 as default
     service.DEFAULT_ARGS = dict(DUMMY_ARGS[:1])
 
-    assert service.compose_args('Test', DUMMY_ARGS, {}) == DUMMY_ARGS
-    assert service.compose_args('Test', None, dict(DUMMY_ARGS)) == DUMMY_ARGS
+    # Check that arguments are completed with default values
     assert service.compose_args('Test', DUMMY_ARGS[1:], {}) == DUMMY_ARGS
     assert service.compose_args('Test', None, dict(DUMMY_ARGS[1:])) \
         == DUMMY_ARGS
+
+    # Check that given arguments override the default values
+    assert service.compose_args('Test', DUMMY_ARGS_ALTERNATIVE, {}) \
+        == DUMMY_ARGS_ALTERNATIVE
+    assert service.compose_args('Test', None, dict(DUMMY_ARGS_ALTERNATIVE)) \
+        == DUMMY_ARGS_ALTERNATIVE
 
 
 


### PR DESCRIPTION
This extends the services module in two ways:

- Handle default value / allowed value range in iter_actions and add a `__str__` function to the resulting Actions, to make the output more readable

- Allow keyword arguments in send_command, so you can do 
  ```python
  renderingControl.SetRoomCalibrationStatus(RoomCalibrationEnabled=False)
  ```
  instead of the less pythonic
  ```python
  renderingControl.SetRoomCalibrationStatus([
      ('InstanceID', 0),
      ('RoomCalibrationEnabled', False)
  ])
  ```
  to switch off Trueplay (something we do not yet support directly).

Let me know what you think of these extensions.