### PR TITLE
Fix for missing audioitem.linein DIDL data structure

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -755,6 +755,25 @@ class DidlAudioItem(DidlItem):
         }
     )
 
+class DidlAudioItemLineIn(DidlItem):
+
+    """A line-in audio item."""
+
+    # the DIDL Lite class for this object.
+    item_class = 'object.item.audioItem.linein'
+    _translation = DidlItem._translation.copy()
+    _translation.update(
+        {
+            'genre': ('upnp', 'genre'),
+            'description': ('dc', 'description'),
+            'long_description': ('upnp', 'longDescription'),
+            'publisher': ('dc', 'publisher'),
+            'language': ('dc', 'language'),
+            'relation': ('dc', 'relation'),
+            'rights': ('dc', 'rights'),
+        }
+    )
+
 
 class DidlMusicTrack(DidlAudioItem):
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -755,6 +755,7 @@ class DidlAudioItem(DidlItem):
         }
     )
 
+
 class DidlAudioItemLineIn(DidlItem):
 
     """A line-in audio item."""


### PR DESCRIPTION
I've recently started using the Line-in on my Sonos Connect, and Soco crashes with an unknown data structure type.  It claims to be a subset of AudioItem, so I simply copied over that object and tacked on the linein designator.

This is another case where SoCo should probably just roll-up to the parent object when encountering subclasses rather than maintaining a hardline on DIDL compliance since that is clearly not a priority for Sonos (see my previous comments around lack of ProtocolID and other stuff being addressed by quirks).  

But since there are fewer examples of the . subclassing than # subclassing and line-in is a common feature across several Sonos devices, it makes sense to target this one directly.