### PR TITLE
Added support for object.item.audioItem.audioBook

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -764,6 +764,24 @@ class DidlMusicTrack(DidlAudioItem):
     )
 
 
+class DidlAudioBook(DidlAudioItem):
+
+    """Class that represents a music library track."""
+
+    # the DIDL Lite class for this object.
+    item_class = 'object.item.audioItem.audioBook'
+    # name: (ns, tag)
+    _translation = DidlAudioItem._translation.copy()
+    _translation.update(
+        {
+            'storageMedium': ('upnp', 'storageMedium'),
+            'producer': ('upnp', 'producer'),
+            'contributor': ('dc', 'contributor'),
+            'date': ('dc', 'date'),
+        }
+    )
+
+
 class DidlAudioBroadcast(DidlAudioItem):
 
     """Class that represents an audio broadcast."""

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -766,7 +766,7 @@ class DidlMusicTrack(DidlAudioItem):
 
 class DidlAudioBook(DidlAudioItem):
 
-    """Class that represents a music library track."""
+    """Class that represents an audio book."""
 
     # the DIDL Lite class for this object.
     item_class = 'object.item.audioItem.audioBook'


### PR DESCRIPTION
The DidlObject hierarchy is missing a class for object.item.audioItem.audioBook.
This results in errors, as described in #616.

This PR creates the corresponding DidlAudioBook class, using the protocol information from page 155 of the [ContentDirectory spec](http://upnp.org/specs/av/UPnP-av-ContentDirectory-v2-Service.pdf).

Closes #616.