### PR TITLE
Copy metadata from DidlItem to MusicServiceItem in get_queue and events

### DIFF
--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -95,13 +95,12 @@ def attempt_datastructure_upgrade(didl_item):
         # matter what it is!
         item_id = '11111111{0}'.format(path)
 
-        # Ignore other metadata for now, in future ask ms data
-        # structure to upgrade metadata from the service
+        # Pass over all the available metadata in the metadata dict, in the
+        # future ask ms data structure to upgrade metadata from the service
         metadata = {}
-        try:
-            metadata['title'] = didl_item.title
-        except AttributeError:
-            pass
+        for key, value in didl_item.to_dict().items():
+            if key not in metadata:
+                metadata[key] = value
 
         # Get class
         try:


### PR DESCRIPTION
This PR fixes an issue with a reduced amount of metadata for queue and
event items when upgrading them to their appropriate music service
type.

This should allow e.g. getting both title and album as properties and all remaining metadata from the DidlItem is available in the .metadata property of thr MusicService item.

Note. This PR is published as an alternative to #559. The reason for that is, that the music service data structures was added, since the music services use a completely different internal structure. In the long run, we want to be able to ask the music service to produce metadata for the MusicService items, including those coming from the queue. But until that has been implemented, we should preserve all the metadata we got.

Closes #535 and #559 and #547 and #552