### PR TITLE
Add group volume operations to SoCo

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1070,6 +1070,73 @@ class SoCo(_SocoSingletonBase):
         zone_group_state_shared_cache.clear()
         self._parse_zone_group_state()
 
+    @property
+    def group_volume(self):
+        """The volume of the group of which this speaker is a member.
+
+        An integer between 0 and 100.
+        """
+        response = self.groupRenderingControl.GetGroupVolume([
+            ('InstanceID', 0)
+        ])
+        return int(response['CurrentVolume'])
+
+    @group_volume.setter
+    def group_volume(self, group_volume):
+        group_volume = int(group_volume)
+        group_volume = max(0, min(group_volume, 100))  # Coerce in range
+        self.groupRenderingControl.SetGroupVolume([
+            ('InstanceID', 0),
+            ('DesiredVolume', group_volume)
+        ])
+
+    @property
+    def group_mute(self):
+        """The group mute state for the group of which this speaker
+        is a member.
+
+        True or False.
+        """
+        response = self.groupRenderingControl.GetGroupMute([
+            ('InstanceID', 0)
+        ])
+        return bool(response['CurrentMute'])
+
+    @group_mute.setter
+    def group_mute(self, group_mute):
+        group_mute = bool(group_mute)
+        self.groupRenderingControl.SetGroupMute([
+            ('InstanceID', 0),
+            ('DesiredMute', group_mute)
+        ])
+
+    @only_on_master
+    def set_relative_group_volume(self, relative_group_volume):
+        """Adjust the group volume up or down by a relative amount.
+
+        Makes a relative adjustment for the group of which this speaker is
+        the coordinator.
+
+        If the adjustment causes the volume to overshoot the maximum value
+        of 100, the volume will be set to 100. If the adjustment causes the
+        volume to undershoot the minimum value of 0, the volume will be set
+        to 0.
+
+        Args:
+            relative_group_volume (int): The relative volume adjustment. Can be
+                positive or negative.
+
+        Returns:
+            int: The new group volume setting.
+        """
+        # Coerce to within the range -100 to +100
+        relative_group_volume = max(-100, min(relative_group_volume, 100))
+        response = self.groupRenderingControl.SetRelativeGroupVolume([
+            ('InstanceID', 0),
+            ('Adjustment', relative_group_volume)
+        ])
+        return int(response['NewVolume'])
+
     def switch_to_line_in(self, source=None):
         """ Switch the speaker's input to line-in.
 
@@ -1977,46 +2044,6 @@ class SoCo(_SocoSingletonBase):
                 return sonos_playlist
         raise ValueError('No match on "{0}" for value "{1}"'.format(attr_name,
                                                                     match))
-
-    @property
-    def group_volume(self):
-        """The volume of the group of which the speaker is a member.
-
-        An integer between 0 and 100.
-        """
-        response = self.groupRenderingControl.GetGroupVolume([
-            ('InstanceID', 0)
-        ])
-        return int(response['CurrentVolume'])
-
-    @group_volume.setter
-    def group_volume(self, group_volume):
-        group_volume = int(group_volume)
-        group_volume = max(0, min(group_volume, 100))  # Coerce in range
-        self.groupRenderingControl.SetGroupVolume([
-            ('InstanceID', 0),
-            ('DesiredVolume', group_volume)
-        ])
-
-    @property
-    def group_mute(self):
-        """The group mute state.
-
-        True or False.
-        """
-        response = self.groupRenderingControl.GetGroupMute([
-            ('InstanceID', 0)
-        ])
-        return bool(response['CurrentMute'])
-
-    @group_mute.setter
-    def group_mute(self, group_mute):
-        group_mute = bool(group_mute)
-        self.groupRenderingControl.SetGroupMute([
-            ('InstanceID', 0),
-            ('DesiredMute', group_mute)
-        ])
-
 
 
 # definition section

--- a/soco/core.py
+++ b/soco/core.py
@@ -158,9 +158,6 @@ class SoCo(_SocoSingletonBase):
         all_groups
         all_zones
         visible_zones
-        group_volume
-        group_mute
-        set_relative_group_volume
 
     ..  rubric:: Player Identity and Settings
     ..  autosummary::
@@ -1069,77 +1066,6 @@ class SoCo(_SocoSingletonBase):
         ])
         zone_group_state_shared_cache.clear()
         self._parse_zone_group_state()
-
-    @property
-    def group_volume(self):
-        """The volume of the group of which this speaker is a member.
-
-        An integer between 0 and 100.
-        """
-        response = self.groupRenderingControl.GetGroupVolume([
-            ('InstanceID', 0)
-        ])
-        return int(response['CurrentVolume'])
-
-    @group_volume.setter
-    def group_volume(self, group_volume):
-        group_volume = int(group_volume)
-        group_volume = max(0, min(group_volume, 100))  # Coerce in range
-        self.groupRenderingControl.SetGroupVolume([
-            ('InstanceID', 0),
-            ('DesiredVolume', group_volume)
-        ])
-
-    @property
-    def group_mute(self):
-        """The group mute state for the group of which this speaker
-        is a member.
-
-        True or False.
-        """
-        response = self.groupRenderingControl.GetGroupMute([
-            ('InstanceID', 0)
-        ])
-        return bool(response['CurrentMute'])
-
-    @group_mute.setter
-    def group_mute(self, group_mute):
-        group_mute = bool(group_mute)
-        self.groupRenderingControl.SetGroupMute([
-            ('InstanceID', 0),
-            ('DesiredMute', group_mute)
-        ])
-
-    @only_on_master
-    def set_relative_group_volume(self, relative_group_volume):
-        """Adjust the group volume up or down by a relative amount.
-
-        Makes a relative adjustment for the group of which this speaker is
-        the coordinator.
-
-        If the adjustment causes the volume to overshoot the maximum value
-        of 100, the volume will be set to 100. If the adjustment causes the
-        volume to undershoot the minimum value of 0, the volume will be set
-        to 0.
-
-        This method is an alternative to using addition and subtraction
-        assignment operators (+=, -=) on the `group_volume` property of a
-        `SoCo` instance. These operators perform the same function as
-        `set_relative_group_volume()` but require two network calls per
-        operation instead of one.
-
-        Args:
-            relative_group_volume (int): The relative volume adjustment. Can be
-                positive or negative.
-
-        Returns:
-            int: The new group volume setting.
-        """
-        response = self.groupRenderingControl.SetRelativeGroupVolume([
-            ('InstanceID', 0),
-            ('Adjustment', relative_group_volume)
-        ])
-        return int(response['NewVolume'])
 
     def switch_to_line_in(self, source=None):
         """ Switch the speaker's input to line-in.

