### PR TITLE
Turn Exception in from_element and to_element into DIDLMetadataError

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -160,7 +160,7 @@ class DidlResource(object):
                 try:
                     return int(result)
                 except ValueError:
-                    raise ValueError(
+                    raise DIDLMetadataError(
                         'Could not convert {0} to an integer'.format(name))
             else:
                 return None
@@ -169,8 +169,8 @@ class DidlResource(object):
         # required
         content['protocol_info'] = element.get('protocolInfo')
         if content['protocol_info'] is None:
-            raise Exception('Could not create Resource from Element: '
-                            'protocolInfo not found (required).')
+            raise DIDLMetadataError('Could not create Resource from Element: '
+                                    'protocolInfo not found (required).')
         # Optional
         content['import_uri'] = element.get('importUri')
         content['size'] = _int_helper('size')
@@ -200,8 +200,9 @@ class DidlResource(object):
             ~xml.etree.ElementTree.Element: an Element.
         """
         if not self.protocol_info:
-            raise Exception('Could not create Element for this resource: '
-                            'protocolInfo not set (required).')
+            raise DIDLMetadataError('Could not create Element for this'
+                                    'resource:'
+                                    'protocolInfo not set (required).')
         root = XML.Element('res')
 
         # Required


### PR DESCRIPTION
This PR turns Exceptions and ValueErrors which are raised in from_didl_string into DIDLMetadataErrors, allowing them to be caught in the event handling code. See [#567](https://github.com/SoCo/SoCo/pull/567#issuecomment-370102539) for why this is necessary.