### PR TITLE
Remove pytest-cov upper bound

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ graphviz
 flake8
 pylint >= 1.4
 coveralls
-pytest-cov>=2.4.0,<2.6
+pytest-cov>=2.4.0
 wheel


### PR DESCRIPTION
Works just fine with 2.6.* and 2.7.* versions