### PR TITLE
Beginning of data structure quirks, fix for missing protocolInfo

### DIFF
--- a/soco/data_structure_quirks.py
+++ b/soco/data_structure_quirks.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""This module implements 'quirks' for the DIDL-Lite data structures
+
+A quirk, in this context, means that a specific music service does not follow
+a specific part of the DIDL-Lite specification. In order not to clutter the
+primary implementation of DIDL-Lite for SoCo (in :mod:`soco.data_structures`)
+up with all these service specific exception, they are implemented separately
+in this module. Besides from keeping the main implementation clean and
+following the specification, this has the added advantage of making it easier
+to track how many quiks are out there.
+
+The implementation of the quirks at this point is just a single function which
+applies quirks to the DIDL-Lite resources, with the options of adding one that
+applies them to DIDL-Lite objects.
+
+"""
+
+import logging
+
+
+_LOG = logging.getLogger(__name__)
+
+
+def apply_resource_quirks(resource):
+    """Apply DIDL-Lite resource quirks"""
+    # At least two music service (Spotify Direct and Amazon in conjunction
+    # with Alexa) has been known not to supply the mandatory protocolInfo, so
+    # if it is missing supply a dummy one
+    if 'protocolInfo' not in resource.attrib:
+        protocol_info = 'DUMMY_ADDED_BY_QUIRK'
+        # For Spotify direct we have a better idea what it should be, since it
+        # is included in the main element text
+        if resource.text and resource.text.startswith("x-sonos-spotify"):
+            protocol_info = "sonos.com-spotify:*:audio/x-spotify.*"
+
+        _LOG.debug(
+            "Resource quirk applied for missing protocolInfo, setting to '%s'",
+            protocol_info,
+        )
+        resource.set('protocolInfo', protocol_info)
+
+    return resource

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -41,6 +41,7 @@ from .utils import really_unicode
 from .xml import (
     XML, ns_tag
 )
+from .data_structure_quirks import apply_resource_quirks
 
 # Due to cyclic import problems, we only import from_didl_string at runtime.
 # from data_structures_entry import from_didl_string
@@ -167,6 +168,9 @@ class DidlResource(object):
                         'Could not convert {0} to an integer'.format(name))
             else:
                 return None
+
+        # Check for and fix non-spec compliant behavior in the incoming data
+        element = apply_resource_quirks(element)
 
         content = {}
         # required


### PR DESCRIPTION
For a long time it has annoyed me, that I couldn't find a compromise I was happy with, between keeping the implementation of DIDL-Lite in data_structures.py specification compliant and at the same time allowing service specific fixes for non spec-compliant behavior. Now I have a proposal for one.

As is usually the case, I didn't make it up, but simply borrowed a solution for cleverer people. I think it was in the realm of graphics card drivers or 3D library implementations for games that I first heard of the idea of quirks, as a way of (separately) implementing exceptions for specific hardware or games that behaves differently from what they are supposed to and I thought that would be a good solutions for us.

In the long run, the idea is to pull the DIDL-Lite implementation in data_structures.py back towards spec compliance and then specifying fixes for all non spec-compliant behavior in data_structure_quirks by manipulating the XML before it is processed. This has the added advantage of allowing us to easily track all the exception we have implemented, instead of them being scattered in the main implementation.

At current the module consist only of the `apply_resource_quirks` function with a crude fix for missing protocolInfo, but there will in the future also be a `apply_object_quirks` function to take care of that.

Let me know what you think of the idea?