### PR TITLE
Initialize all DidlObject attributes to None

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -651,13 +651,15 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
 
         # Add the rest of the metadata attributes (i.e all those listed in
         # _translation) as sub-elements of the item element.
-        for key, value in self._translation.items():
-            if hasattr(self, key):
+        # pylint: disable=invalid-name
+        for key, (ns, tag) in self._translation.items():
+            value = getattr(self, key)
+            if value:
                 # Some attributes have a namespace of '', which means they
                 # are in the default namespace. We need to handle those
                 # carefully
-                tag = "%s:%s" % value if value[0] else "%s" % value[1]
-                XML.SubElement(elt, tag).text = ("%s" % getattr(self, key))
+                tag = "%s:%s" % (ns, tag) if ns else "%s" % tag
+                XML.SubElement(elt, tag).text = ("%s" % value)
         # Now add in the item class
         XML.SubElement(elt, 'upnp:class').text = self.item_class
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -411,6 +411,10 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # only seems to use one, so we won't bother with a list
         self.desc = desc
 
+        # Initialize all allowed class-specific attributes to None
+        for key in self._translation:
+            setattr(self, key, None)
+
         for key, value in kwargs.items():
             # For each attribute, check to see if this class allows it
             if key not in self._translation:
@@ -502,6 +506,8 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
             if result is not None:
                 # We store info as unicode internally.
                 content[key] = really_unicode(result)
+            else:
+                content[key] = None
 
         # Convert type for original track number
         if content.get('original_track_number') is not None:

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -506,8 +506,6 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
             if result is not None:
                 # We store info as unicode internally.
                 content[key] = really_unicode(result)
-            else:
-                content[key] = None
 
         # Convert type for original track number
         if content.get('original_track_number') is not None:

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -207,12 +207,14 @@ class TestDidlObject():
             parent_id='pid',
             item_id='iid',
             creator='a_creator',
+            write_status='wstatus',
             desc='dummy')
         the_dict = {
             'title': 'a_title',
             'parent_id': 'pid',
             'item_id': 'iid',
             'creator': 'a_creator',
+            'write_status': 'wstatus',
             'restricted': True,
             'desc': 'dummy'
         }
@@ -282,12 +284,18 @@ class TestDidlObject():
 
     def test_didl_object_to_dict(self):
         didl_object = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title='a_title',
+            parent_id='pid',
+            item_id='iid',
+            creator='a_creator',
+            write_status='wstatus'
+        )
         the_dict = {
             'title': 'a_title',
             'parent_id': 'pid',
             'item_id': 'iid',
             'creator': 'a_creator',
+            'write_status': 'wstatus',
             'restricted': True,
             'desc': 'RINCON_AssociatedZPUDN'
         }
@@ -302,16 +310,20 @@ class TestDidlObject():
     def test_didl_object_to_dict_resources(self):
         resources_list = [data_structures.DidlResource('a%20uri',
                                                        'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 resources=resources_list)
+        didl_object = data_structures.DidlObject(
+            title='a_title',
+            parent_id='pid',
+            item_id='iid',
+            creator='a_creator',
+            write_status='wstatus',
+            resources=resources_list
+        )
         the_dict = {
             'title': 'a_title',
             'parent_id': 'pid',
             'item_id': 'iid',
             'creator': 'a_creator',
+            'write_status': 'wstatus',
             'restricted': True,
             'desc': 'RINCON_AssociatedZPUDN',
             'resources': [resource.to_dict() for resource in resources_list]
@@ -321,16 +333,20 @@ class TestDidlObject():
     def test_didl_object_to_dict_resources_remove_nones(self):
         resources_list = [data_structures.DidlResource('a%20uri',
                                                        'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 resources=resources_list)
+        didl_object = data_structures.DidlObject(
+            title='a_title',
+            parent_id='pid',
+            item_id='iid',
+            creator='a_creator',
+            write_status='wstatus',
+            resources=resources_list
+        )
         the_dict = {
             'title': 'a_title',
             'parent_id': 'pid',
             'item_id': 'iid',
             'creator': 'a_creator',
+            'write_status': 'wstatus',
             'restricted': True,
             'desc': 'RINCON_AssociatedZPUDN',
             'resources': [resource.to_dict(remove_nones=True)
@@ -340,7 +356,12 @@ class TestDidlObject():
 
     def test_didl_object_to_element(self):
         didl_object = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title='a_title',
+            parent_id='pid',
+            item_id='iid',
+            creator='a_creator',
+            write_status='wstatus'
+        )
         # we seem to have to go through this to get ElementTree to deal
         # with namespaces properly!
         elt = XML.fromstring(XML.tostring(didl_object.to_element(True)))
@@ -351,6 +372,7 @@ class TestDidlObject():
             '<item id="iid" parentID="pid" restricted="true">' +
             '<dc:title>a_title</dc:title>' +
             '<dc:creator>a_creator</dc:creator>' +
+            '<upnp:writeStatus>wstatus</upnp:writeStatus>' +
             '<upnp:class>object</upnp:class><desc id="cdudn" ' +
             'nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">' +
             'RINCON_AssociatedZPUDN</desc></item></dummy>')[0]


### PR DESCRIPTION
This is a PR for #356.
It initializes all allowed class-specific attributes for DidlObject to None.
Furthermore, it updates and restructures test_new_datastructures.py.
Closes #356.