--- a/soco/core.py
+++ b/soco/core.py
@@ -1122,7 +1122,7 @@ class SoCo(_SocoSingletonBase):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
-        This method is an alternative to using increment and decrement
+        This method is an alternative to using addition and subtraction
         assignment operators (+=, -=) on the `group_volume` property of a
         `SoCo` instance. These operators perform the same function as
         `set_relative_group_volume()` but require two network calls per

--- a/soco/core.py
+++ b/soco/core.py
@@ -1122,6 +1122,12 @@ class SoCo(_SocoSingletonBase):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
+        This method is an alternative to using increment and decrement
+        assignment operators (+=, -=) on the `group_volume` property of a
+        `SoCo` instance. These operators perform the same function as
+        `set_relative_group_volume()` but require two network calls per
+        operation instead of one.
+
         Args:
             relative_group_volume (int): The relative volume adjustment. Can be
                 positive or negative.
@@ -1129,8 +1135,6 @@ class SoCo(_SocoSingletonBase):
         Returns:
             int: The new group volume setting.
         """
-        # Coerce to within the range -100 to +100
-        relative_group_volume = max(-100, min(relative_group_volume, 100))
         response = self.groupRenderingControl.SetRelativeGroupVolume([
             ('InstanceID', 0),
             ('Adjustment', relative_group_volume)

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -192,7 +192,8 @@ class ZoneGroup(object):
             int: The new group volume setting.
 
         Raises:
-            ValueError: If `relative_group_volume` cannot be cast as an integer.
+            ValueError: If `relative_group_volume` cannot be cast as
+                an integer.
         """
         relative_group_volume = int(relative_group_volume)
         # Sonos automatically handles out-of-range values.

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -132,7 +132,7 @@ class ZoneGroup(object):
 
     @property
     def volume(self):
