### PR TITLE
Downgrade the severity of SoCoFault logging

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -146,11 +146,11 @@ def parse_event_xml(xml_event):
                         try:
                             value = from_didl_string(value)[0]
                         except SoCoException as original_exception:
-                            log.warning("Event contains illegal metadata"
-                                        "for '%s'.\n"
-                                        "Error message: '%s'\n"
-                                        "The result will be a SoCoFault.",
-                                        tag, str(original_exception))
+                            log.debug("Event contains illegal metadata"
+                                      "for '%s'.\n"
+                                      "Error message: '%s'\n"
+                                      "The result will be a SoCoFault.",
+                                      tag, str(original_exception))
                             event_parse_exception = EventParseException(
                                 tag, value, original_exception
                             )


### PR DESCRIPTION
It seems reasonable to keep the log quiet when users cannot do anything about the situation.