### PR TITLE
Let DidlMusicAlbum copy _translation from DidlAlbum

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -889,7 +889,7 @@ class DidlMusicAlbum(DidlAlbum):
     # name: (ns, tag)
     # pylint: disable=protected-access
     #:
-    _translation = DidlAudioItem._translation.copy()
+    _translation = DidlAlbum._translation.copy()
     _translation.update(
         {
             'artist': ('upnp', 'artist'),


### PR DESCRIPTION
A simple fix for #462.
DidlMusicAlbum now copies its _translation from its parent DidlAlbum instead of DidlAudioItem.
Closes #462.