### PR TITLE
Added household_id as optional parameter. 

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -19,7 +19,11 @@ _LOG = logging.getLogger(__name__)
 # pylint: disable=too-many-locals, too-many-branches
 
 
-def discover(timeout=5, include_invisible=False, interface_addr=None):
+def discover(
+        timeout=5,
+        include_invisible=False,
+        interface_addr=None,
+        household_id="Sonos"):
     """ Discover Sonos zones on the local network.
 
     Return a set of `SoCo` instances for each zone found.
@@ -40,6 +44,10 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
             the system default interface for UDP multicast messages will be
             used. This is probably what you want to happen. Defaults to
             `None`.
+        household_id (str or "Sonos"): returns only instance where the
+            household_id is the same as the specified. If default or not
+            specified it will return the first to responde. Defaults to
+            'Sonos'.
     Returns:
         set: a set of `SoCo` instances, one for each zone found, or else
             `None`.

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -172,7 +172,7 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
                 _LOG.debug(
                     'Received discovery response from %s: "%s"', addr, data
                 )
-                if b"Sonos" in data:
+                if really_utf8(household_id) in data:
                     # Now we have an IP, we can build a SoCo instance and query
                     # that player for the topology to find the other players.
                     # It is much more efficient to rely upon the Zone


### PR DESCRIPTION
Use byte code b'Sonos_7O********************R7eU' from X-RINCON-HOUSEHOLD: Sonos_7O********************R7eU.