### PR TITLE
Make zone-group-state cache per-household

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -380,14 +380,6 @@ def scan_network(
         _LOG.info("No Sonos zones discovered")
         return None
 
-    # Disable caching to prevent problems with the list of zones
-    # if there are multiple households
-    if multi_household:
-        original_cache_state = core.zone_group_state_shared_cache.enabled
-        if original_cache_state:
-            core.zone_group_state_shared_cache.enabled = False
-            _LOG.info("Disabled SoCo caching")
-
     # Collect SoCo instances
     zones = set()
     for ip_address in sonos_ip_addresses:
@@ -401,12 +393,6 @@ def scan_network(
         # all zones across all households
         if not multi_household:
             break
-
-    # Restore the original cache state if required
-    if multi_household:
-        if original_cache_state:
-            core.zone_group_state_shared_cache.enabled = True
-            _LOG.info("Re-enabled SoCo caching")
 
     _LOG.info(
         "Include_invisible: %s | multi_household: %s | %d Zones: %s",

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -16,7 +16,6 @@ import ifaddr
 
 from . import config
 from .utils import really_utf8
-from . import core
 
 _LOG = logging.getLogger(__name__)
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -94,13 +94,6 @@ class Vartype(namedtuple('VartypeBase', 'datatype, default, list, range')):
         return self.datatype
 
 
-# A shared cache for ZoneGroupState. Each zone has the same info, so when a
-# SoCo instance is asked for group info, we can cache it and return it when
-# another instance is asked. To do this we need a cache to be shared between
-# instances
-zone_group_state_shared_cache = Cache()
-
-
 # pylint: disable=too-many-instance-attributes
 class Service(object):
 
@@ -781,12 +774,6 @@ class ZoneGroupTopology(Service):
 
     """Sonos zone group topology service, for functions relating to network
     topology, diagnostics and updates."""
-
-    def GetZoneGroupState(self, *args, **kwargs):
-        """Overrides default handling to use the global shared zone group state
-        cache, unless another cache is specified."""
-        kwargs['cache'] = kwargs.get('cache', zone_group_state_shared_cache)
-        return self.send_command('GetZoneGroupState', *args, **kwargs)
 
 
 class GroupManagement(Service):


### PR DESCRIPTION
I am trying to enable multi-household control. A blocker for this is that we currently maintain a global state cache that is invalid when a speaker from a different household is accessed.

This PR removes the global variable and makes the cache per-household.

I moved 10.0.2.14 ("Test") to a separate household. Before this PR:
```
$ python -c 'import soco; a = soco.SoCo("10.0.2.18"); b = soco.SoCo("10.0.2.14"); print(a.player_name); print(b.player_name);'
Kitchen
None
```

After this PR:
```
$ python -c 'import soco; a = soco.SoCo("10.0.2.18"); b = soco.SoCo("10.0.2.14"); print(a.player_name); print(b.player_name);'
Kitchen
Test
```
