### PR TITLE
Create full_album_art_uri property for DidlItem

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -32,6 +32,7 @@ import sys
 import textwrap
 import warnings
 
+from .discovery import any_soco
 from .compat import with_metaclass
 from .exceptions import DIDLMetadataError
 from .utils import really_unicode
@@ -722,6 +723,16 @@ class DidlItem(DidlObject):
             'album_art_uri': ('upnp', 'albumArtURI'),
         }
     )
+
+    @property
+    def full_album_art_uri(self):
+        """str: The absolute album art uri.
+
+        This will use the IP address of a random player on the network.
+        """
+        library = any_soco().music_library
+        album_art_uri = getattr(self, 'album_art_uri')
+        return library.build_album_art_full_uri(album_art_uri)
 
 
 class DidlAudioItem(DidlItem):


### PR DESCRIPTION
Sonos uses a relative path for its album art uris. This means that the user has to call build_album_art_full_uri() (which is currently being moved) before invoking the URI. Some, but not all methods automatically upgrade the uri, creating an inconsistency.
This PR tries to solve this by adding a full_album_art_uri property to DidlItem. It upgrades the album_art_uri using a SoCo instance from discovery.any_soco(). It assumes that #576 or #596 get merged first.