### PR TITLE
Make Snapshot a context manager

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -286,3 +286,9 @@ class Snapshot(object):
             for queue_group in self.queue:
                 for queue_item in queue_group:
                     self.device.add_uri_to_queue(queue_item.uri)
+
+    def __enter__(self):
+        self.snapshot()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.restore()

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -289,6 +289,7 @@ class Snapshot(object):
 
     def __enter__(self):
         self.snapshot()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.restore()


### PR DESCRIPTION
This adds `__enter__` and `__exit__` methods to Snapshot, to make this idiom possible:
```python
with Snapshot(player):
    player.play(something)  # e.g. announcement
    time.sleep(10)
# Player is reset to its prior state
```
