### PR TITLE
Event advertisement IP config

### DIFF
--- a/soco/config.py
+++ b/soco/config.py
@@ -30,6 +30,15 @@ See also:
     The :mod:`soco.cache` module.
 """
 
++EVENT_ADVERTISE_IP = None
+"""The IP on which to advertise to Sonos.
+
+The default of None means that the relevant IP address will be detected
+automatically.
+
+See also:
+    The :mod:`soco.events` module.
+"""
 
 EVENT_LISTENER_IP = None
 """The IP on which the event listener listens.

--- a/soco/events.py
+++ b/soco/events.py
@@ -472,6 +472,10 @@ class Subscription(object):
 
         # pylint: disable=unbalanced-tuple-unpacking
         ip_address, port = event_listener.address
+
+        if config.EVENT_ADVERTISE_IP:
+            ip_address = config.EVENT_ADVERTISE_IP
+
         headers = {
             'Callback': '<http://{}:{}>'.format(ip_address, port),
             'NT': 'upnp:event'


### PR DESCRIPTION
Recreated https://github.com/SoCo/SoCo/pull/450 to allow configuration of event advertisement IP.