### PR TITLE
Remove warning about missing track title

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1185,8 +1185,6 @@ class SoCo(_SocoSingletonBase):
                 track['title'] = metadata.findtext('.//{http://purl.org/dc/'
                                                    'elements/1.1/}title')
                 if not track['title']:
-                    _LOG.warning('Could not handle track info: "%s"',
-                                 trackinfo)
                     track['title'] = trackinfo
 
         # If the speaker is playing from the line-in source, querying for track


### PR DESCRIPTION
I think simply removing this warning is in line with the amount of logging generally used in soco.core but I can change it to merely downgrade the severity if you prefer?

Reported in home-assistant/home-assistant#13413: _Noticed when streaming from Amazon Music sources. On each track change, soco.core dumps warnings_