-        """The volume of the group.
+        """int: The volume of the group.
 
         An integer between 0 and 100.
         """
@@ -152,7 +152,7 @@ class ZoneGroup(object):
 
     @property
     def mute(self):
-        """The mute state for the group.
+        """bool: The mute state for the group.
 
         True or False.
         """

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -66,9 +66,15 @@ class ZoneGroup(object):
     relative adjustments to the group volume, e.g.:
 
         >>> device.group.volume = 25
-        >>> device.group.mute = False
+        >>> device.group.volume
+        25
         >>> device.group.set_relative_volume(-10)
         15
+        >>> device.group.mute
+        >>> False
+        >>> device.group.mute = True
+        >>> device.group.mute
+        True
     """
 
     def __init__(self, uid, coordinator, members=None):
@@ -172,10 +178,10 @@ class ZoneGroup(object):
         volume to undershoot the minimum value of 0, the volume will be set
         to 0.
 
-        This method is an alternative to using addition and subtraction
-        assignment operators (+=, -=) on the `volume` property of a
-        `ZoneGroup` instance. These operators perform the same function as
-        `set_relative_volume()` but require two network calls per
+        Note that this method is an alternative to using addition and
+        subtraction assignment operators (+=, -=) on the `volume` property
+        of a `ZoneGroup` instance. These operators perform the same function
+        as `set_relative_volume()` but require two network calls per
         operation instead of one.
 
         Args:
@@ -184,7 +190,12 @@ class ZoneGroup(object):
 
         Returns:
             int: The new group volume setting.
+
+        Raises:
+            ValueError: If `relative_group_volume` cannot be cast as an integer.
         """
