### PR TITLE
Adds the SoCo.set_relative_volume() method.

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -488,6 +488,12 @@ class SoCo(_SocoSingletonBase):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
+        This method is an alternative to using increment and decrement
+        assignment operators (+=, -=) on the `volume` property of a `SoCo`
+        instance. These operators perform the same function as
+        `set_relative_volume()` but require two network calls per operation
+        instead of one.
+
         Args:
             relative_volume (int): The relative volume adjustment. Can be
                 positive or negative.
@@ -495,8 +501,6 @@ class SoCo(_SocoSingletonBase):
         Returns:
             int: The new volume setting.
         """
-        # Coerce to within the range -100 to +100
-        relative_volume = max(-100, min(relative_volume, 100))
         response = self.renderingControl.SetRelativeVolume([
             ('InstanceID', 0),
             ('Channel', 'Master'),

--- a/soco/core.py
+++ b/soco/core.py
@@ -133,6 +133,7 @@ class SoCo(_SocoSingletonBase):
         play_mode
         cross_fade
         ramp_to_volume
+        set_relative_volume
         get_current_track_info
         get_speaker_info
         get_current_transport_info
@@ -478,6 +479,30 @@ class SoCo(_SocoSingletonBase):
             ('ProgramURI', '')
         ])
         return int(response['RampTime'])
+
+    def set_relative_volume(self, relative_volume):
+        """Adjust the volume up or down by a relative amount.
+
+        If the adjustment causes the volume to overshoot the maximum value
+        of 100, the volume will be set to 100. If the adjustment causes the
+        volume to undershoot the minimum value of 0, the volume will be set
+        to 0.
+
+        Args:
+            relative_volume (int): The relative volume adjustment. Can be
+                positive or negative.
+
+        Returns:
+            int: The new volume setting.
+        """
+        # Coerce to within the range -100 to +100
+        relative_volume = max(-100, min(relative_volume, 100))
+        response = self.renderingControl.SetRelativeVolume([
+            ('InstanceID', 0),
+            ('Channel', 'Master'),
+            ('Adjustment', relative_volume)
+        ])
+        return int(response['NewVolume'])
 
     @only_on_master
     def play_from_queue(self, index, start=True):

--- a/soco/core.py
+++ b/soco/core.py
@@ -488,9 +488,9 @@ class SoCo(_SocoSingletonBase):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
-        This method is an alternative to using addition and subtraction
-        assignment operators (+=, -=) on the `volume` property of a `SoCo`
-        instance. These operators perform the same function as
+        Note that this method is an alternative to using addition and
+        subtraction assignment operators (+=, -=) on the `volume` property
+        of a `SoCo` instance. These operators perform the same function as
         `set_relative_volume()` but require two network calls per operation
         instead of one.
 
@@ -500,6 +500,9 @@ class SoCo(_SocoSingletonBase):
 
         Returns:
             int: The new volume setting.
+
+        Raises:
+            ValueError: If `relative_volume` cannot be cast as an integer.
         """
         relative_volume = int(relative_volume)
         # Sonos will automatically handle out-of-range adjustments

--- a/soco/core.py
+++ b/soco/core.py
@@ -488,7 +488,7 @@ class SoCo(_SocoSingletonBase):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
-        This method is an alternative to using increment and decrement
+        This method is an alternative to using addition and subtraction
         assignment operators (+=, -=) on the `volume` property of a `SoCo`
         instance. These operators perform the same function as
         `set_relative_volume()` but require two network calls per operation

--- a/soco/core.py
+++ b/soco/core.py
@@ -501,6 +501,8 @@ class SoCo(_SocoSingletonBase):
         Returns:
             int: The new volume setting.
         """
+        relative_volume = int(relative_volume)
+        # Sonos will automatically handle out-of-range adjustments
         response = self.renderingControl.SetRelativeVolume([
             ('InstanceID', 0),
             ('Channel', 'Master'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1028,6 +1028,14 @@ class TestRenderingControl:
         )
         assert ramp_time == 12
 
+    def test_set_relative_volume(self, moco):
+        moco.renderingControl.SetRelativeVolume.return_value = {'NewVolume': '75'}
+        new_volume = moco.set_relative_volume(25)
+        moco.renderingControl.SetRelativeVolume.assert_called_once_with(
+            [('InstanceID', 0), ('Channel', 'Master'), ('Adjustment', 25)]
+        )
+        assert new_volume == 75
+
     def test_soco_treble(self, moco):
         moco.renderingControl.GetTreble.return_value = {'CurrentTreble': '15'}
         assert moco.treble == 15


### PR DESCRIPTION
This PR adds the `set_relative_volume()` method to the `SoCo` class.