### PR TITLE
Fix what broke when the deprecated methods were removed

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1214,8 +1214,8 @@ class SoCo(_SocoSingletonBase):
             album_art_url = metadata.findtext(
                 './/{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI')
             if album_art_url is not None:
-                track['album_art'] = self._build_album_art_full_uri(
-                    album_art_url)
+                track['album_art'] = \
+                    self.music_library.build_album_art_full_uri(album_art_url)
 
         return track
 
@@ -1580,7 +1580,7 @@ class SoCo(_SocoSingletonBase):
             item: The item to update the URI for
         """
         if getattr(item, 'album_art_uri', False):
-            item.album_art_uri = self._build_album_art_full_uri(
+            item.album_art_uri = self.music_library.build_album_art_full_uri(
                 item.album_art_uri)
 
     def create_sonos_playlist(self, title):
@@ -1684,7 +1684,8 @@ class SoCo(_SocoSingletonBase):
         """Get an item's Album Art absolute URI."""
 
         if getattr(item, 'album_art_uri', False):
-            return self._build_album_art_full_uri(item.album_art_uri)
+            return self.music_library.build_album_art_full_uri(
+                item.album_art_uri)
         else:
             return None
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -1344,7 +1344,7 @@ class SoCo(_SocoSingletonBase):
         for item in items:
             # Check if the album art URI should be fully qualified
             if full_album_art_uri:
-                self._update_album_art_to_full_uri(item)
+                self.music_library._update_album_art_to_full_uri(item)
             queue.append(item)
 
         # pylint: disable=star-args
@@ -1573,16 +1573,6 @@ class SoCo(_SocoSingletonBase):
 
         return result
 
-    def _update_album_art_to_full_uri(self, item):
-        """Update an item's Album Art URI to be an absolute URI.
-
-        Args:
-            item: The item to update the URI for
-        """
-        if getattr(item, 'album_art_uri', False):
-            item.album_art_uri = self.music_library.build_album_art_full_uri(
-                item.album_art_uri)
-
     def create_sonos_playlist(self, title):
         """Create a new empty Sonos playlist.
 
@@ -1679,15 +1669,6 @@ class SoCo(_SocoSingletonBase):
             # this index therefore probably amounts to adding it "at the end"
             ('AddAtIndex', 4294967295)
         ])
-
-    def get_item_album_art_uri(self, item):
-        """Get an item's Album Art absolute URI."""
-
-        if getattr(item, 'album_art_uri', False):
-            return self.music_library.build_album_art_full_uri(
-                item.album_art_uri)
-        else:
-            return None
 
     @only_on_master
     def set_sleep_timer(self, sleep_time_seconds):
@@ -1843,7 +1824,7 @@ class SoCo(_SocoSingletonBase):
         # track_list = ','.join(track_list)
         # position_list = ','.join(position_list)
         if update_id == 0:  # retrieve the update id for the object
-            response, _ = self._music_lib_search(object_id, 0, 1)
+            response, _ = self.music_library._music_lib_search(object_id, 0, 1)
             update_id = response['UpdateID']
         change = 0
 

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -68,6 +68,16 @@ class MusicLibrary(object):
             url = 'http://' + self.soco.ip_address + ':1400' + url
         return url
 
+    def _update_album_art_to_full_uri(self, item):
+        """Update an item's Album Art URI to be an absolute URI.
+
+        Args:
+            item: The item to update the URI for
+        """
+        if getattr(item, 'album_art_uri', False):
+            item.album_art_uri = self.build_album_art_full_uri(
+                item.album_art_uri)
+
     def get_artists(self, *args, **kwargs):
         """Convenience method for `get_music_library_information`
         with ``search_type='artists'``. For details of other arguments,
@@ -304,7 +314,7 @@ class MusicLibrary(object):
             for item in items:
                 # Check if the album art URI should be fully qualified
                 if full_album_art_uri:
-                    self.soco._update_album_art_to_full_uri(item)
+                    self._update_album_art_to_full_uri(item)
                 # Append the item to the list
                 item_list.append(item)
 
@@ -378,7 +388,7 @@ class MusicLibrary(object):
         for container in containers:
             # Check if the album art URI should be fully qualified
             if full_album_art_uri:
-                self.soco._update_album_art_to_full_uri(container)
+                self._update_album_art_to_full_uri(container)
             item_list.append(container)
 
         # pylint: disable=star-args

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -53,7 +53,7 @@ class MusicLibrary(object):
         self.soco = soco if soco is not None else discovery.any_soco()
         self.contentDirectory = self.soco.contentDirectory
 
-    def _build_album_art_full_uri(self, url):
+    def build_album_art_full_uri(self, url):
         """Ensure an Album Art URI is an absolute URI.
 
         Args:


### PR DESCRIPTION
I checked the changes I made in #542 and adjusted all calls to the now-removed methods. This is based on @amelchio's work on #576.
Closes #576.