### PR TITLE
Auto deploy new tagged releases to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,13 @@ script:
 after_script:
   - coveralls
 
+deploy:
+  provider: pypi
+  user: soco-bot
+  password:
+    secure: IgMK3d7ON41NRlfIPYhlk7BPfT/jPRqC1Qn2Lcj69/vqSK5be0vyWloGRAI26v9r9VS1+slSocSUZ05BiUXQj6+srvgWLQfuRnivz6ZjttL/P+oHEvqeV917NqXU2gV7Xejs4j1Y1lu38KdAlul1XZ+0leq3tm88q8bNKAij/C0=
+  on:
+    tags: true
+  distributions: sdist bdist_wheel
+
 sudo: false

--- a/doc/development/release-howto.rst
+++ b/doc/development/release-howto.rst
@@ -29,7 +29,9 @@ Create and Publish
 
     git tag -a v0.7 -m 'release version 0.7'
 
-* Push the tag. This will create a new release on GitHub.
+* Push the tag. This will create a new release on GitHub, and will
+  automatically deploy the new version to PyPI (see `#593
+  <https://github.com/SoCo/SoCo/pull/593>`_)
 
 .. code-block:: bash
 
@@ -38,12 +40,6 @@ Create and Publish
 * Update the `GitHub release <https://github.com/SoCo/SoCo/releases/new>`_
   using the release notes from the documentation. The release notes can be
   abbreviated if a link to the documentation is provided.
-
-* Upload the release to PyPI.
-
-.. code-block:: bash
-
-    python setup.py sdist bdist_wheel upload
 
 
 Wrap-Up


### PR DESCRIPTION
This pull request implements automatic deployment of tagged commits to PyPI.

The upload is triggered by Travis-CI. See [the documentation](https://docs.travis-ci.com/user/deployment/pypi/) for more information on this feature.

For this purpose I have created a new PyPI user `soco-bot`, and added it as a maintainer for the soco project there. Please let me know if I should add additional email addresses to this user, to avoid being the single point of failure for recovering access to the account.

This change would (slightly) reduce the effort of doing a release, and would lower the entry barrier for doing so.