### PR TITLE
Remove logging of UPnP failures

### DIFF
--- a/soco/services.py
+++ b/soco/services.py
@@ -494,11 +494,7 @@ class Service(object):
             # Internal server error. UPnP requires this to be returned if the
             # device does not like the action for some reason. The returned
             # content will be a SOAP Fault. Parse it and raise an error.
-            try:
-                self.handle_upnp_error(response.text)
-            except Exception as exc:
-                log.exception(str(exc))
-                raise
+            self.handle_upnp_error(response.text)
         else:
             # Something else has gone wrong. Probably a network error. Let
             # Requests handle it


### PR DESCRIPTION
This unconditional logging created noise for reasonable situations such as trying to skip the last track. Since we already raise an exception, just let the client decide how it should be handled.