### PR TITLE
Add DidlPlaylistContainerTracklist to data_structures.py

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1055,6 +1055,12 @@ class DidlPlaylistContainerFavorite(DidlPlaylistContainer):
     item_class = 'object.container.playlistContainer.sonos-favorite'
 
 
+class DidlPlaylistContainerTracklist(DidlPlaylistContainer):
+
+    """Class that represents a Sonos tracklist."""
+    item_class = 'object.container.playlistContainer.tracklist'
+
+
 class DidlGenre(DidlContainer):
 
     """A content directory class representing a general genre."""


### PR DESCRIPTION
This adds a simple DidlPlaylistContainerTracklist class to data_structures.py. The class is used by Sonos when Sonos Speakers are controlled by Spotify Connect. The absence of the class from data_structures.py causes errors.