+        relative_group_volume = int(relative_group_volume)
+        # Sonos automatically handles out-of-range values.
         resp = self.coordinator.groupRenderingControl.SetRelativeGroupVolume([
             ('InstanceID', 0),
             ('Adjustment', relative_group_volume)

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -60,6 +60,15 @@ class ZoneGroup(object):
 
     A consistent readable label for the group members can be returned with
     the `label` and `short_label` properties.
+
+    Properties are available to get and set the group `volume` and the group
+    `mute` state, and the `set_relative_volume()` method can be used to make
+    relative adjustments to the group volume, e.g.:
+
+        >>> device.group.volume = 25
+        >>> device.group.mute = False
+        >>> device.group.set_relative_volume(-10)
+        15
     """
 
     def __init__(self, uid, coordinator, members=None):
@@ -114,3 +123,70 @@ class ZoneGroup(object):
         if len(group_names) > 1:
             group_label += " + {}".format(len(group_names) - 1)
         return group_label
+
+    @property
+    def volume(self):
+        """The volume of the group.
+
+        An integer between 0 and 100.
+        """
+        response = self.coordinator.groupRenderingControl.GetGroupVolume([
+            ('InstanceID', 0)
+        ])
+        return int(response['CurrentVolume'])
+
+    @volume.setter
+    def volume(self, group_volume):
+        group_volume = int(group_volume)
+        group_volume = max(0, min(group_volume, 100))  # Coerce in range
+        self.coordinator.groupRenderingControl.SetGroupVolume([
+            ('InstanceID', 0),
+            ('DesiredVolume', group_volume)
+        ])
+
+    @property
+    def mute(self):
+        """The mute state for the group.
+
+        True or False.
+        """
+        response = self.coordinator.groupRenderingControl.GetGroupMute([
+            ('InstanceID', 0)
+        ])
+        mute_state = response['CurrentMute']
+        return bool(int(mute_state))
+
+    @mute.setter
+    def mute(self, group_mute):
+        mute_value = '1' if group_mute else '0'
+        self.coordinator.groupRenderingControl.SetGroupMute([
+            ('InstanceID', 0),
+            ('DesiredMute', mute_value)
+        ])
+
+    def set_relative_volume(self, relative_group_volume):
+        """Adjust the group volume up or down by a relative amount.
+
+        If the adjustment causes the volume to overshoot the maximum value
+        of 100, the volume will be set to 100. If the adjustment causes the
+        volume to undershoot the minimum value of 0, the volume will be set
+        to 0.
+
+        This method is an alternative to using addition and subtraction
+        assignment operators (+=, -=) on the `volume` property of a
+        `ZoneGroup` instance. These operators perform the same function as
+        `set_relative_volume()` but require two network calls per
+        operation instead of one.
+
+        Args:
+            relative_group_volume (int): The relative volume adjustment. Can be
+                positive or negative.
+
+        Returns:
+            int: The new group volume setting.
+        """
+        resp = self.coordinator.groupRenderingControl.SetRelativeGroupVolume([
+            ('InstanceID', 0),
+            ('Adjustment', relative_group_volume)
+        ])
+        return int(resp['NewVolume'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1149,7 +1149,7 @@ class TestZoneGroupTopology:
         assert isinstance(moco_zgs.group, ZoneGroup)
         assert moco_zgs in moco_zgs.group
 
-    def test_all_zones(self, moco_zgs):
+    def test_all_zones(selfself, moco_zgs):
         zones = moco_zgs.all_zones
         assert len(zones) == 4
         assert len(set(zones)) == 4
@@ -1157,7 +1157,7 @@ class TestZoneGroupTopology:
             assert isinstance(zone, SoCo)
         assert moco_zgs in zones
 
-    def test_visible_zones(self, moco_zgs):
+    def test_visible_zones(selfself, moco_zgs):
         zones = moco_zgs.visible_zones
         assert len(zones) == 4
         assert len(set(zones)) == 4
@@ -1165,7 +1165,7 @@ class TestZoneGroupTopology:
             assert isinstance(zone, SoCo)
         assert moco_zgs in zones
 
-    def test_group_label(self, moco_zgs):
+    def test_group_label(selfself, moco_zgs):
         g = moco_zgs.group
         # Have to mock out group members zone group state here since
         # g.members is parsed from the XML.
@@ -1175,7 +1175,7 @@ class TestZoneGroupTopology:
             }
         assert g.label == "Kitchen, Living Room"
 
-    def test_group_short_label(self, moco_zgs):
+    def test_group_short_label(selfself, moco_zgs):
         g = moco_zgs.group
         # Have to mock out group members zone group state here since
         # g.members is parsed from the XML.
@@ -1204,7 +1204,7 @@ class TestZoneGroupTopology:
         g = moco_zgs.group
         c = moco_zgs.group.coordinator
         c.groupRenderingControl.GetGroupMute.return_value = {
-            'CurrentMute': 0
+            'CurrentMute': '0'
         }
         assert g.mute is False
         c.groupRenderingControl.GetGroupMute.assert_called_once_with(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1215,7 +1215,7 @@ class TestZoneGroupTopology:
             [('InstanceID', 0), ('DesiredMute', '1')]
         )
 
-    def test_set_relative_volume(self, moco_zgs):
+    def test_set_relative_group_volume(self, moco_zgs):
         g = moco_zgs.group
         c = moco_zgs.group.coordinator
         c.groupRenderingControl.SetRelativeGroupVolume.return_value = {


### PR DESCRIPTION
This PR adds group `volume` and `mute` properties, and the group `set_relative_volume()` method, to the ZoneGroup class.