### PR TITLE
Add Python 2.7 deprecation warning

### DIFF
--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -10,6 +10,8 @@
 
 
 import logging
+import warnings
+import sys
 
 from .core import SoCo
 from .discovery import discover
@@ -36,3 +38,9 @@ __all__ = [
 # Avoids spurious error messages if no logger is configured by the user
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+if sys.version_info.major < 3:
+    warnings.warn(
+        "Version 0.19 of SoCo is the last to support Python 2.7",
+        stacklevel=2,
+    )


### PR DESCRIPTION
As per #591 there no longer seems to be any opposition against deprecation of Python 2.7 in SoCo. This PR adds a deprecation warning stating that SoCo 0.19 will be the last version to support Python 2.7.