### PR TITLE
Fix quirks implementation

### DIFF
--- a/soco/data_structure_quirks.py
+++ b/soco/data_structure_quirks.py
@@ -40,4 +40,6 @@ def apply_resource_quirks(resource):
         )
         resource.set('protocolInfo', protocol_info)
 
+        if not resource.text:
+            resource.text = ""
     return resource


### PR DESCRIPTION
If protocol_info gets set manually we also have to make sure that
resource.text is defined otherwise we run into issues later on.