### PR TITLE
Paint soco black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - pylint soco
   - py.test --cov-config .coveragerc --cov soco .
-  - black --check soco tests
+  - if [ `python -c "from __future__ import print_function;import sys;print(int(sys.version_info.major==3 and sys.version_info.minor>=6 and sys.implementation.name == 'cpython'))"` -gt 0 ];then black --check soco tests;fi
 
 after_script:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - pylint soco
   - py.test --cov-config .coveragerc --cov soco .
+  - black --check soco tests
 
 after_script:
   - coveralls

--- a/examples/play_local_files/play_local_files.py
+++ b/examples/play_local_files/play_local_files.py
@@ -25,18 +25,21 @@ import time
 import socket
 from threading import Thread
 from random import choice
+
 try:
     # Python 3
     from urllib.parse import quote
     from http.server import SimpleHTTPRequestHandler
     from socketserver import TCPServer
-    print('Running as python 3')
+
+    print("Running as python 3")
 except ImportError:
     # Python 2
     from urllib import quote
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from SocketServer import TCPServer
-    print('Running as python 2')
+
+    print("Running as python 2")
 
 from soco.discovery import by_name, discover
 
@@ -52,12 +55,12 @@ class HttpServer(Thread):
 
     def run(self):
         """Start the server"""
-        print('Start HTTP server')
+        print("Start HTTP server")
         self.httpd.serve_forever()
 
     def stop(self):
         """Stop the server"""
-        print('Stop HTTP server')
+        print("Stop HTTP server")
         self.httpd.socket.close()
 
 
@@ -67,20 +70,18 @@ def add_random_file_from_present_folder(machine_ip, port, zone):
     # below the current folder whose extension does not start with .py
     # This will probably need to be modded for other pusposes.
     music_files = []
-    print('Looking for music files')
-    for path, dirs, files in os.walk('.'):
+    print("Looking for music files")
+    for path, dirs, files in os.walk("."):
         for file_ in files:
-            if not os.path.splitext(file_)[1].startswith('.py'):
+            if not os.path.splitext(file_)[1].startswith(".py"):
                 music_files.append(os.path.relpath(os.path.join(path, file_)))
-                print('Found:', music_files[-1])
+                print("Found:", music_files[-1])
 
     random_file = choice(music_files)
     # urlencode all the path parts (but not the /'s)
-    random_file = os.path.join(
-        *[quote(part) for part in os.path.split(random_file)]
-    )
-    print('\nPlaying random file:', random_file)
-    netpath = 'http://{}:{}/{}'.format(machine_ip, port, random_file)
+    random_file = os.path.join(*[quote(part) for part in os.path.split(random_file)])
+    print("\nPlaying random file:", random_file)
+    netpath = "http://{}:{}/{}".format(machine_ip, port, random_file)
 
     number_in_queue = zone.add_uri_to_queue(netpath)
     # play_from_queue indexes are 0-based
@@ -101,15 +102,20 @@ def detect_ip_address():
 def parse_args():
     """Parse the command line arguments"""
     import argparse
-    description = 'Play local files with Sonos by running a local web server'
+
+    description = "Play local files with Sonos by running a local web server"
     parser = argparse.ArgumentParser(description=description)
 
-    parser.add_argument('zone', help='The name of the zone to play from')
-    parser.add_argument('--port', default=8000,
-                        help='The local machine port to run the webser on')
-    parser.add_argument('--ip', default=detect_ip_address(),
-                        help='The local IP address of this machine. By '
-                        'default it will attempt to autodetect it.')
+    parser.add_argument("zone", help="The name of the zone to play from")
+    parser.add_argument(
+        "--port", default=8000, help="The local machine port to run the webser on"
+    )
+    parser.add_argument(
+        "--ip",
+        default=detect_ip_address(),
+        help="The local IP address of this machine. By "
+        "default it will attempt to autodetect it.",
+    )
 
     return parser.parse_args()
 
@@ -117,10 +123,12 @@ def parse_args():
 def main():
     # Settings
     args = parse_args()
-    print(" Will use the following settings:\n"
-          " Zone: {args.zone}\n"
-          " IP of this machine: {args.ip}\n"
-          " Use port: {args.port}".format(args=args))
+    print(
+        " Will use the following settings:\n"
+        " Zone: {args.zone}\n"
+        " IP of this machine: {args.ip}\n"
+        " Use port: {args.port}".format(args=args)
+    )
 
     # Get the zone
     zone = by_name(args.zone)
@@ -128,16 +136,22 @@ def main():
     # Check if a zone by the given name was found
     if zone is None:
         zone_names = [zone_.player_name for zone_ in discover()]
-        print("No Sonos player named '{}'. Player names are {}"\
-              .format(args.zone, zone_names))
+        print(
+            "No Sonos player named '{}'. Player names are {}".format(
+                args.zone, zone_names
+            )
+        )
         sys.exit(1)
 
     # Check whether the zone is a coordinator (stand alone zone or
     # master of a group)
     if not zone.is_coordinator:
-        print("The zone '{}' is not a group master, and therefore cannot "
-              "play music. Please use '{}' in stead"\
-              .format(args.zone, zone.group.coordinator.player_name))
+        print(
+            "The zone '{}' is not a group master, and therefore cannot "
+            "play music. Please use '{}' in stead".format(
+                args.zone, zone.group.coordinator.player_name
+            )
+        )
         sys.exit(2)
 
     # Setup and start the http server
@@ -152,8 +166,9 @@ def main():
         add_random_file_from_present_folder(args.ip, args.port, zone)
         # Remember the http server runs in its own daemonized thread, so it is
         # necessary to keep the main thread alive. So sleep for 3 years.
-        time.sleep(10**8)
+        time.sleep(10 ** 8)
     except KeyboardInterrupt:
         server.stop()
+
 
 main()

--- a/examples/snapshot/basic_snap.py
+++ b/examples/snapshot/basic_snap.py
@@ -21,29 +21,29 @@ import soco
 from soco.snapshot import Snapshot
 
 # something to play on a Sonos player to start (a radio station)
-start_uri = 'x-sonosapi-stream:s2846?sid=254&amp;flags=32'
+start_uri = "x-sonosapi-stream:s2846?sid=254&amp;flags=32"
 
 # alert sound to interrupt the above (a poem) - use amy file Sonos can play
-alert_uri = 'https://ia800504.us.archive.org/21/items/PoemsInEnglish/tygerblake.mp3'
+alert_uri = "https://ia800504.us.archive.org/21/items/PoemsInEnglish/tygerblake.mp3"
 
 # choose device
-device = soco.SoCo('192.168.1.68')  # <--change IP to one of your Sonos devices
+device = soco.SoCo("192.168.1.68")  # <--change IP to one of your Sonos devices
 
 # start playing something on this device(a radio station)
-print('playing a radio station')
-device.play_uri(start_uri, title='test radio station')
+print("playing a radio station")
+device.play_uri(start_uri, title="test radio station")
 time.sleep(10)  # pause to ensure radio station playing
 
 # take snapshot of current state
 snap = Snapshot(device)  # 1) create a Snapshot class for this device
-snap.snapshot()          # 2) take a snapshot of this device's status
+snap.snapshot()  # 2) take a snapshot of this device's status
 
 # Do something that changes what's playing on this device
-print('playing alert')
-device.volume += 10                             # increase volume
-device.play_uri(alert_uri, title='my alert')    # play an alert sound
-time.sleep(10)                                  # wait for a bit !
+print("playing alert")
+device.volume += 10  # increase volume
+device.play_uri(alert_uri, title="my alert")  # play an alert sound
+time.sleep(10)  # wait for a bit !
 
 # Restore previous state of Sonos (with slow fade up)
-print('reinstating how it was before....')
+print("reinstating how it was before....")
 snap.restore(fade=True)

--- a/examples/snapshot/multi_zone_snap.py
+++ b/examples/snapshot/multi_zone_snap.py
@@ -24,6 +24,7 @@ import time
 import soco
 from soco.snapshot import Snapshot
 
+
 def play_alert(zones, alert_uri, alert_volume=20, alert_duration=0, fade_back=False):
     """
     Demo function using soco.snapshot across multiple Sonos players.
@@ -40,7 +41,7 @@ def play_alert(zones, alert_uri, alert_volume=20, alert_duration=0, fade_back=Fa
     for zone in zones:
         zone.snap = Snapshot(zone)
         zone.snap.snapshot()
-        print('snapshot of zone: {}'.format(zone.player_name))
+        print("snapshot of zone: {}".format(zone.player_name))
 
     # prepare all zones for playing the alert
     for zone in zones:
@@ -49,7 +50,7 @@ def play_alert(zones, alert_uri, alert_volume=20, alert_duration=0, fade_back=Fa
             if not zone.is_playing_tv:  # can't pause TV - so don't try!
                 # pause music for each coordinators if playing
                 trans_state = zone.get_current_transport_info()
-                if trans_state['current_transport_state'] == 'PLAYING':
+                if trans_state["current_transport_state"] == "PLAYING":
                     zone.pause()
 
         # For every Sonos player set volume and mute for every zone
@@ -57,25 +58,29 @@ def play_alert(zones, alert_uri, alert_volume=20, alert_duration=0, fade_back=Fa
         zone.mute = False
 
     # play the sound (uri) on each sonos coordinator
-    print('will play: {} on all coordinators'.format(alert_uri))
+    print("will play: {} on all coordinators".format(alert_uri))
     for zone in zones:
         if zone.is_coordinator:
-            zone.play_uri(uri=alert_uri, title='Sonos Alert')
+            zone.play_uri(uri=alert_uri, title="Sonos Alert")
 
     # wait for alert_duration
     time.sleep(alert_duration)
 
     # restore each zone to previous state
     for zone in zones:
-        print('restoring {}'.format(zone.player_name))
+        print("restoring {}".format(zone.player_name))
         zone.snap.restore(fade=fade_back)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
 
     all_zones = soco.discover()
 
     # alert uri to send to sonos - this uri must be available to Sonos
-    alert_sound = 'https://ia800503.us.archive.org/8/items/futuresoundfx-98/futuresoundfx-96.mp3'
+    alert_sound = (
+        "https://ia800503.us.archive.org/8/items/futuresoundfx-98/futuresoundfx-96.mp3"
+    )
 
-    play_alert(all_zones, alert_sound, alert_volume=30, alert_duration=3,
-               fade_back=False)
+    play_alert(
+        all_zones, alert_sound, alert_volume=30, alert_duration=3, fade_back=False
+    )

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 
 lint: soco
 	flake8 soco
+	flake8 --ignore=F401,F841 tests
 	pylint soco
 
 test:

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,8 @@
 # duplicate code check disabled whilst refactoring of wimp plugin is in
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
-    bad-option-value,no-else-return,cyclic-import,too-many-public-methods
+    bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
+    bad-continuation
 
 
 [REPORTS]
@@ -17,7 +18,7 @@ reports=no
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=79
+max-line-length=88
 
 [TYPECHECK]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pylint >= 1.4
 coveralls
 pytest-cov>=2.4.0
 wheel
-black
+black; python_version >= "3.6" and implementation_name == "cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pylint >= 1.4
 coveralls
 pytest-cov>=2.4.0
 wheel
+black

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ norecursedirs=venv* .git .hg build doc *.egg-info
 # Ingore errors relating to naming conventions.  Will be picked up by pylint
 # Ignore W504 line break after binary operator
 ignore = N801,N802,N804,N805,N806,W504
+max-line-length = 88
+extend-ignore = E203,W503,E231
 
 
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class PyTest(TestCommand):
 
 
 src = io.open('soco/__init__.py', encoding='utf-8').read()
-metadata = dict(re.findall("__([a-z]+)__ = '([^']+)'", src))
+metadata = dict(re.findall("__([a-z]+)__ = \"([^\"]+)\"", src))
 docstrings = re.findall('"""(.*?)"""', src, re.MULTILINE | re.DOTALL)
 
 NAME = 'soco'

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -18,20 +18,20 @@ from .discovery import discover
 from .exceptions import SoCoException, UnknownSoCoException
 
 # Will be parsed by setup.py to determine package metadata
-__author__ = 'The SoCo-Team <python-soco@googlegroups.com>'
+__author__ = "The SoCo-Team <python-soco@googlegroups.com>"
 # Please add the suffix "+" to the version after release, to make it
 # possible infer whether in development code from the version string
-__version__ = '0.18+'
-__website__ = 'https://github.com/SoCo/SoCo'
-__license__ = 'MIT License'
+__version__ = "0.18+"
+__website__ = "https://github.com/SoCo/SoCo"
+__license__ = "MIT License"
 
 # You really should not `import *` - it is poor practice
 # but if you do, here is what you get:
 __all__ = [
-    'discover',
-    'SoCo',
-    'SoCoException',
-    'UnknownSoCoException',
+    "discover",
+    "SoCo",
+    "SoCoException",
+    "UnknownSoCoException",
 ]
 
 # http://docs.python.org/2/howto/logging.html#library-config
@@ -41,6 +41,5 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 if sys.version_info.major < 3:
     warnings.warn(
-        "Version 0.19 of SoCo is the last to support Python 2.7",
-        stacklevel=2,
+        "Version 0.19 of SoCo is the last to support Python 2.7", stacklevel=2,
     )

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -52,7 +52,7 @@ def is_valid_recurrence(text):
     """
     if text in ("DAILY", "ONCE", "WEEKDAYS", "WEEKENDS"):
         return True
-    return re.search(r'^ON_[0-7]{1,7}$', text) is not None
+    return re.search(r"^ON_[0-7]{1,7}$", text) is not None
 
 
 class Alarm(object):
@@ -84,16 +84,25 @@ class Alarm(object):
         >>> print get_alarms()
         set([])
     """
+
     # pylint: disable=too-many-instance-attributes
 
     _all_alarms = weakref.WeakValueDictionary()
 
     # pylint: disable=too-many-arguments
     def __init__(
-            self, zone, start_time=None, duration=None,
-            recurrence='DAILY', enabled=True,
-            program_uri=None, program_metadata='',
-            play_mode='NORMAL', volume=20, include_linked_zones=False):
+        self,
+        zone,
+        start_time=None,
+        duration=None,
+        recurrence="DAILY",
+        enabled=True,
+        program_uri=None,
+        program_metadata="",
+        play_mode="NORMAL",
+        volume=20,
+        include_linked_zones=False,
+    ):
         """
         Args:
             zone (`SoCo`): The soco instance which will play the alarm.
@@ -150,7 +159,8 @@ class Alarm(object):
     def __repr__(self):
         middle = str(self.start_time.strftime(TIME_FORMAT))
         return "<{0} id:{1}@{2} at {3}>".format(
-            self.__class__.__name__, self._alarm_id, middle, hex(id(self)))
+            self.__class__.__name__, self._alarm_id, middle, hex(id(self))
+        )
 
     @property
     def play_mode(self):
@@ -211,26 +221,30 @@ class Alarm(object):
         """
         # pylint: disable=bad-continuation
         args = [
-            ('StartLocalTime', self.start_time.strftime(TIME_FORMAT)),
-            ('Duration', '' if self.duration is None else
-                self.duration.strftime(TIME_FORMAT)),
-            ('Recurrence', self.recurrence),
-            ('Enabled', '1' if self.enabled else '0'),
-            ('RoomUUID', self.zone.uid),
-            ('ProgramURI', "x-rincon-buzzer:0" if self.program_uri is None
-                else self.program_uri),
-            ('ProgramMetaData', self.program_metadata),
-            ('PlayMode', self.play_mode),
-            ('Volume', self.volume),
-            ('IncludeLinkedZones', '1' if self.include_linked_zones else '0')
+            ("StartLocalTime", self.start_time.strftime(TIME_FORMAT)),
+            (
+                "Duration",
+                "" if self.duration is None else self.duration.strftime(TIME_FORMAT),
+            ),
+            ("Recurrence", self.recurrence),
+            ("Enabled", "1" if self.enabled else "0"),
+            ("RoomUUID", self.zone.uid),
+            (
+                "ProgramURI",
+                "x-rincon-buzzer:0" if self.program_uri is None else self.program_uri,
+            ),
+            ("ProgramMetaData", self.program_metadata),
+            ("PlayMode", self.play_mode),
+            ("Volume", self.volume),
+            ("IncludeLinkedZones", "1" if self.include_linked_zones else "0"),
         ]
         if self._alarm_id is None:
             response = self.zone.alarmClock.CreateAlarm(args)
-            self._alarm_id = response['AssignedID']
+            self._alarm_id = response["AssignedID"]
             Alarm._all_alarms[self._alarm_id] = self
         else:
             # The alarm has been saved before. Update it instead.
-            args.insert(0, ('ID', self._alarm_id))
+            args.insert(0, ("ID", self._alarm_id))
             self.zone.alarmClock.UpdateAlarm(args)
 
     def remove(self):
@@ -239,9 +253,7 @@ class Alarm(object):
         There is no need to call `save`. The Python instance is not deleted,
         and can be saved back to Sonos again if desired.
         """
-        self.zone.alarmClock.DestroyAlarm([
-            ('ID', self._alarm_id)
-        ])
+        self.zone.alarmClock.DestroyAlarm([("ID", self._alarm_id)])
         alarm_id = self._alarm_id
         try:
             del Alarm._all_alarms[alarm_id]
@@ -268,8 +280,8 @@ def get_alarms(zone=None):
     if zone is None:
         zone = discovery.any_soco()
     response = zone.alarmClock.ListAlarms()
-    alarm_list = response['CurrentAlarmList']
-    tree = XML.fromstring(alarm_list.encode('utf-8'))
+    alarm_list = response["CurrentAlarmList"]
+    tree = XML.fromstring(alarm_list.encode("utf-8"))
 
     # An alarm list looks like this:
     # <Alarms>
@@ -288,11 +300,11 @@ def get_alarms(zone=None):
     # </Alarms>
 
     # pylint: disable=protected-access
-    alarms = tree.findall('Alarm')
+    alarms = tree.findall("Alarm")
     result = set()
     for alarm in alarms:
         values = alarm.attrib
-        alarm_id = values['ID']
+        alarm_id = values["ID"]
         # If an instance already exists for this ID, update and return it.
         # Otherwise, create a new one and populate its values
         if Alarm._all_alarms.get(alarm_id):
@@ -303,23 +315,31 @@ def get_alarms(zone=None):
             Alarm._all_alarms[instance._alarm_id] = instance
 
         instance.start_time = datetime.strptime(
-            values['StartTime'], "%H:%M:%S").time()  # NB StartTime, not
+            values["StartTime"], "%H:%M:%S"
+        ).time()  # NB StartTime, not
         # StartLocalTime, which is used by CreateAlarm
-        instance.duration = None if values['Duration'] == '' else\
-            datetime.strptime(values['Duration'], "%H:%M:%S").time()
-        instance.recurrence = values['Recurrence']
-        instance.enabled = values['Enabled'] == '1'
-        instance.zone = next((z for z in zone.all_zones
-                              if z.uid == values['RoomUUID']), None)
+        instance.duration = (
+            None
+            if values["Duration"] == ""
+            else datetime.strptime(values["Duration"], "%H:%M:%S").time()
+        )
+        instance.recurrence = values["Recurrence"]
+        instance.enabled = values["Enabled"] == "1"
+        instance.zone = next(
+            (z for z in zone.all_zones if z.uid == values["RoomUUID"]), None
+        )
         # some alarms are not associated to zones -> filter these out
         if instance.zone is None:
             continue
-        instance.program_uri = None if values['ProgramURI'] ==\
-            "x-rincon-buzzer:0" else values['ProgramURI']
-        instance.program_metadata = values['ProgramMetaData']
-        instance.play_mode = values['PlayMode']
-        instance.volume = values['Volume']
-        instance.include_linked_zones = values['IncludeLinkedZones'] == '1'
+        instance.program_uri = (
+            None
+            if values["ProgramURI"] == "x-rincon-buzzer:0"
+            else values["ProgramURI"]
+        )
+        instance.program_metadata = values["ProgramMetaData"]
+        instance.play_mode = values["PlayMode"]
+        instance.volume = values["Volume"]
+        instance.include_linked_zones = values["IncludeLinkedZones"] == "1"
 
         result.add(instance)
     return result

--- a/soco/cache.py
+++ b/soco/cache.py
@@ -20,6 +20,7 @@ from .compat import dumps
 class _BaseCache(object):
 
     """An abstract base class for the cache."""
+
     # pylint: disable=no-self-use, unused-argument
 
     def __init__(self, *args, **kwargs):
@@ -158,7 +159,7 @@ class TimedCache(_BaseCache):
         if not self.enabled:
             return
         # Check for a timeout keyword, store and remove it.
-        timeout = kwargs.pop('timeout', None)
+        timeout = kwargs.pop("timeout", None)
         if timeout is None:
             timeout = self.default_timeout
         cache_key = self.make_key(args, kwargs)

--- a/soco/compat.py
+++ b/soco/compat.py
@@ -15,6 +15,7 @@ try:  # python 3
     from urllib.parse import quote_plus  # noqa
     import socketserver  # noqa
     from queue import Queue  # noqa
+
     StringType = bytes  # noqa
     UnicodeType = str  # noqa
     from urllib.parse import quote as quote_url  # noqa
@@ -27,7 +28,7 @@ except ImportError:  # python 2.7
     import SocketServer as socketserver  # noqa
     from Queue import Queue  # noqa
     from types import StringType, UnicodeType  # noqa
-    from urllib import quote as quote_url   # noqa
+    from urllib import quote as quote_url  # noqa
     from urlparse import urlparse, parse_qs  # noqa
 
 try:  # python 2.7 - this has to be done the other way round
@@ -47,8 +48,10 @@ def with_metaclass(meta, *bases):
         class MyClass(with_metaclass(MyMetaClass, BaseClass)):
                 pass
     """
+
     class _Metaclass(meta):
         """Inner class"""
+
         __call__ = type.__call__
         __init__ = type.__init__
 
@@ -57,4 +60,4 @@ def with_metaclass(meta, *bases):
                 return type.__new__(cls, name, (), attrs)
             return meta(name, bases, attrs)
 
-    return _Metaclass(str('temporary_class'), None, {})
+    return _Metaclass(str("temporary_class"), None, {})

--- a/soco/core.py
+++ b/soco/core.py
@@ -19,23 +19,33 @@ import requests
 from . import config
 from .compat import UnicodeType
 from .data_structures import (
-    DidlObject, DidlPlaylistContainer, DidlResource,
-    Queue, to_didl_string
+    DidlObject,
+    DidlPlaylistContainer,
+    DidlResource,
+    Queue,
+    to_didl_string,
 )
 from .data_structures_entry import from_didl_string
 from .exceptions import (
-    SoCoSlaveException, SoCoUPnPException, NotSupportedException,
+    SoCoSlaveException,
+    SoCoUPnPException,
+    NotSupportedException,
 )
 from .groups import ZoneGroup
 from .music_library import MusicLibrary
 from .services import (
-    DeviceProperties, ContentDirectory, RenderingControl, AVTransport,
-    ZoneGroupTopology, AlarmClock, SystemProperties, MusicServices,
-    zone_group_state_shared_cache, GroupRenderingControl
+    DeviceProperties,
+    ContentDirectory,
+    RenderingControl,
+    AVTransport,
+    ZoneGroupTopology,
+    AlarmClock,
+    SystemProperties,
+    MusicServices,
+    zone_group_state_shared_cache,
+    GroupRenderingControl,
 )
-from .utils import (
-    really_utf8, camel_to_underscore, deprecated
-)
+from .utils import really_utf8, camel_to_underscore, deprecated
 from .xml import XML
 
 _LOG = logging.getLogger(__name__)
@@ -70,20 +80,23 @@ class _ArgsSingleton(type):
     AssertionError
     >>> assert First('hi') is Second('hi')
     """
+
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
-        key = cls._class_group if hasattr(cls, '_class_group') else cls
+        key = cls._class_group if hasattr(cls, "_class_group") else cls
         if key not in cls._instances:
             cls._instances[key] = {}
         if args not in cls._instances[key]:
             cls._instances[key][args] = super(_ArgsSingleton, cls).__call__(
-                *args, **kwargs)
+                *args, **kwargs
+            )
         return cls._instances[key][args]
 
 
 class _SocoSingletonBase(  # pylint: disable=too-few-public-methods,no-init
-        _ArgsSingleton(str('ArgsSingletonMeta'), (object,), {})):
+    _ArgsSingleton(str("ArgsSingletonMeta"), (object,), {})
+):
 
     """The base class for the SoCo class.
 
@@ -95,14 +108,18 @@ class _SocoSingletonBase(  # pylint: disable=too-few-public-methods,no-init
 
 def only_on_master(function):
     """Decorator that raises SoCoSlaveException on master call on slave."""
+
     @wraps(function)
     def inner_function(self, *args, **kwargs):
         """Master checking inner function."""
         if not self.is_coordinator:
-            message = 'The method or property "{0}" can only be called/used '\
-                'on the coordinator in a group'.format(function.__name__)
+            message = (
+                'The method or property "{0}" can only be called/used '
+                "on the coordinator in a group".format(function.__name__)
+            )
             raise SoCoSlaveException(message)
         return function(self, *args, **kwargs)
+
     return inner_function
 
 
@@ -227,7 +244,7 @@ class SoCo(_SocoSingletonBase):
 
     """
 
-    _class_group = 'SoCo'
+    _class_group = "SoCo"
 
     # pylint: disable=super-on-old-class
     def __init__(self, ip_address):
@@ -273,8 +290,7 @@ class SoCo(_SocoSingletonBase):
         _LOG.debug("Created SoCo instance for ip: %s", ip_address)
 
     def __str__(self):
-        return "<{0} object at ip {1}>".format(
-            self.__class__.__name__, self.ip_address)
+        return "<{0} object at ip {1}>".format(self.__class__.__name__, self.ip_address)
 
     def __repr__(self):
         return '{0}("{1}")'.format(self.__class__.__name__, self.ip_address)
@@ -293,11 +309,13 @@ class SoCo(_SocoSingletonBase):
     @player_name.setter
     def player_name(self, playername):
         """Set the speaker's name."""
-        self.deviceProperties.SetZoneAttributes([
-            ('DesiredZoneName', playername),
-            ('DesiredIcon', ''),
-            ('DesiredConfiguration', '')
-        ])
+        self.deviceProperties.SetZoneAttributes(
+            [
+                ("DesiredZoneName", playername),
+                ("DesiredIcon", ""),
+                ("DesiredConfiguration", ""),
+            ]
+        )
 
     @property
     def uid(self):
@@ -336,7 +354,8 @@ class SoCo(_SocoSingletonBase):
         # know the answer. If so, return the cached version
         if self._household_id is None:
             self._household_id = self.deviceProperties.GetHouseholdID()[
-                'CurrentHouseholdID']
+                "CurrentHouseholdID"
+            ]
         return self._household_id
 
     @property
@@ -382,7 +401,7 @@ class SoCo(_SocoSingletonBase):
             if not self.speaker_info:
                 self.get_speaker_info()
 
-            model_name = self.speaker_info['model_name'].lower()
+            model_name = self.speaker_info["model_name"].lower()
             self._is_soundbar = any(model_name.endswith(s) for s in SOUNDBARS)
 
         return self._is_soundbar
@@ -401,10 +420,8 @@ class SoCo(_SocoSingletonBase):
             repeat.
 
         """
-        result = self.avTransport.GetTransportSettings([
-            ('InstanceID', 0),
-        ])
-        return result['PlayMode']
+        result = self.avTransport.GetTransportSettings([("InstanceID", 0),])
+        return result["PlayMode"]
 
     @play_mode.setter
     def play_mode(self, playmode):
@@ -413,10 +430,7 @@ class SoCo(_SocoSingletonBase):
         if playmode not in PLAY_MODES:
             raise KeyError("'%s' is not a valid play mode" % playmode)
 
-        self.avTransport.SetPlayMode([
-            ('InstanceID', 0),
-            ('NewPlayMode', playmode)
-        ])
+        self.avTransport.SetPlayMode([("InstanceID", 0), ("NewPlayMode", playmode)])
 
     @property
     @only_on_master  # Only for symmetry with the setter
@@ -426,23 +440,20 @@ class SoCo(_SocoSingletonBase):
         True if enabled, False otherwise
         """
 
-        response = self.avTransport.GetCrossfadeMode([
-            ('InstanceID', 0),
-        ])
-        cross_fade_state = response['CrossfadeMode']
+        response = self.avTransport.GetCrossfadeMode([("InstanceID", 0),])
+        cross_fade_state = response["CrossfadeMode"]
         return bool(int(cross_fade_state))
 
     @cross_fade.setter
     @only_on_master
     def cross_fade(self, crossfade):
         """Set the speaker's cross fade state."""
-        crossfade_value = '1' if crossfade else '0'
-        self.avTransport.SetCrossfadeMode([
-            ('InstanceID', 0),
-            ('CrossfadeMode', crossfade_value)
-        ])
+        crossfade_value = "1" if crossfade else "0"
+        self.avTransport.SetCrossfadeMode(
+            [("InstanceID", 0), ("CrossfadeMode", crossfade_value)]
+        )
 
-    def ramp_to_volume(self, volume, ramp_type='SLEEP_TIMER_RAMP_TYPE'):
+    def ramp_to_volume(self, volume, ramp_type="SLEEP_TIMER_RAMP_TYPE"):
         """Smoothly change the volume.
 
         There are three ramp types available:
@@ -472,15 +483,17 @@ class SoCo(_SocoSingletonBase):
             int: The ramp time in seconds, rounded down. Note that this does
             not include the wait time.
         """
-        response = self.renderingControl.RampToVolume([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-            ('RampType', ramp_type),
-            ('DesiredVolume', volume),
-            ('ResetVolumeAfter', False),
-            ('ProgramURI', '')
-        ])
-        return int(response['RampTime'])
+        response = self.renderingControl.RampToVolume(
+            [
+                ("InstanceID", 0),
+                ("Channel", "Master"),
+                ("RampType", ramp_type),
+                ("DesiredVolume", volume),
+                ("ResetVolumeAfter", False),
+                ("ProgramURI", ""),
+            ]
+        )
+        return int(response["RampTime"])
 
     def set_relative_volume(self, relative_volume):
         """Adjust the volume up or down by a relative amount.
@@ -508,12 +521,10 @@ class SoCo(_SocoSingletonBase):
         """
         relative_volume = int(relative_volume)
         # Sonos will automatically handle out-of-range adjustments
-        response = self.renderingControl.SetRelativeVolume([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-            ('Adjustment', relative_volume)
-        ])
-        return int(response['NewVolume'])
+        response = self.renderingControl.SetRelativeVolume(
+            [("InstanceID", 0), ("Channel", "Master"), ("Adjustment", relative_volume)]
+        )
+        return int(response["NewVolume"])
 
     @only_on_master
     def play_from_queue(self, index, start=True):
@@ -532,19 +543,15 @@ class SoCo(_SocoSingletonBase):
             self.get_speaker_info()
 
         # first, set the queue itself as the source URI
-        uri = 'x-rincon-queue:{0}#0'.format(self.uid)
-        self.avTransport.SetAVTransportURI([
-            ('InstanceID', 0),
-            ('CurrentURI', uri),
-            ('CurrentURIMetaData', '')
-        ])
+        uri = "x-rincon-queue:{0}#0".format(self.uid)
+        self.avTransport.SetAVTransportURI(
+            [("InstanceID", 0), ("CurrentURI", uri), ("CurrentURIMetaData", "")]
+        )
 
         # second, set the track number with a seek command
-        self.avTransport.Seek([
-            ('InstanceID', 0),
-            ('Unit', 'TRACK_NR'),
-            ('Target', index + 1)
-        ])
+        self.avTransport.Seek(
+            [("InstanceID", 0), ("Unit", "TRACK_NR"), ("Target", index + 1)]
+        )
 
         # finally, just play what's set if needed
         if start:
@@ -553,15 +560,11 @@ class SoCo(_SocoSingletonBase):
     @only_on_master
     def play(self):
         """Play the currently selected track."""
-        self.avTransport.Play([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.avTransport.Play([("InstanceID", 0), ("Speed", 1)])
 
     @only_on_master
     # pylint: disable=too-many-arguments
-    def play_uri(self, uri='', meta='', title='', start=True,
-                 force_radio=False):
+    def play_uri(self, uri="", meta="", title="", start=True, force_radio=False):
         """Play a URI.
 
         Playing a URI will replace what was playing with the stream given by
@@ -612,33 +615,31 @@ class SoCo(_SocoSingletonBase):
            using the "force_radio=True" parameter.
            A few streams may fail if not forced to to Radio format.
         """
-        if meta == '' and title != '':
-            meta_template = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'\
-                '/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '\
-                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '\
-                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'\
-                '<item id="R:0/0/0" parentID="R:0/0" restricted="true">'\
-                '<dc:title>{title}</dc:title><upnp:class>'\
-                'object.item.audioItem.audioBroadcast</upnp:class><desc '\
-                'id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:'\
+        if meta == "" and title != "":
+            meta_template = (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'
+                '/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                '<item id="R:0/0/0" parentID="R:0/0" restricted="true">'
+                "<dc:title>{title}</dc:title><upnp:class>"
+                "object.item.audioItem.audioBroadcast</upnp:class><desc "
+                'id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:'
                 'metadata-1-0/">{service}</desc></item></DIDL-Lite>'
-            tunein_service = 'SA_RINCON65031_'
+            )
+            tunein_service = "SA_RINCON65031_"
             # Radio stations need to have at least a title to play
-            meta = meta_template.format(
-                title=escape(title),
-                service=tunein_service)
+            meta = meta_template.format(title=escape(title), service=tunein_service)
 
         # change uri prefix to force radio style display and commands
         if force_radio:
-            colon = uri.find(':')
+            colon = uri.find(":")
             if colon > 0:
-                uri = 'x-rincon-mp3radio{0}'.format(uri[colon:])
+                uri = "x-rincon-mp3radio{0}".format(uri[colon:])
 
-        self.avTransport.SetAVTransportURI([
-            ('InstanceID', 0),
-            ('CurrentURI', uri),
-            ('CurrentURIMetaData', meta)
-        ])
+        self.avTransport.SetAVTransportURI(
+            [("InstanceID", 0), ("CurrentURI", uri), ("CurrentURIMetaData", meta)]
+        )
         # The track is enqueued, now play it if needed
         if start:
             return self.play()
@@ -647,18 +648,12 @@ class SoCo(_SocoSingletonBase):
     @only_on_master
     def pause(self):
         """Pause the currently playing track."""
-        self.avTransport.Pause([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.avTransport.Pause([("InstanceID", 0), ("Speed", 1)])
 
     @only_on_master
     def stop(self):
         """Stop the currently playing track."""
-        self.avTransport.Stop([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.avTransport.Stop([("InstanceID", 0), ("Speed", 1)])
 
     @only_on_master
     def seek(self, timestamp):
@@ -668,14 +663,12 @@ class SoCo(_SocoSingletonBase):
         Raises:
             ValueError: if the given timestamp is invalid.
         """
-        if not re.match(r'^[0-9][0-9]?:[0-9][0-9]:[0-9][0-9]$', timestamp):
-            raise ValueError('invalid timestamp, use HH:MM:SS format')
+        if not re.match(r"^[0-9][0-9]?:[0-9][0-9]:[0-9][0-9]$", timestamp):
+            raise ValueError("invalid timestamp, use HH:MM:SS format")
 
-        self.avTransport.Seek([
-            ('InstanceID', 0),
-            ('Unit', 'REL_TIME'),
-            ('Target', timestamp)
-        ])
+        self.avTransport.Seek(
+            [("InstanceID", 0), ("Unit", "REL_TIME"), ("Target", timestamp)]
+        )
 
     @only_on_master
     def next(self):
@@ -687,10 +680,7 @@ class SoCo(_SocoSingletonBase):
         code will likely be returned (since Pandora has limits on how many
         songs can be skipped).
         """
-        self.avTransport.Next([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.avTransport.Next([("InstanceID", 0), ("Speed", 1)])
 
     @only_on_master
     def previous(self):
@@ -701,10 +691,7 @@ class SoCo(_SocoSingletonBase):
         code (error code 701) if the Sonos is streaming Pandora since you can't
         go back on tracks.
         """
-        self.avTransport.Previous([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.avTransport.Previous([("InstanceID", 0), ("Speed", 1)])
 
     @property
     def mute(self):
@@ -713,22 +700,19 @@ class SoCo(_SocoSingletonBase):
         True if muted, False otherwise.
         """
 
-        response = self.renderingControl.GetMute([
-            ('InstanceID', 0),
-            ('Channel', 'Master')
-        ])
-        mute_state = response['CurrentMute']
+        response = self.renderingControl.GetMute(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
+        mute_state = response["CurrentMute"]
         return bool(int(mute_state))
 
     @mute.setter
     def mute(self, mute):
         """Mute (or unmute) the speaker."""
-        mute_value = '1' if mute else '0'
-        self.renderingControl.SetMute([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-            ('DesiredMute', mute_value)
-        ])
+        mute_value = "1" if mute else "0"
+        self.renderingControl.SetMute(
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredMute", mute_value)]
+        )
 
     @property
     def volume(self):
@@ -737,11 +721,10 @@ class SoCo(_SocoSingletonBase):
         An integer between 0 and 100.
         """
 
-        response = self.renderingControl.GetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-        ])
-        volume = response['CurrentVolume']
+        response = self.renderingControl.GetVolume(
+            [("InstanceID", 0), ("Channel", "Master"),]
+        )
+        volume = response["CurrentVolume"]
         return int(volume)
 
     @volume.setter
@@ -749,11 +732,9 @@ class SoCo(_SocoSingletonBase):
         """Set the speaker's volume."""
         volume = int(volume)
         volume = max(0, min(volume, 100))  # Coerce in range
-        self.renderingControl.SetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-            ('DesiredVolume', volume)
-        ])
+        self.renderingControl.SetVolume(
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredVolume", volume)]
+        )
 
     @property
     def bass(self):
@@ -762,11 +743,10 @@ class SoCo(_SocoSingletonBase):
         An integer between -10 and 10.
         """
 
-        response = self.renderingControl.GetBass([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-        ])
-        bass = response['CurrentBass']
+        response = self.renderingControl.GetBass(
+            [("InstanceID", 0), ("Channel", "Master"),]
+        )
+        bass = response["CurrentBass"]
         return int(bass)
 
     @bass.setter
@@ -774,10 +754,7 @@ class SoCo(_SocoSingletonBase):
         """Set the speaker's bass."""
         bass = int(bass)
         bass = max(-10, min(bass, 10))  # Coerce in range
-        self.renderingControl.SetBass([
-            ('InstanceID', 0),
-            ('DesiredBass', bass)
-        ])
+        self.renderingControl.SetBass([("InstanceID", 0), ("DesiredBass", bass)])
 
     @property
     def treble(self):
@@ -786,11 +763,10 @@ class SoCo(_SocoSingletonBase):
         An integer between -10 and 10.
         """
 
-        response = self.renderingControl.GetTreble([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-        ])
-        treble = response['CurrentTreble']
+        response = self.renderingControl.GetTreble(
+            [("InstanceID", 0), ("Channel", "Master"),]
+        )
+        treble = response["CurrentTreble"]
         return int(treble)
 
     @treble.setter
@@ -798,10 +774,7 @@ class SoCo(_SocoSingletonBase):
         """Set the speaker's treble."""
         treble = int(treble)
         treble = max(-10, min(treble, 10))  # Coerce in range
-        self.renderingControl.SetTreble([
-            ('InstanceID', 0),
-            ('DesiredTreble', treble)
-        ])
+        self.renderingControl.SetTreble([("InstanceID", 0), ("DesiredTreble", treble)])
 
     @property
     def loudness(self):
@@ -813,22 +786,23 @@ class SoCo(_SocoSingletonBase):
         Wikipedia: https://en.wikipedia.org/wiki/Loudness
 
         """
-        response = self.renderingControl.GetLoudness([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-        ])
+        response = self.renderingControl.GetLoudness(
+            [("InstanceID", 0), ("Channel", "Master"),]
+        )
         loudness = response["CurrentLoudness"]
         return bool(int(loudness))
 
     @loudness.setter
     def loudness(self, loudness):
         """Switch on/off the speaker's loudness compensation."""
-        loudness_value = '1' if loudness else '0'
-        self.renderingControl.SetLoudness([
-            ('InstanceID', 0),
-            ('Channel', 'Master'),
-            ('DesiredLoudness', loudness_value)
-        ])
+        loudness_value = "1" if loudness else "0"
+        self.renderingControl.SetLoudness(
+            [
+                ("InstanceID", 0),
+                ("Channel", "Master"),
+                ("DesiredLoudness", loudness_value),
+            ]
+        )
 
     @property
     def balance(self):
@@ -842,16 +816,14 @@ class SoCo(_SocoSingletonBase):
             right channel at zero volume.
         """
 
-        response_lf = self.renderingControl.GetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'LF'),
-        ])
-        response_rf = self.renderingControl.GetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'RF'),
-        ])
-        volume_lf = response_lf['CurrentVolume']
-        volume_rf = response_rf['CurrentVolume']
+        response_lf = self.renderingControl.GetVolume(
+            [("InstanceID", 0), ("Channel", "LF"),]
+        )
+        response_rf = self.renderingControl.GetVolume(
+            [("InstanceID", 0), ("Channel", "RF"),]
+        )
+        volume_lf = response_lf["CurrentVolume"]
+        volume_rf = response_rf["CurrentVolume"]
         return int(volume_lf), int(volume_rf)
 
     @balance.setter
@@ -862,16 +834,12 @@ class SoCo(_SocoSingletonBase):
         right = int(right)
         left = max(0, min(left, 100))  # Coerce in range
         right = max(0, min(right, 100))  # Coerce in range
-        self.renderingControl.SetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'LF'),
-            ('DesiredVolume', left)
-        ])
-        self.renderingControl.SetVolume([
-            ('InstanceID', 0),
-            ('Channel', 'RF'),
-            ('DesiredVolume', right)
-        ])
+        self.renderingControl.SetVolume(
+            [("InstanceID", 0), ("Channel", "LF"), ("DesiredVolume", left)]
+        )
+        self.renderingControl.SetVolume(
+            [("InstanceID", 0), ("Channel", "RF"), ("DesiredVolume", right)]
+        )
 
     @property
     def night_mode(self):
@@ -882,11 +850,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        response = self.renderingControl.GetEQ([
-            ('InstanceID', 0),
-            ('EQType', 'NightMode')
-        ])
-        return bool(int(response['CurrentValue']))
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "NightMode")]
+        )
+        return bool(int(response["CurrentValue"]))
 
     @night_mode.setter
     def night_mode(self, night_mode):
@@ -898,14 +865,16 @@ class SoCo(_SocoSingletonBase):
         night mode.
         """
         if not self.is_soundbar:
-            message = 'This device does not support night mode'
+            message = "This device does not support night mode"
             raise NotSupportedException(message)
 
-        self.renderingControl.SetEQ([
-            ('InstanceID', 0),
-            ('EQType', 'NightMode'),
-            ('DesiredValue', int(night_mode))
-        ])
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "NightMode"),
+                ("DesiredValue", int(night_mode)),
+            ]
+        )
 
     @property
     def dialog_mode(self):
@@ -916,11 +885,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        response = self.renderingControl.GetEQ([
-            ('InstanceID', 0),
-            ('EQType', 'DialogLevel')
-        ])
-        return bool(int(response['CurrentValue']))
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "DialogLevel")]
+        )
+        return bool(int(response["CurrentValue"]))
 
     @dialog_mode.setter
     def dialog_mode(self, dialog_mode):
@@ -932,14 +900,16 @@ class SoCo(_SocoSingletonBase):
         dialog mode.
         """
         if not self.is_soundbar:
-            message = 'This device does not support dialog mode'
+            message = "This device does not support dialog mode"
             raise NotSupportedException(message)
 
-        self.renderingControl.SetEQ([
-            ('InstanceID', 0),
-            ('EQType', 'DialogLevel'),
-            ('DesiredValue', int(dialog_mode))
-        ])
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "DialogLevel"),
+                ("DesiredValue", int(dialog_mode)),
+            ]
+        )
 
     def _parse_zone_group_state(self):
         """The Zone Group State contains a lot of useful information.
@@ -947,45 +917,45 @@ class SoCo(_SocoSingletonBase):
         Retrieve and parse it, and populate the relevant properties.
         """
 
-# zoneGroupTopology.GetZoneGroupState()['ZoneGroupState'] returns XML like
-# this:
-#
-# <ZoneGroups>
-#   <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000XXXX1400:0">
-#     <ZoneGroupMember
-#         BootSeq="33"
-#         Configuration="1"
-#         Icon="x-rincon-roomicon:zoneextender"
-#         Invisible="1"
-#         IsZoneBridge="1"
-#         Location="http://192.168.1.100:1400/xml/device_description.xml"
-#         MinCompatibleVersion="22.0-00000"
-#         SoftwareVersion="24.1-74200"
-#         UUID="RINCON_000ZZZ1400"
-#         ZoneName="BRIDGE"/>
-#   </ZoneGroup>
-#   <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000XXX1400:46">
-#     <ZoneGroupMember
-#         BootSeq="44"
-#         Configuration="1"
-#         Icon="x-rincon-roomicon:living"
-#         Location="http://192.168.1.101:1400/xml/device_description.xml"
-#         MinCompatibleVersion="22.0-00000"
-#         SoftwareVersion="24.1-74200"
-#         UUID="RINCON_000XXX1400"
-#         ZoneName="Living Room"/>
-#     <ZoneGroupMember
-#         BootSeq="52"
-#         Configuration="1"
-#         Icon="x-rincon-roomicon:kitchen"
-#         Location="http://192.168.1.102:1400/xml/device_description.xml"
-#         MinCompatibleVersion="22.0-00000"
-#         SoftwareVersion="24.1-74200"
-#         UUID="RINCON_000YYY1400"
-#         ZoneName="Kitchen"/>
-#   </ZoneGroup>
-# </ZoneGroups>
-#
+        # zoneGroupTopology.GetZoneGroupState()['ZoneGroupState'] returns XML like
+        # this:
+        #
+        # <ZoneGroups>
+        #   <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000XXXX1400:0">
+        #     <ZoneGroupMember
+        #         BootSeq="33"
+        #         Configuration="1"
+        #         Icon="x-rincon-roomicon:zoneextender"
+        #         Invisible="1"
+        #         IsZoneBridge="1"
+        #         Location="http://192.168.1.100:1400/xml/device_description.xml"
+        #         MinCompatibleVersion="22.0-00000"
+        #         SoftwareVersion="24.1-74200"
+        #         UUID="RINCON_000ZZZ1400"
+        #         ZoneName="BRIDGE"/>
+        #   </ZoneGroup>
+        #   <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000XXX1400:46">
+        #     <ZoneGroupMember
+        #         BootSeq="44"
+        #         Configuration="1"
+        #         Icon="x-rincon-roomicon:living"
+        #         Location="http://192.168.1.101:1400/xml/device_description.xml"
+        #         MinCompatibleVersion="22.0-00000"
+        #         SoftwareVersion="24.1-74200"
+        #         UUID="RINCON_000XXX1400"
+        #         ZoneName="Living Room"/>
+        #     <ZoneGroupMember
+        #         BootSeq="52"
+        #         Configuration="1"
+        #         Icon="x-rincon-roomicon:kitchen"
+        #         Location="http://192.168.1.102:1400/xml/device_description.xml"
+        #         MinCompatibleVersion="22.0-00000"
+        #         SoftwareVersion="24.1-74200"
+        #         UUID="RINCON_000YYY1400"
+        #         ZoneName="Kitchen"/>
+        #   </ZoneGroup>
+        # </ZoneGroups>
+        #
 
         def parse_zone_group_member(member_element):
             """Parse a ZoneGroupMember or Satellite element from Zone Group
@@ -996,16 +966,15 @@ class SoCo(_SocoSingletonBase):
             # been created, and useful if they haven't. We can then
             # update various properties for that instance.
             member_attribs = member_element.attrib
-            ip_addr = member_attribs['Location'].\
-                split('//')[1].split(':')[0]
+            ip_addr = member_attribs["Location"].split("//")[1].split(":")[0]
             zone = config.SOCO_CLASS(ip_addr)
             # uid doesn't change, but it's not harmful to (re)set it, in case
             # the zone is as yet unseen.
-            zone._uid = member_attribs['UUID']
-            zone._player_name = member_attribs['ZoneName']
+            zone._uid = member_attribs["UUID"]
+            zone._player_name = member_attribs["ZoneName"]
             # add the zone to the set of all members, and to the set
             # of visible members if appropriate
-            is_visible = (member_attribs.get('Invisible') != '1')
+            is_visible = member_attribs.get("Invisible") != "1"
             if is_visible:
                 self._visible_zones.add(zone)
             self._all_zones.add(zone)
@@ -1015,24 +984,25 @@ class SoCo(_SocoSingletonBase):
         # Maintain a private cache. If the zgt has not changed, there is no
         # need to repeat all the XML parsing. In addition, switch on network
         # caching for a short interval (5 secs).
-        zgs = self.zoneGroupTopology.GetZoneGroupState(
-            cache_timeout=5)['ZoneGroupState']
+        zgs = self.zoneGroupTopology.GetZoneGroupState(cache_timeout=5)[
+            "ZoneGroupState"
+        ]
         if zgs == self._zgs_cache:
             return
         self._zgs_cache = zgs
-        tree = XML.fromstring(zgs.encode('utf-8'))
+        tree = XML.fromstring(zgs.encode("utf-8"))
         # Empty the set of all zone_groups
         self._groups.clear()
         # and the set of all members
         self._all_zones.clear()
         self._visible_zones.clear()
         # Loop over each ZoneGroup Element
-        for group_element in tree.find('ZoneGroups').findall('ZoneGroup'):
-            coordinator_uid = group_element.attrib['Coordinator']
-            group_uid = group_element.attrib['ID']
+        for group_element in tree.find("ZoneGroups").findall("ZoneGroup"):
+            coordinator_uid = group_element.attrib["Coordinator"]
+            group_uid = group_element.attrib["ID"]
             group_coordinator = None
             members = set()
-            for member_element in group_element.findall('ZoneGroupMember'):
+            for member_element in group_element.findall("ZoneGroupMember"):
                 zone = parse_zone_group_member(member_element)
                 # Perform extra processing relevant to direct zone group
                 # members
@@ -1047,13 +1017,12 @@ class SoCo(_SocoSingletonBase):
                 # is_bridge doesn't change, but it does no real harm to
                 # set/reset it here, just in case the zone has not been seen
                 # before
-                zone._is_bridge = (
-                    member_element.attrib.get('IsZoneBridge') == '1')
+                zone._is_bridge = member_element.attrib.get("IsZoneBridge") == "1"
                 # add the zone to the members for this group
                 members.add(zone)
                 # Loop over Satellite elements if present, and process as for
                 # ZoneGroup elements
-                for satellite_element in member_element.findall('Satellite'):
+                for satellite_element in member_element.findall("Satellite"):
                     zone = parse_zone_group_member(satellite_element)
                     # Assume a satellite can't be a bridge or coordinator, so
                     # no need to check.
@@ -1123,11 +1092,13 @@ class SoCo(_SocoSingletonBase):
 
     def join(self, master):
         """Join this speaker to another "master" speaker."""
-        self.avTransport.SetAVTransportURI([
-            ('InstanceID', 0),
-            ('CurrentURI', 'x-rincon:{0}'.format(master.uid)),
-            ('CurrentURIMetaData', '')
-        ])
+        self.avTransport.SetAVTransportURI(
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon:{0}".format(master.uid)),
+                ("CurrentURIMetaData", ""),
+            ]
+        )
         zone_group_state_shared_cache.clear()
         self._parse_zone_group_state()
 
@@ -1139,9 +1110,7 @@ class SoCo(_SocoSingletonBase):
         returns ok.
         """
 
-        self.avTransport.BecomeCoordinatorOfStandaloneGroup([
-            ('InstanceID', 0)
-        ])
+        self.avTransport.BecomeCoordinatorOfStandaloneGroup([("InstanceID", 0)])
         zone_group_state_shared_cache.clear()
         self._parse_zone_group_state()
 
@@ -1157,50 +1126,51 @@ class SoCo(_SocoSingletonBase):
         else:
             uid = self.uid
 
-        self.avTransport.SetAVTransportURI([
-            ('InstanceID', 0),
-            ('CurrentURI', 'x-rincon-stream:{0}'.format(uid)),
-            ('CurrentURIMetaData', '')
-        ])
+        self.avTransport.SetAVTransportURI(
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon-stream:{0}".format(uid)),
+                ("CurrentURIMetaData", ""),
+            ]
+        )
 
     @property
     def is_playing_radio(self):
         """bool: Is the speaker playing radio?"""
-        response = self.avTransport.GetPositionInfo([
-            ('InstanceID', 0),
-            ('Channel', 'Master')
-        ])
-        track_uri = response['TrackURI']
-        return re.match(r'^x-rincon-mp3radio:', track_uri) is not None
+        response = self.avTransport.GetPositionInfo(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
+        track_uri = response["TrackURI"]
+        return re.match(r"^x-rincon-mp3radio:", track_uri) is not None
 
     @property
     def is_playing_line_in(self):
         """bool: Is the speaker playing line-in?"""
-        response = self.avTransport.GetPositionInfo([
-            ('InstanceID', 0),
-            ('Channel', 'Master')
-        ])
-        track_uri = response['TrackURI']
-        return re.match(r'^x-rincon-stream:', track_uri) is not None
+        response = self.avTransport.GetPositionInfo(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
+        track_uri = response["TrackURI"]
+        return re.match(r"^x-rincon-stream:", track_uri) is not None
 
     @property
     def is_playing_tv(self):
         """bool: Is the playbar speaker input from TV?"""
-        response = self.avTransport.GetPositionInfo([
-            ('InstanceID', 0),
-            ('Channel', 'Master')
-        ])
-        track_uri = response['TrackURI']
-        return re.match(r'^x-sonos-htastream:', track_uri) is not None
+        response = self.avTransport.GetPositionInfo(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
+        track_uri = response["TrackURI"]
+        return re.match(r"^x-sonos-htastream:", track_uri) is not None
 
     def switch_to_tv(self):
         """Switch the playbar speaker's input to TV."""
 
-        self.avTransport.SetAVTransportURI([
-            ('InstanceID', 0),
-            ('CurrentURI', 'x-sonos-htastream:{0}:spdif'.format(self.uid)),
-            ('CurrentURIMetaData', '')
-        ])
+        self.avTransport.SetAVTransportURI(
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-sonos-htastream:{0}:spdif".format(self.uid)),
+                ("CurrentURIMetaData", ""),
+            ]
+        )
 
     @property
     def status_light(self):
@@ -1216,10 +1186,10 @@ class SoCo(_SocoSingletonBase):
     @status_light.setter
     def status_light(self, led_on):
         """Switch on/off the speaker's status light."""
-        led_state = 'On' if led_on else 'Off'
-        self.deviceProperties.SetLEDState([
-            ('DesiredLEDState', led_state),
-        ])
+        led_state = "On" if led_on else "Off"
+        self.deviceProperties.SetLEDState(
+            [("DesiredLEDState", led_state),]
+        )
 
     def get_current_track_info(self):
         """Get information about the currently playing track.
@@ -1240,67 +1210,79 @@ class SoCo(_SocoSingletonBase):
             this speaker was playing.
 
         """
-        response = self.avTransport.GetPositionInfo([
-            ('InstanceID', 0),
-            ('Channel', 'Master')
-        ])
+        response = self.avTransport.GetPositionInfo(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
 
-        track = {'title': '', 'artist': '', 'album': '', 'album_art': '',
-                 'position': ''}
-        track['playlist_position'] = response['Track']
-        track['duration'] = response['TrackDuration']
-        track['uri'] = response['TrackURI']
-        track['position'] = response['RelTime']
+        track = {
+            "title": "",
+            "artist": "",
+            "album": "",
+            "album_art": "",
+            "position": "",
+        }
+        track["playlist_position"] = response["Track"]
+        track["duration"] = response["TrackDuration"]
+        track["uri"] = response["TrackURI"]
+        track["position"] = response["RelTime"]
 
-        metadata = response['TrackMetaData']
+        metadata = response["TrackMetaData"]
         # Store the entire Metadata entry in the track, this can then be
         # used if needed by the client to restart a given URI
-        track['metadata'] = metadata
+        track["metadata"] = metadata
         # Duration seems to be '0:00:00' when listening to radio
-        if metadata != '' and track['duration'] == '0:00:00':
+        if metadata != "" and track["duration"] == "0:00:00":
             metadata = XML.fromstring(really_utf8(metadata))
             # Try parse trackinfo
-            trackinfo = metadata.findtext('.//{urn:schemas-rinconnetworks-com:'
-                                          'metadata-1-0/}streamContent') or ''
-            index = trackinfo.find(' - ')
+            trackinfo = (
+                metadata.findtext(
+                    ".//{urn:schemas-rinconnetworks-com:" "metadata-1-0/}streamContent"
+                )
+                or ""
+            )
+            index = trackinfo.find(" - ")
 
             if index > -1:
-                track['artist'] = trackinfo[:index]
-                track['title'] = trackinfo[index + 3:]
+                track["artist"] = trackinfo[:index]
+                track["title"] = trackinfo[index + 3 :]
             else:
                 # Might find some kind of title anyway in metadata
-                track['title'] = metadata.findtext('.//{http://purl.org/dc/'
-                                                   'elements/1.1/}title')
-                if not track['title']:
-                    track['title'] = trackinfo
+                track["title"] = metadata.findtext(
+                    ".//{http://purl.org/dc/" "elements/1.1/}title"
+                )
+                if not track["title"]:
+                    track["title"] = trackinfo
 
         # If the speaker is playing from the line-in source, querying for track
         # metadata will return "NOT_IMPLEMENTED".
-        elif metadata not in ('', 'NOT_IMPLEMENTED', None):
+        elif metadata not in ("", "NOT_IMPLEMENTED", None):
             # Track metadata is returned in DIDL-Lite format
             metadata = XML.fromstring(really_utf8(metadata))
-            md_title = metadata.findtext(
-                './/{http://purl.org/dc/elements/1.1/}title')
+            md_title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")
             md_artist = metadata.findtext(
-                './/{http://purl.org/dc/elements/1.1/}creator')
+                ".//{http://purl.org/dc/elements/1.1/}creator"
+            )
             md_album = metadata.findtext(
-                './/{urn:schemas-upnp-org:metadata-1-0/upnp/}album')
+                ".//{urn:schemas-upnp-org:metadata-1-0/upnp/}album"
+            )
 
-            track['title'] = ""
+            track["title"] = ""
             if md_title:
-                track['title'] = md_title
-            track['artist'] = ""
+                track["title"] = md_title
+            track["artist"] = ""
             if md_artist:
-                track['artist'] = md_artist
-            track['album'] = ""
+                track["artist"] = md_artist
+            track["album"] = ""
             if md_album:
-                track['album'] = md_album
+                track["album"] = md_album
 
             album_art_url = metadata.findtext(
-                './/{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI')
+                ".//{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI"
+            )
             if album_art_url is not None:
-                track['album_art'] = \
-                    self.music_library.build_album_art_full_uri(album_art_url)
+                track["album_art"] = self.music_library.build_album_art_full_uri(
+                    album_art_url
+                )
 
         return track
 
@@ -1321,40 +1303,48 @@ class SoCo(_SocoSingletonBase):
         if self.speaker_info and refresh is False:
             return self.speaker_info
         else:
-            response = requests.get('http://' + self.ip_address +
-                                    ':1400/xml/device_description.xml',
-                                    timeout=timeout)
+            response = requests.get(
+                "http://" + self.ip_address + ":1400/xml/device_description.xml",
+                timeout=timeout,
+            )
             dom = XML.fromstring(response.content)
 
-        device = dom.find('{urn:schemas-upnp-org:device-1-0}device')
+        device = dom.find("{urn:schemas-upnp-org:device-1-0}device")
         if device is not None:
-            self.speaker_info['zone_name'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}roomName')
-
-            # no zone icon in device_description.xml -> player icon
-            self.speaker_info['player_icon'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}iconList/'
-                '{urn:schemas-upnp-org:device-1-0}icon/'
-                '{urn:schemas-upnp-org:device-1-0}url'
+            self.speaker_info["zone_name"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}roomName"
             )
 
-            self.speaker_info['uid'] = self.uid
-            self.speaker_info['serial_number'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}serialNum')
-            self.speaker_info['software_version'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}softwareVersion')
-            self.speaker_info['hardware_version'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}hardwareVersion')
-            self.speaker_info['model_number'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}modelNumber')
-            self.speaker_info['model_name'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}modelName')
-            self.speaker_info['display_version'] = device.findtext(
-                '{urn:schemas-upnp-org:device-1-0}displayVersion')
+            # no zone icon in device_description.xml -> player icon
+            self.speaker_info["player_icon"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}iconList/"
+                "{urn:schemas-upnp-org:device-1-0}icon/"
+                "{urn:schemas-upnp-org:device-1-0}url"
+            )
+
+            self.speaker_info["uid"] = self.uid
+            self.speaker_info["serial_number"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}serialNum"
+            )
+            self.speaker_info["software_version"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}softwareVersion"
+            )
+            self.speaker_info["hardware_version"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}hardwareVersion"
+            )
+            self.speaker_info["model_number"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}modelNumber"
+            )
+            self.speaker_info["model_name"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}modelName"
+            )
+            self.speaker_info["display_version"] = device.findtext(
+                "{urn:schemas-upnp-org:device-1-0}displayVersion"
+            )
 
             # no mac address - extract from serial number
-            mac = self.speaker_info['serial_number'].split(':')[0]
-            self.speaker_info['mac_address'] = mac
+            mac = self.speaker_info["serial_number"].split(":")[0]
+            self.speaker_info["mac_address"] = mac
 
             return self.speaker_info
         return None
@@ -1374,21 +1364,17 @@ class SoCo(_SocoSingletonBase):
         This allows us to know if speaker is playing or not. Don't know other
         states of CurrentTransportStatus and CurrentSpeed.
         """
-        response = self.avTransport.GetTransportInfo([
-            ('InstanceID', 0),
-        ])
+        response = self.avTransport.GetTransportInfo([("InstanceID", 0),])
 
         playstate = {
-            'current_transport_status': '',
-            'current_transport_state': '',
-            'current_transport_speed': ''
+            "current_transport_status": "",
+            "current_transport_state": "",
+            "current_transport_speed": "",
         }
 
-        playstate['current_transport_state'] = \
-            response['CurrentTransportState']
-        playstate['current_transport_status'] = \
-            response['CurrentTransportStatus']
-        playstate['current_transport_speed'] = response['CurrentSpeed']
+        playstate["current_transport_state"] = response["CurrentTransportState"]
+        playstate["current_transport_status"] = response["CurrentTransportStatus"]
+        playstate["current_transport_speed"] = response["CurrentSpeed"]
 
         return playstate
 
@@ -1405,18 +1391,20 @@ class SoCo(_SocoSingletonBase):
         implementation
         """
         queue = []
-        response = self.contentDirectory.Browse([
-            ('ObjectID', 'Q:0'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', start),
-            ('RequestedCount', max_items),
-            ('SortCriteria', '')
-        ])
-        result = response['Result']
+        response = self.contentDirectory.Browse(
+            [
+                ("ObjectID", "Q:0"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", start),
+                ("RequestedCount", max_items),
+                ("SortCriteria", ""),
+            ]
+        )
+        result = response["Result"]
 
         metadata = {}
-        for tag in ['NumberReturned', 'TotalMatches', 'UpdateID']:
+        for tag in ["NumberReturned", "TotalMatches", "UpdateID"]:
             metadata[camel_to_underscore(tag)] = int(response[tag])
 
         # I'm not sure this necessary (any more). Even with an empty queue,
@@ -1438,21 +1426,22 @@ class SoCo(_SocoSingletonBase):
     @property
     def queue_size(self):
         """int: Size of the queue."""
-        response = self.contentDirectory.Browse([
-            ('ObjectID', 'Q:0'),
-            ('BrowseFlag', 'BrowseMetadata'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 1),
-            ('SortCriteria', '')
-        ])
-        dom = XML.fromstring(really_utf8(response['Result']))
+        response = self.contentDirectory.Browse(
+            [
+                ("ObjectID", "Q:0"),
+                ("BrowseFlag", "BrowseMetadata"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 1),
+                ("SortCriteria", ""),
+            ]
+        )
+        dom = XML.fromstring(really_utf8(response["Result"]))
 
         queue_size = None
-        container = dom.find(
-            '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}container')
+        container = dom.find("{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}container")
         if container is not None:
-            child_count = container.get('childCount')
+            child_count = container.get("childCount")
             if child_count is not None:
                 queue_size = int(child_count)
 
@@ -1465,9 +1454,8 @@ class SoCo(_SocoSingletonBase):
         Refer to the docstring for that method
 
         """
-        args = tuple(['sonos_playlists'] + list(args))
-        return self.music_library.get_music_library_information(*args,
-                                                                **kwargs)
+        args = tuple(["sonos_playlists"] + list(args))
+        return self.music_library.get_music_library_information(*args, **kwargs)
 
     @only_on_master
     def add_uri_to_queue(self, uri, position=0, as_next=False):
@@ -1478,7 +1466,7 @@ class SoCo(_SocoSingletonBase):
         # FIXME: The res.protocol_info should probably represent the mime type
         # etc of the uri. But this seems OK.
         res = [DidlResource(uri=uri, protocol_info="x-rincon-playlist:*:*:*")]
-        item = DidlObject(resources=res, title='', parent_id='', item_id='')
+        item = DidlObject(resources=res, title="", parent_id="", item_id="")
         return self.add_to_queue(item, position, as_next)
 
     @only_on_master
@@ -1497,14 +1485,16 @@ class SoCo(_SocoSingletonBase):
             int: The index of the new item in the queue.
         """
         metadata = to_didl_string(queueable_item)
-        response = self.avTransport.AddURIToQueue([
-            ('InstanceID', 0),
-            ('EnqueuedURI', queueable_item.resources[0].uri),
-            ('EnqueuedURIMetaData', metadata),
-            ('DesiredFirstTrackNumberEnqueued', position),
-            ('EnqueueAsNext', int(as_next))
-        ])
-        qnumber = response['FirstTrackNumberEnqueued']
+        response = self.avTransport.AddURIToQueue(
+            [
+                ("InstanceID", 0),
+                ("EnqueuedURI", queueable_item.resources[0].uri),
+                ("EnqueuedURIMetaData", metadata),
+                ("DesiredFirstTrackNumberEnqueued", position),
+                ("EnqueueAsNext", int(as_next)),
+            ]
+        )
+        qnumber = response["FirstTrackNumberEnqueued"]
         return int(qnumber)
 
     def add_multiple_to_queue(self, items, container=None):
@@ -1519,26 +1509,28 @@ class SoCo(_SocoSingletonBase):
             container_uri = container.resources[0].uri
             container_metadata = to_didl_string(container)
         else:
-            container_uri = ''  # Sonos seems to accept this as well
-            container_metadata = ''  # pylint: disable=redefined-variable-type
+            container_uri = ""  # Sonos seems to accept this as well
+            container_metadata = ""  # pylint: disable=redefined-variable-type
 
         chunk_size = 16  # With each request, we can only add 16 items
         item_list = list(items)  # List for slicing
         for index in range(0, len(item_list), chunk_size):
-            chunk = item_list[index:index + chunk_size]
-            uris = ' '.join([item.resources[0].uri for item in chunk])
-            uri_metadata = ' '.join([to_didl_string(item) for item in chunk])
-            self.avTransport.AddMultipleURIsToQueue([
-                ('InstanceID', 0),
-                ('UpdateID', 0),
-                ('NumberOfURIs', len(chunk)),
-                ('EnqueuedURIs', uris),
-                ('EnqueuedURIsMetaData', uri_metadata),
-                ('ContainerURI', container_uri),
-                ('ContainerMetaData', container_metadata),
-                ('DesiredFirstTrackNumberEnqueued', 0),
-                ('EnqueueAsNext', 0)
-            ])
+            chunk = item_list[index : index + chunk_size]
+            uris = " ".join([item.resources[0].uri for item in chunk])
+            uri_metadata = " ".join([to_didl_string(item) for item in chunk])
+            self.avTransport.AddMultipleURIsToQueue(
+                [
+                    ("InstanceID", 0),
+                    ("UpdateID", 0),
+                    ("NumberOfURIs", len(chunk)),
+                    ("EnqueuedURIs", uris),
+                    ("EnqueuedURIsMetaData", uri_metadata),
+                    ("ContainerURI", container_uri),
+                    ("ContainerMetaData", container_metadata),
+                    ("DesiredFirstTrackNumberEnqueued", 0),
+                    ("EnqueueAsNext", 0),
+                ]
+            )
 
     @only_on_master
     def remove_from_queue(self, index):
@@ -1549,22 +1541,20 @@ class SoCo(_SocoSingletonBase):
             index (int): The (0-based) index of the track to remove
         """
         # TODO: what do these parameters actually do?
-        updid = '0'
-        objid = 'Q:0/' + str(index + 1)
-        self.avTransport.RemoveTrackFromQueue([
-            ('InstanceID', 0),
-            ('ObjectID', objid),
-            ('UpdateID', updid),
-        ])
+        updid = "0"
+        objid = "Q:0/" + str(index + 1)
+        self.avTransport.RemoveTrackFromQueue(
+            [("InstanceID", 0), ("ObjectID", objid), ("UpdateID", updid),]
+        )
 
     @only_on_master
     def clear_queue(self):
         """Remove all tracks from the queue."""
-        self.avTransport.RemoveAllTracksFromQueue([
-            ('InstanceID', 0),
-        ])
+        self.avTransport.RemoveAllTracksFromQueue(
+            [("InstanceID", 0),]
+        )
 
-    @deprecated('0.13', "soco.music_library.get_favorite_radio_shows", '0.15')
+    @deprecated("0.13", "soco.music_library.get_favorite_radio_shows", "0.15")
     def get_favorite_radio_shows(self, start=0, max_items=100):
         """Get favorite radio shows from Sonos' Radio app.
 
@@ -1578,31 +1568,36 @@ class SoCo(_SocoSingletonBase):
         requested (`max_items`), if it is, use `start` to page through and
         get the entire list of favorites.
         """
-        message = 'The output type of this method will probably change in '\
-                  'the future to use SoCo data structures'
+        message = (
+            "The output type of this method will probably change in "
+            "the future to use SoCo data structures"
+        )
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(RADIO_SHOWS, start, max_items)
 
-    @deprecated('0.13', "soco.music_library.get_favorite_radio_stations",
-                '0.15')
+    @deprecated("0.13", "soco.music_library.get_favorite_radio_stations", "0.15")
     def get_favorite_radio_stations(self, start=0, max_items=100):
         """Get favorite radio stations from Sonos' Radio app.
 
         See :meth:`get_favorite_radio_shows` for return type and remarks.
         """
-        message = 'The output type of this method will probably change in '\
-                  'the future to use SoCo data structures'
+        message = (
+            "The output type of this method will probably change in "
+            "the future to use SoCo data structures"
+        )
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(RADIO_STATIONS, start, max_items)
 
-    @deprecated('0.13', "soco.music_library.get_sonos_favorites", '0.15')
+    @deprecated("0.13", "soco.music_library.get_sonos_favorites", "0.15")
     def get_sonos_favorites(self, start=0, max_items=100):
         """Get Sonos favorites.
 
         See :meth:`get_favorite_radio_shows` for return type and remarks.
         """
-        message = 'The output type of this method will probably change in '\
-                  'the future to use SoCo data structures'
+        message = (
+            "The output type of this method will probably change in "
+            "the future to use SoCo data structures"
+        )
         warnings.warn(message, stacklevel=2)
         return self.__get_favorites(SONOS_FAVORITES, start, max_items)
 
@@ -1620,41 +1615,50 @@ class SoCo(_SocoSingletonBase):
         if favorite_type not in (RADIO_SHOWS, RADIO_STATIONS):
             favorite_type = SONOS_FAVORITES
 
-        response = self.contentDirectory.Browse([
-            ('ObjectID',
-             'FV:2' if favorite_type is SONOS_FAVORITES
-             else 'R:0/{0}'.format(favorite_type)),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', start),
-            ('RequestedCount', max_items),
-            ('SortCriteria', '')
-        ])
+        response = self.contentDirectory.Browse(
+            [
+                (
+                    "ObjectID",
+                    "FV:2"
+                    if favorite_type is SONOS_FAVORITES
+                    else "R:0/{0}".format(favorite_type),
+                ),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", start),
+                ("RequestedCount", max_items),
+                ("SortCriteria", ""),
+            ]
+        )
         result = {}
         favorites = []
-        results_xml = response['Result']
+        results_xml = response["Result"]
 
-        if results_xml != '':
+        if results_xml != "":
             # Favorites are returned in DIDL-Lite format
             metadata = XML.fromstring(really_utf8(results_xml))
 
             for item in metadata.findall(
-                    '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}container'
-                    if favorite_type == RADIO_SHOWS else
-                    '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item'):
+                "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}container"
+                if favorite_type == RADIO_SHOWS
+                else "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item"
+            ):
                 favorite = {}
-                favorite['title'] = item.findtext(
-                    '{http://purl.org/dc/elements/1.1/}title')
-                favorite['uri'] = item.findtext(
-                    '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}res')
+                favorite["title"] = item.findtext(
+                    "{http://purl.org/dc/elements/1.1/}title"
+                )
+                favorite["uri"] = item.findtext(
+                    "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}res"
+                )
                 if favorite_type == SONOS_FAVORITES:
-                    favorite['meta'] = item.findtext(
-                        '{urn:schemas-rinconnetworks-com:metadata-1-0/}resMD')
+                    favorite["meta"] = item.findtext(
+                        "{urn:schemas-rinconnetworks-com:metadata-1-0/}resMD"
+                    )
                 favorites.append(favorite)
 
-        result['total'] = response['TotalMatches']
-        result['returned'] = len(favorites)
-        result['favorites'] = favorites
+        result["total"] = response["TotalMatches"]
+        result["returned"] = len(favorites)
+        result["favorites"] = favorites
 
         return result
 
@@ -1666,20 +1670,23 @@ class SoCo(_SocoSingletonBase):
 
         :rtype: :py:class:`~.soco.data_structures.DidlPlaylistContainer`
         """
-        response = self.avTransport.CreateSavedQueue([
-            ('InstanceID', 0),
-            ('Title', title),
-            ('EnqueuedURI', ''),
-            ('EnqueuedURIMetaData', ''),
-        ])
+        response = self.avTransport.CreateSavedQueue(
+            [
+                ("InstanceID", 0),
+                ("Title", title),
+                ("EnqueuedURI", ""),
+                ("EnqueuedURIMetaData", ""),
+            ]
+        )
 
-        item_id = response['AssignedObjectID']
-        obj_id = item_id.split(':', 2)[1]
+        item_id = response["AssignedObjectID"]
+        obj_id = item_id.split(":", 2)[1]
         uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(obj_id)
 
         res = [DidlResource(uri=uri, protocol_info="x-rincon-playlist:*:*:*")]
         return DidlPlaylistContainer(
-            resources=res, title=title, parent_id='SQ:', item_id=item_id)
+            resources=res, title=title, parent_id="SQ:", item_id=item_id
+        )
 
     @only_on_master
     # pylint: disable=invalid-name
@@ -1694,17 +1701,16 @@ class SoCo(_SocoSingletonBase):
         # Note: probably same as Queue service method SaveAsSonosPlaylist
         # but this has not been tested.  This method is what the
         # controller uses.
-        response = self.avTransport.SaveQueue([
-            ('InstanceID', 0),
-            ('Title', title),
-            ('ObjectID', '')
-        ])
-        item_id = response['AssignedObjectID']
-        obj_id = item_id.split(':', 2)[1]
+        response = self.avTransport.SaveQueue(
+            [("InstanceID", 0), ("Title", title), ("ObjectID", "")]
+        )
+        item_id = response["AssignedObjectID"]
+        obj_id = item_id.split(":", 2)[1]
         uri = "file:///jffs/settings/savedqueues.rsq#{0}".format(obj_id)
         res = [DidlResource(uri=uri, protocol_info="x-rincon-playlist:*:*:*")]
         return DidlPlaylistContainer(
-            resources=res, title=title, parent_id='SQ:', item_id=item_id)
+            resources=res, title=title, parent_id="SQ:", item_id=item_id
+        )
 
     @only_on_master
     def remove_sonos_playlist(self, sonos_playlist):
@@ -1722,8 +1728,8 @@ class SoCo(_SocoSingletonBase):
                 object.
 
         """
-        object_id = getattr(sonos_playlist, 'item_id', sonos_playlist)
-        return self.contentDirectory.DestroyObject([('ObjectID', object_id)])
+        object_id = getattr(sonos_playlist, "item_id", sonos_playlist)
+        return self.contentDirectory.DestroyObject([("ObjectID", object_id)])
 
     def add_item_to_sonos_playlist(self, queueable_item, sonos_playlist):
         """Adds a queueable item to a Sonos' playlist.
@@ -1734,26 +1740,27 @@ class SoCo(_SocoSingletonBase):
                 which the item should be added
         """
         # Get the update_id for the playlist
-        response, _ = self.music_library._music_lib_search(
-            sonos_playlist.item_id, 0, 1)
-        update_id = response['UpdateID']
+        response, _ = self.music_library._music_lib_search(sonos_playlist.item_id, 0, 1)
+        update_id = response["UpdateID"]
 
         # Form the metadata for queueable_item
         metadata = to_didl_string(queueable_item)
 
         # Make the request
-        self.avTransport.AddURIToSavedQueue([
-            ('InstanceID', 0),
-            ('UpdateID', update_id),
-            ('ObjectID', sonos_playlist.item_id),
-            ('EnqueuedURI', queueable_item.resources[0].uri),
-            ('EnqueuedURIMetaData', metadata),
-            # 2 ** 32 - 1 = 4294967295, this field has always this value. Most
-            # likely, playlist positions are represented as a 32 bit uint and
-            # this is therefore the largest index possible. Asking to add at
-            # this index therefore probably amounts to adding it "at the end"
-            ('AddAtIndex', 4294967295)
-        ])
+        self.avTransport.AddURIToSavedQueue(
+            [
+                ("InstanceID", 0),
+                ("UpdateID", update_id),
+                ("ObjectID", sonos_playlist.item_id),
+                ("EnqueuedURI", queueable_item.resources[0].uri),
+                ("EnqueuedURIMetaData", metadata),
+                # 2 ** 32 - 1 = 4294967295, this field has always this value. Most
+                # likely, playlist positions are represented as a 32 bit uint and
+                # this is therefore the largest index possible. Asking to add at
+                # this index therefore probably amounts to adding it "at the end"
+                ("AddAtIndex", 4294967295),
+            ]
+        )
 
     @only_on_master
     def set_sleep_timer(self, sleep_time_seconds):
@@ -1775,23 +1782,24 @@ class SoCo(_SocoSingletonBase):
         # useful feature, while None means cancel the current timer
         try:
             if sleep_time_seconds is None:
-                sleep_time = ''
+                sleep_time = ""
             else:
-                sleep_time = format(
-                    datetime.timedelta(seconds=int(sleep_time_seconds))
-                )
-            self.avTransport.ConfigureSleepTimer([
-                ('InstanceID', 0),
-                ('NewSleepTimerDuration', sleep_time),
-            ])
+                sleep_time = format(datetime.timedelta(seconds=int(sleep_time_seconds)))
+            self.avTransport.ConfigureSleepTimer(
+                [("InstanceID", 0), ("NewSleepTimerDuration", sleep_time),]
+            )
         except SoCoUPnPException as err:
-            if 'Error 402 received' in str(err):
-                raise ValueError('invalid sleep_time_seconds, must be integer \
-                    value between 0 and 86399 inclusive or None')
+            if "Error 402 received" in str(err):
+                raise ValueError(
+                    "invalid sleep_time_seconds, must be integer \
+                    value between 0 and 86399 inclusive or None"
+                )
             raise
         except ValueError:
-            raise ValueError('invalid sleep_time_seconds, must be integer \
-                value between 0 and 86399 inclusive or None')
+            raise ValueError(
+                "invalid sleep_time_seconds, must be integer \
+                value between 0 and 86399 inclusive or None"
+            )
 
     @only_on_master
     def get_sleep_timer(self):
@@ -1801,20 +1809,15 @@ class SoCo(_SocoSingletonBase):
             int or NoneType: Number of seconds left in timer. If there is no
                 sleep timer currently set it will return None.
         """
-        resp = self.avTransport.GetRemainingSleepTimerDuration([
-            ('InstanceID', 0),
-        ])
-        if resp['RemainingSleepTimerDuration']:
-            times = resp['RemainingSleepTimerDuration'].split(':')
-            return (int(times[0]) * 3600 +
-                    int(times[1]) * 60 +
-                    int(times[2]))
+        resp = self.avTransport.GetRemainingSleepTimerDuration([("InstanceID", 0),])
+        if resp["RemainingSleepTimerDuration"]:
+            times = resp["RemainingSleepTimerDuration"].split(":")
+            return int(times[0]) * 3600 + int(times[1]) * 60 + int(times[2])
         else:
             return None
 
     @only_on_master
-    def reorder_sonos_playlist(self, sonos_playlist, tracks, new_pos,
-                               update_id=0):
+    def reorder_sonos_playlist(self, sonos_playlist, tracks, new_pos, update_id=0):
         """Reorder and/or Remove tracks in a Sonos playlist.
 
         The underlying call is quite complex as it can both move a track
@@ -1892,42 +1895,50 @@ class SoCo(_SocoSingletonBase):
                 and/or new_pos arguments are invalid.
         """
         # allow either a string 'SQ:10' or an object with item_id attribute.
-        object_id = getattr(sonos_playlist, 'item_id', sonos_playlist)
+        object_id = getattr(sonos_playlist, "item_id", sonos_playlist)
 
         if isinstance(tracks, UnicodeType):
-            track_list = [tracks, ]
-            position_list = [new_pos, ]
+            track_list = [
+                tracks,
+            ]
+            position_list = [
+                new_pos,
+            ]
         elif isinstance(tracks, int):
-            track_list = [tracks, ]
+            track_list = [
+                tracks,
+            ]
             if new_pos is None:
-                new_pos = ''
-            position_list = [new_pos, ]
+                new_pos = ""
+            position_list = [
+                new_pos,
+            ]
         else:
             track_list = [str(x) for x in tracks]
-            position_list = [str(x) if x is not None else '' for x in new_pos]
+            position_list = [str(x) if x is not None else "" for x in new_pos]
         # track_list = ','.join(track_list)
         # position_list = ','.join(position_list)
         if update_id == 0:  # retrieve the update id for the object
             response, _ = self.music_library._music_lib_search(object_id, 0, 1)
-            update_id = response['UpdateID']
+            update_id = response["UpdateID"]
         change = 0
 
         for track, position in zip(track_list, position_list):
-            if track == position:   # there is no move, a no-op
+            if track == position:  # there is no move, a no-op
                 continue
-            response = self.avTransport.ReorderTracksInSavedQueue([
-                ("InstanceID", 0),
-                ("ObjectID", object_id),
-                ("UpdateID", update_id),
-                ("TrackList", track),
-                ("NewPositionList", position),
-            ])
-            change += int(response['QueueLengthChange'])
-            update_id = int(response['NewUpdateID'])
-        length = int(response['NewQueueLength'])
-        response = {'change': change,
-                    'update_id': update_id,
-                    'length': length}
+            response = self.avTransport.ReorderTracksInSavedQueue(
+                [
+                    ("InstanceID", 0),
+                    ("ObjectID", object_id),
+                    ("UpdateID", update_id),
+                    ("TrackList", track),
+                    ("NewPositionList", position),
+                ]
+            )
+            change += int(response["QueueLengthChange"])
+            update_id = int(response["NewUpdateID"])
+        length = int(response["NewQueueLength"])
+        response = {"change": change, "update_id": update_id, "length": length}
         return response
 
     @only_on_master
@@ -1955,19 +1966,18 @@ class SoCo(_SocoSingletonBase):
             SoCoUPnPException: See :py:meth:`reorder_sonos_playlist`
         """
         if not isinstance(sonos_playlist, DidlPlaylistContainer):
-            sonos_playlist = self.get_sonos_playlist_by_attr('item_id',
-                                                             sonos_playlist)
+            sonos_playlist = self.get_sonos_playlist_by_attr("item_id", sonos_playlist)
         count = self.music_library.browse(ml_item=sonos_playlist).total_matches
-        tracks = ','.join([str(x) for x in range(count)])
+        tracks = ",".join([str(x) for x in range(count)])
         if tracks:
-            return self.reorder_sonos_playlist(sonos_playlist, tracks=tracks,
-                                               new_pos='', update_id=update_id)
+            return self.reorder_sonos_playlist(
+                sonos_playlist, tracks=tracks, new_pos="", update_id=update_id
+            )
         else:
-            return {'change': 0, 'update_id': update_id, 'length': count}
+            return {"change": 0, "update_id": update_id, "length": count}
 
     @only_on_master
-    def move_in_sonos_playlist(self, sonos_playlist, track, new_pos,
-                               update_id=0):
+    def move_in_sonos_playlist(self, sonos_playlist, track, new_pos, update_id=0):
         """Move a track to a new position within a Sonos Playlist.
         This is a convenience method for :py:meth:`reorder_sonos_playlist`.
 
@@ -1992,8 +2002,9 @@ class SoCo(_SocoSingletonBase):
         Raises:
             SoCoUPnPException: See :py:meth:`reorder_sonos_playlist`
         """
-        return self.reorder_sonos_playlist(sonos_playlist, int(track),
-                                           int(new_pos), update_id)
+        return self.reorder_sonos_playlist(
+            sonos_playlist, int(track), int(new_pos), update_id
+        )
 
     @only_on_master
     def remove_from_sonos_playlist(self, sonos_playlist, track, update_id=0):
@@ -2020,8 +2031,7 @@ class SoCo(_SocoSingletonBase):
         Raises:
             SoCoUPnPException: See :py:meth:`reorder_sonos_playlist`
         """
-        return self.reorder_sonos_playlist(sonos_playlist, int(track), None,
-                                           update_id)
+        return self.reorder_sonos_playlist(sonos_playlist, int(track), None, update_id)
 
     @only_on_master
     def get_sonos_playlist_by_attr(self, attr_name, match):
@@ -2050,8 +2060,7 @@ class SoCo(_SocoSingletonBase):
         for sonos_playlist in self.get_sonos_playlists():
             if getattr(sonos_playlist, attr_name) == match:
                 return sonos_playlist
-        raise ValueError('No match on "{0}" for value "{1}"'.format(attr_name,
-                                                                    match))
+        raise ValueError('No match on "{0}" for value "{1}"'.format(attr_name, match))
 
 
 # definition section
@@ -2060,14 +2069,22 @@ RADIO_STATIONS = 0
 RADIO_SHOWS = 1
 SONOS_FAVORITES = 2
 
-NS = {'dc': '{http://purl.org/dc/elements/1.1/}',
-      'upnp': '{urn:schemas-upnp-org:metadata-1-0/upnp/}',
-      '': '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}'}
+NS = {
+    "dc": "{http://purl.org/dc/elements/1.1/}",
+    "upnp": "{urn:schemas-upnp-org:metadata-1-0/upnp/}",
+    "": "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}",
+}
 # Valid play modes
-PLAY_MODES = ('NORMAL', 'SHUFFLE_NOREPEAT', 'SHUFFLE', 'REPEAT_ALL',
-              'SHUFFLE_REPEAT_ONE', 'REPEAT_ONE')
+PLAY_MODES = (
+    "NORMAL",
+    "SHUFFLE_NOREPEAT",
+    "SHUFFLE",
+    "REPEAT_ALL",
+    "SHUFFLE_REPEAT_ONE",
+    "REPEAT_ONE",
+)
 # soundbar product names
-SOUNDBARS = ('playbase', 'playbar', 'beam')
+SOUNDBARS = ("playbase", "playbar", "beam")
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo

--- a/soco/data_structure_quirks.py
+++ b/soco/data_structure_quirks.py
@@ -27,8 +27,8 @@ def apply_resource_quirks(resource):
     # At least two music service (Spotify Direct and Amazon in conjunction
     # with Alexa) has been known not to supply the mandatory protocolInfo, so
     # if it is missing supply a dummy one
-    if 'protocolInfo' not in resource.attrib:
-        protocol_info = 'DUMMY_ADDED_BY_QUIRK'
+    if "protocolInfo" not in resource.attrib:
+        protocol_info = "DUMMY_ADDED_BY_QUIRK"
         # For Spotify direct we have a better idea what it should be, since it
         # is included in the main element text
         if resource.text and resource.text.startswith("x-sonos-spotify"):
@@ -38,6 +38,6 @@ def apply_resource_quirks(resource):
             "Resource quirk applied for missing protocolInfo, setting to '%s'",
             protocol_info,
         )
-        resource.set('protocolInfo', protocol_info)
+        resource.set("protocolInfo", protocol_info)
 
     return resource

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -38,9 +38,7 @@ import warnings
 from .compat import with_metaclass
 from .exceptions import DIDLMetadataError
 from .utils import really_unicode
-from .xml import (
-    XML, ns_tag
-)
+from .xml import XML, ns_tag
 from .data_structure_quirks import apply_resource_quirks
 
 # Due to cyclic import problems, we only import from_didl_string at runtime.
@@ -51,6 +49,7 @@ _FROM_DIDL_STRING_FUNCTION = None
 ###############################################################################
 # MISC HELPER FUNCTIONS                                                       #
 ###############################################################################
+
 
 def to_didl_string(*args):
     """Convert any number of `DidlObjects <DidlObject>` to a unicode xml
@@ -64,24 +63,26 @@ def to_didl_string(*args):
         ``'<DIDL-Lite ...>...</DIDL-Lite>'``.
     """
     didl = XML.Element(
-        'DIDL-Lite',
+        "DIDL-Lite",
         {
-            'xmlns': "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
-            'xmlns:dc': "http://purl.org/dc/elements/1.1/",
-            'xmlns:upnp': "urn:schemas-upnp-org:metadata-1-0/upnp/",
-            'xmlns:r': "urn:schemas-rinconnetworks-com:metadata-1-0/"
-        })
+            "xmlns": "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
+            "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+            "xmlns:upnp": "urn:schemas-upnp-org:metadata-1-0/upnp/",
+            "xmlns:r": "urn:schemas-rinconnetworks-com:metadata-1-0/",
+        },
+    )
     for arg in args:
         didl.append(arg.to_element())
     if sys.version_info[0] == 2:
         return XML.tostring(didl)
     else:
-        return XML.tostring(didl, encoding='unicode')
+        return XML.tostring(didl, encoding="unicode")
 
 
 ###############################################################################
 # DIDL RESOURCE                                                               #
 ###############################################################################
+
 
 class DidlResource(object):
 
@@ -95,10 +96,21 @@ class DidlResource(object):
     # Adapted from a class taken from the Python Brisa project - MIT licence.
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, uri, protocol_info, import_uri=None, size=None,
-                 duration=None, bitrate=None, sample_frequency=None,
-                 bits_per_sample=None, nr_audio_channels=None, resolution=None,
-                 color_depth=None, protection=None):
+    def __init__(
+        self,
+        uri,
+        protocol_info,
+        import_uri=None,
+        size=None,
+        duration=None,
+        bitrate=None,
+        sample_frequency=None,
+        bits_per_sample=None,
+        nr_audio_channels=None,
+        resolution=None,
+        color_depth=None,
+        protection=None,
+    ):
         """
         Args:
             uri (str): value of the ``<res>`` tag, typically a URI. It
@@ -157,6 +169,7 @@ class DidlResource(object):
                 element
 
         """
+
         def _int_helper(name):
             """Try to convert the name attribute to an int, or None."""
             result = element.get(name)
@@ -165,7 +178,8 @@ class DidlResource(object):
                     return int(result)
                 except ValueError:
                     raise DIDLMetadataError(
-                        'Could not convert {0} to an integer'.format(name))
+                        "Could not convert {0} to an integer".format(name)
+                    )
             else:
                 return None
 
@@ -174,28 +188,30 @@ class DidlResource(object):
 
         content = {}
         # required
-        content['protocol_info'] = element.get('protocolInfo')
-        if content['protocol_info'] is None:
-            raise DIDLMetadataError('Could not create Resource from Element: '
-                                    'protocolInfo not found (required).')
+        content["protocol_info"] = element.get("protocolInfo")
+        if content["protocol_info"] is None:
+            raise DIDLMetadataError(
+                "Could not create Resource from Element: "
+                "protocolInfo not found (required)."
+            )
         # Optional
-        content['import_uri'] = element.get('importUri')
-        content['size'] = _int_helper('size')
-        content['duration'] = element.get('duration')
-        content['bitrate'] = _int_helper('bitrate')
-        content['sample_frequency'] = _int_helper('sampleFrequency')
-        content['bits_per_sample'] = _int_helper('bitsPerSample')
-        content['nr_audio_channels'] = _int_helper('nrAudioChannels')
-        content['resolution'] = element.get('resolution')
-        content['color_depth'] = _int_helper('colorDepth')
-        content['protection'] = element.get('protection')
-        content['uri'] = element.text
+        content["import_uri"] = element.get("importUri")
+        content["size"] = _int_helper("size")
+        content["duration"] = element.get("duration")
+        content["bitrate"] = _int_helper("bitrate")
+        content["sample_frequency"] = _int_helper("sampleFrequency")
+        content["bits_per_sample"] = _int_helper("bitsPerSample")
+        content["nr_audio_channels"] = _int_helper("nrAudioChannels")
+        content["resolution"] = element.get("resolution")
+        content["color_depth"] = _int_helper("colorDepth")
+        content["protection"] = element.get("protection")
+        content["uri"] = element.text
         return cls(**content)
 
     def __repr__(self):
-        return '<{0} \'{1}\' at {2}>'.format(self.__class__.__name__,
-                                             self.uri,
-                                             hex(id(self)))
+        return "<{0} '{1}' at {2}>".format(
+            self.__class__.__name__, self.uri, hex(id(self))
+        )
 
     def __str__(self):
         return self.__repr__()
@@ -207,34 +223,36 @@ class DidlResource(object):
             ~xml.etree.ElementTree.Element: an Element.
         """
         if not self.protocol_info:
-            raise DIDLMetadataError('Could not create Element for this'
-                                    'resource:'
-                                    'protocolInfo not set (required).')
-        root = XML.Element('res')
+            raise DIDLMetadataError(
+                "Could not create Element for this"
+                "resource:"
+                "protocolInfo not set (required)."
+            )
+        root = XML.Element("res")
 
         # Required
-        root.attrib['protocolInfo'] = self.protocol_info
+        root.attrib["protocolInfo"] = self.protocol_info
         # Optional
         if self.import_uri is not None:
-            root.attrib['importUri'] = self.import_uri
+            root.attrib["importUri"] = self.import_uri
         if self.size is not None:
-            root.attrib['size'] = str(self.size)
+            root.attrib["size"] = str(self.size)
         if self.duration is not None:
-            root.attrib['duration'] = self.duration
+            root.attrib["duration"] = self.duration
         if self.bitrate is not None:
-            root.attrib['bitrate'] = str(self.bitrate)
+            root.attrib["bitrate"] = str(self.bitrate)
         if self.sample_frequency is not None:
-            root.attrib['sampleFrequency'] = str(self.sample_frequency)
+            root.attrib["sampleFrequency"] = str(self.sample_frequency)
         if self.bits_per_sample is not None:
-            root.attrib['bitsPerSample'] = str(self.bits_per_sample)
+            root.attrib["bitsPerSample"] = str(self.bits_per_sample)
         if self.nr_audio_channels is not None:
-            root.attrib['nrAudioChannels'] = str(self.nr_audio_channels)
+            root.attrib["nrAudioChannels"] = str(self.nr_audio_channels)
         if self.resolution is not None:
-            root.attrib['resolution'] = self.resolution
+            root.attrib["resolution"] = self.resolution
         if self.color_depth is not None:
-            root.attrib['colorDepth'] = str(self.color_depth)
+            root.attrib["colorDepth"] = str(self.color_depth)
         if self.protection is not None:
-            root.attrib['protection'] = self.protection
+            root.attrib["protection"] = self.protection
 
         root.text = self.uri
         return root
@@ -250,18 +268,18 @@ class DidlResource(object):
             dict: a dict representing the `DidlResource`
         """
         content = {
-            'uri': self.uri,
-            'protocol_info': self.protocol_info,
-            'import_uri': self.import_uri,
-            'size': self.size,
-            'duration': self.duration,
-            'bitrate': self.bitrate,
-            'sample_frequency': self.sample_frequency,
-            'bits_per_sample': self.bits_per_sample,
-            'nr_audio_channels': self.nr_audio_channels,
-            'resolution': self.resolution,
-            'color_depth': self.color_depth,
-            'protection': self.protection,
+            "uri": self.uri,
+            "protocol_info": self.protocol_info,
+            "import_uri": self.import_uri,
+            "size": self.size,
+            "duration": self.duration,
+            "bitrate": self.bitrate,
+            "sample_frequency": self.sample_frequency,
+            "bits_per_sample": self.bits_per_sample,
+            "nr_audio_channels": self.nr_audio_channels,
+            "resolution": self.resolution,
+            "color_depth": self.color_depth,
+            "protection": self.protection,
         }
         if remove_nones:
             # delete any elements that have a value of None to optimize size
@@ -318,7 +336,7 @@ class DidlMetaClass(type):
         """
         new_cls = super(DidlMetaClass, cls).__new__(cls, name, bases, attrs)
         # Register all subclasses with the global _DIDL_CLASS_TO_CLASS mapping
-        item_class = attrs.get('item_class', None)
+        item_class = attrs.get("item_class", None)
         if item_class is not None:
             _DIDL_CLASS_TO_CLASS[item_class] = new_cls
         return new_cls
@@ -350,16 +368,24 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
     """
 
     # the DIDL Lite class for this object.
-    item_class = 'object'
-    tag = 'item'
+    item_class = "object"
+    tag = "item"
     # key: attribute_name: (ns, tag)
     _translation = {
-        'creator': ('dc', 'creator'),
-        'write_status': ('upnp', 'writeStatus'),
+        "creator": ("dc", "creator"),
+        "write_status": ("upnp", "writeStatus"),
     }
 
-    def __init__(self, title, parent_id, item_id, restricted=True,
-                 resources=None, desc='RINCON_AssociatedZPUDN', **kwargs):
+    def __init__(
+        self,
+        title,
+        parent_id,
+        item_id,
+        restricted=True,
+        resources=None,
+        desc="RINCON_AssociatedZPUDN",
+        **kwargs
+    ):
         """
         Args:
             title (str): the title for the item.
@@ -423,10 +449,11 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
             # For each attribute, check to see if this class allows it
             if key not in self._translation:
                 raise ValueError(
-                    'The key \'{0}\' is not allowed as an argument. Only '
-                    'these keys are allowed: parent_id, item_id, title, '
-                    'restricted, resources, desc'
-                    ' {1}'.format(key, ', '.join(self._translation.keys())))
+                    "The key '{0}' is not allowed as an argument. Only "
+                    "these keys are allowed: parent_id, item_id, title, "
+                    "restricted, resources, desc"
+                    " {1}".format(key, ", ".join(self._translation.keys()))
+                )
             # It is an allowed attribute. Set it as an attribute on self, so
             # that it can be accessed as Classname.attribute in the normal
             # way.
@@ -434,7 +461,7 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
 
     # pylint: disable=too-many-locals, too-many-branches
     @classmethod
-    def from_element(cls, element):     # pylint: disable=R0914
+    def from_element(cls, element):  # pylint: disable=R0914
         """Create an instance of this class from an ElementTree xml Element.
 
         An alternative constructor. The element must be a DIDL-Lite <item> or
@@ -449,31 +476,32 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # indiscriminately, eg a playlistContainer can be an item or a
         # container. So we now just check that it is one or the other.
         tag = element.tag
-        if not (tag.endswith('item') or tag.endswith('container')):
+        if not (tag.endswith("item") or tag.endswith("container")):
             raise DIDLMetadataError(
                 "Wrong element. Expected <item> or <container>,"
-                " got <{0}> for class {1}'".format(
-                    tag, cls.item_class))
+                " got <{0}> for class {1}'".format(tag, cls.item_class)
+            )
         # and that the upnp matches what we are expecting
-        item_class = element.find(ns_tag('upnp', 'class')).text
+        item_class = element.find(ns_tag("upnp", "class")).text
 
         # In case this class has an # specified unofficial
         # subclass, ignore it by stripping it from item_class
-        if '.#' in item_class:
-            item_class = item_class[:item_class.find('.#')]
+        if ".#" in item_class:
+            item_class = item_class[: item_class.find(".#")]
 
         if item_class != cls.item_class:
             raise DIDLMetadataError(
                 "UPnP class is incorrect. Expected '{0}',"
-                " got '{1}'".format(cls.item_class, item_class))
+                " got '{1}'".format(cls.item_class, item_class)
+            )
 
         # parent_id, item_id  and restricted are stored as attributes on the
         # element
-        item_id = element.get('id', None)
+        item_id = element.get("id", None)
         if item_id is None:
             raise DIDLMetadataError("Missing id attribute")
         item_id = really_unicode(item_id)
-        parent_id = element.get('parentID', None)
+        parent_id = element.get("parentID", None)
         if parent_id is None:
             raise DIDLMetadataError("Missing parentID attribute")
         parent_id = really_unicode(parent_id)
@@ -482,29 +510,28 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # Elements are normally required to have a `restricted` tag, but
         # Spotify Direct violates this. To make it work, a missing restricted
         # tag is interpreted as `restricted = True`.
-        restricted = element.get('restricted', None)
-        restricted = (restricted not in [0, 'false', 'False'])
+        restricted = element.get("restricted", None)
+        restricted = restricted not in [0, "false", "False"]
 
         # Similarily, all elements should have a title tag, but Spotify Direct
         # does not comply
-        title_elt = element.find(ns_tag('dc', 'title'))
+        title_elt = element.find(ns_tag("dc", "title"))
         if title_elt is None or not title_elt.text:
-            title = ''
+            title = ""
         else:
             title = really_unicode(title_elt.text)
 
         # Deal with any resource elements
         resources = []
-        for res_elt in element.findall(ns_tag('', 'res')):
+        for res_elt in element.findall(ns_tag("", "res")):
             # Not all Favorits have resources, so in case the "res"
             # tage has no attributes, just skip it
             if cls is DidlFavorite and not res_elt.attrib:
                 continue
-            resources.append(
-                DidlResource.from_element(res_elt))
+            resources.append(DidlResource.from_element(res_elt))
 
         # and the desc element (There is only one in Sonos)
-        desc = element.findtext(ns_tag('', 'desc'))
+        desc = element.findtext(ns_tag("", "desc"))
 
         # Get values of the elements listed in _translation and add them to
         # the content dict
@@ -516,15 +543,20 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
                 content[key] = really_unicode(result)
 
         # Convert type for original track number
-        if content.get('original_track_number') is not None:
-            content['original_track_number'] = \
-                int(content['original_track_number'])
+        if content.get("original_track_number") is not None:
+            content["original_track_number"] = int(content["original_track_number"])
 
         # Now pass the content dict we have just built to the main
         # constructor, as kwargs, to create the object
-        return cls(title=title, parent_id=parent_id, item_id=item_id,
-                   restricted=restricted, resources=resources, desc=desc,
-                   **content)
+        return cls(
+            title=title,
+            parent_id=parent_id,
+            item_id=item_id,
+            restricted=restricted,
+            resources=resources,
+            desc=desc,
+            **content
+        )
 
     @classmethod
     def from_dict(cls, content):
@@ -539,9 +571,10 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         """
         # Do we really need this constructor? Could use DidlObject(**content)
         # instead.  -- We do now
-        if 'resources' in content:
-            content['resources'] = [DidlResource.from_dict(x)
-                                    for x in content['resources']]
+        if "resources" in content:
+            content["resources"] = [
+                DidlResource.from_dict(x) for x in content["resources"]
+            ]
         return cls(**content)
 
     def __eq__(self, playable_item):
@@ -577,12 +610,12 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # 40 originates from terminal width (78) - (15) for address part and
         # (19) for the longest class name and a little left for buffer
         if self.title is not None:
-            middle = self.title.encode('ascii', 'replace')[0:40]
+            middle = self.title.encode("ascii", "replace")[0:40]
         else:
-            middle = str(self.to_dict).encode('ascii', 'replace')[0:40]
-        return '<{0} \'{1}\' at {2}>'.format(self.__class__.__name__,
-                                             middle,
-                                             hex(id(self)))
+            middle = str(self.to_dict).encode("ascii", "replace")[0:40]
+        return "<{0} '{1}' at {2}>".format(
+            self.__class__.__name__, middle, hex(id(self))
+        )
 
     def __str__(self):
         """Get the str value for the item.
@@ -614,14 +647,16 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
                 content[key] = getattr(self, key)
         # also add parent_id, item_id, restricted, title and resources because
         # they are not listed in _translation
-        content['parent_id'] = self.parent_id
-        content['item_id'] = self.item_id
-        content['restricted'] = self.restricted
-        content['title'] = self.title
+        content["parent_id"] = self.parent_id
+        content["item_id"] = self.item_id
+        content["restricted"] = self.restricted
+        content["title"] = self.title
         if self.resources != []:
-            content['resources'] = [resource.to_dict(remove_nones=remove_nones)
-                                    for resource in self.resources]
-        content['desc'] = self.desc
+            content["resources"] = [
+                resource.to_dict(remove_nones=remove_nones)
+                for resource in self.resources
+            ]
+        content["desc"] = self.desc
         return content
 
     def to_element(self, include_namespaces=False):
@@ -636,20 +671,24 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         """
         elt_attrib = {}
         if include_namespaces:
-            elt_attrib.update({
-                'xmlns': "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
-                'xmlns:dc': "http://purl.org/dc/elements/1.1/",
-                'xmlns:upnp': "urn:schemas-upnp-org:metadata-1-0/upnp/",
-            })
-        elt_attrib.update({
-            'parentID': self.parent_id,
-            'restricted': 'true' if self.restricted else 'false',
-            'id': self.item_id
-        })
+            elt_attrib.update(
+                {
+                    "xmlns": "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
+                    "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+                    "xmlns:upnp": "urn:schemas-upnp-org:metadata-1-0/upnp/",
+                }
+            )
+        elt_attrib.update(
+            {
+                "parentID": self.parent_id,
+                "restricted": "true" if self.restricted else "false",
+                "id": self.item_id,
+            }
+        )
         elt = XML.Element(self.tag, elt_attrib)
 
         # Add the title, which should always come first, according to the spec
-        XML.SubElement(elt, 'dc:title').text = self.title
+        XML.SubElement(elt, "dc:title").text = self.title
 
         # Add in any resources
         for resource in self.resources:
@@ -663,14 +702,16 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
                 # are in the default namespace. We need to handle those
                 # carefully
                 tag = "%s:%s" % value if value[0] else "%s" % value[1]
-                XML.SubElement(elt, tag).text = ("%s" % getattr(self, key))
+                XML.SubElement(elt, tag).text = "%s" % getattr(self, key)
         # Now add in the item class
-        XML.SubElement(elt, 'upnp:class').text = self.item_class
+        XML.SubElement(elt, "upnp:class").text = self.item_class
 
         # And the desc element
-        desc_attrib = {'id': 'cdudn', 'nameSpace':
-                       'urn:schemas-rinconnetworks-com:metadata-1-0/'}
-        desc_elt = XML.SubElement(elt, 'desc', desc_attrib)
+        desc_attrib = {
+            "id": "cdudn",
+            "nameSpace": "urn:schemas-rinconnetworks-com:metadata-1-0/",
+        }
+        desc_elt = XML.SubElement(elt, "desc", desc_attrib)
         desc_elt.text = self.desc
 
         return elt
@@ -708,13 +749,14 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         except IndexError:
             if protocol_info is None:
                 # create default protcol info
-                protocol_info = uri[:uri.index(':')] + ':*:*:*'
+                protocol_info = uri[: uri.index(":")] + ":*:*:*"
             self.resources.append(DidlResource(uri, protocol_info))
 
 
 ###############################################################################
 # OBJECT.ITEM HIERARCHY                                                       #
 ###############################################################################
+
 
 class DidlItem(DidlObject):
 
@@ -723,15 +765,15 @@ class DidlItem(DidlObject):
     # The spec allows for an option 'refID' attribute, but we do not handle it
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item'
+    item_class = "object.item"
     # _translation = DidlObject._translation.update({ ...})
     # does not work, but doing it in two steps does
     _translation = DidlObject._translation.copy()
     _translation.update(
         {
-            'stream_content': ('r', 'streamContent'),
-            'radio_show': ('r', 'radioShowMd'),
-            'album_art_uri': ('upnp', 'albumArtURI'),
+            "stream_content": ("r", "streamContent"),
+            "radio_show": ("r", "radioShowMd"),
+            "album_art_uri": ("upnp", "albumArtURI"),
         }
     )
 
@@ -741,17 +783,17 @@ class DidlAudioItem(DidlItem):
     """An audio item."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem'
+    item_class = "object.item.audioItem"
     _translation = DidlItem._translation.copy()
     _translation.update(
         {
-            'genre': ('upnp', 'genre'),
-            'description': ('dc', 'description'),
-            'long_description': ('upnp', 'longDescription'),
-            'publisher': ('dc', 'publisher'),
-            'language': ('dc', 'language'),
-            'relation': ('dc', 'relation'),
-            'rights': ('dc', 'rights'),
+            "genre": ("upnp", "genre"),
+            "description": ("dc", "description"),
+            "long_description": ("upnp", "longDescription"),
+            "publisher": ("dc", "publisher"),
+            "language": ("dc", "language"),
+            "relation": ("dc", "relation"),
+            "rights": ("dc", "rights"),
         }
     )
 
@@ -761,17 +803,17 @@ class DidlMusicTrack(DidlAudioItem):
     """Class that represents a music library track."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem.musicTrack'
+    item_class = "object.item.audioItem.musicTrack"
     # name: (ns, tag)
     _translation = DidlAudioItem._translation.copy()
     _translation.update(
         {
-            'artist': ('upnp', 'artist'),
-            'album': ('upnp', 'album'),
-            'original_track_number': ('upnp', 'originalTrackNumber'),
-            'playlist': ('upnp', 'playlist'),
-            'contributor': ('dc', 'contributor'),
-            'date': ('dc', 'date'),
+            "artist": ("upnp", "artist"),
+            "album": ("upnp", "album"),
+            "original_track_number": ("upnp", "originalTrackNumber"),
+            "playlist": ("upnp", "playlist"),
+            "contributor": ("dc", "contributor"),
+            "date": ("dc", "date"),
         }
     )
 
@@ -781,15 +823,15 @@ class DidlAudioBook(DidlAudioItem):
     """Class that represents an audio book."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem.audioBook'
+    item_class = "object.item.audioItem.audioBook"
     # name: (ns, tag)
     _translation = DidlAudioItem._translation.copy()
     _translation.update(
         {
-            'storageMedium': ('upnp', 'storageMedium'),
-            'producer': ('upnp', 'producer'),
-            'contributor': ('dc', 'contributor'),
-            'date': ('dc', 'date'),
+            "storageMedium": ("upnp", "storageMedium"),
+            "producer": ("upnp", "producer"),
+            "contributor": ("dc", "contributor"),
+            "date": ("dc", "date"),
         }
     )
 
@@ -799,14 +841,14 @@ class DidlAudioBroadcast(DidlAudioItem):
     """Class that represents an audio broadcast."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem.audioBroadcast'
+    item_class = "object.item.audioItem.audioBroadcast"
     _translation = DidlAudioItem._translation.copy()
     _translation.update(
         {
-            'region': ('upnp', 'region'),
-            'radio_call_sign': ('upnp', 'radioCallSign'),
-            'radio_station_id': ('upnp', 'radioStationID'),
-            'channel_nr': ('upnp', 'channelNr'),
+            "region": ("upnp", "region"),
+            "radio_call_sign": ("upnp", "radioCallSign"),
+            "radio_station_id": ("upnp", "radioStationID"),
+            "channel_nr": ("upnp", "channelNr"),
         }
     )
 
@@ -816,7 +858,7 @@ class DidlRecentShow(DidlMusicTrack):
     """Class that represents a recent radio show/podcast."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem.musicTrack.recentShow'
+    item_class = "object.item.audioItem.musicTrack.recentShow"
 
 
 class DidlAudioBroadcastFavorite(DidlAudioBroadcast):
@@ -828,7 +870,7 @@ class DidlAudioBroadcastFavorite(DidlAudioBroadcast):
     # regular object.item.audioItem.audioBroadcast
 
     # the DIDL Lite class for this object.
-    item_class = 'object.item.audioItem.audioBroadcast.sonos-favorite'
+    item_class = "object.item.audioItem.audioBroadcast.sonos-favorite"
 
 
 class DidlFavorite(DidlItem):
@@ -839,14 +881,14 @@ class DidlFavorite(DidlItem):
     object returned by `favorite.reference` instead."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.itemobject.item.sonos-favorite'
+    item_class = "object.itemobject.item.sonos-favorite"
     _translation = DidlItem._translation.copy()
     _translation.update(
         {
-            'type': ('r', 'type'),
-            'description': ('r', 'description'),
-            'favorite_nr': ('r', 'ordinal'),
-            'resource_meta_data': ('r', 'resMD')
+            "type": ("r", "type"),
+            "description": ("r", "description"),
+            "favorite_nr": ("r", "ordinal"),
+            "resource_meta_data": ("r", "resMD"),
         }
     )
 
@@ -863,10 +905,10 @@ class DidlFavorite(DidlItem):
         global _FROM_DIDL_STRING_FUNCTION  # pylint: disable=global-statement
         if not _FROM_DIDL_STRING_FUNCTION:
             from . import data_structures_entry
+
             _FROM_DIDL_STRING_FUNCTION = data_structures_entry.from_didl_string
 
-        ref = _FROM_DIDL_STRING_FUNCTION(
-            getattr(self, 'resource_meta_data'))[0]
+        ref = _FROM_DIDL_STRING_FUNCTION(getattr(self, "resource_meta_data"))[0]
         # The resMD metadata lacks a <res> tag, so we use the resources from
         # the favorite to make 'reference' playable.
         ref.resources = self.resources
@@ -874,7 +916,7 @@ class DidlFavorite(DidlItem):
 
     @reference.setter
     def reference(self, value):
-        setattr(self, 'resource_meta_data', to_didl_string(value))
+        setattr(self, "resource_meta_data", to_didl_string(value))
         self.resources = value.resources
 
 
@@ -882,13 +924,14 @@ class DidlFavorite(DidlItem):
 # OBJECT.CONTAINER HIERARCHY                                                  #
 ###############################################################################
 
+
 class DidlContainer(DidlObject):
 
     """Class that represents a music library container."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container'
-    tag = 'container'
+    item_class = "object.container"
+    tag = "container"
     # We do not implement createClass or searchClass. Not used by Sonos??
     # TODO: handle the 'childCount' element.
 
@@ -898,18 +941,18 @@ class DidlAlbum(DidlContainer):
     """A content directory album."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.album'
+    item_class = "object.container.album"
     # name: (ns, tag)
     _translation = DidlContainer._translation.copy()
     _translation.update(
         {
-            'description': ('dc', 'description'),
-            'long_description': ('upnp', 'longDescription'),
-            'publisher': ('dc', 'publisher'),
-            'contributor': ('dc', 'contributor'),
-            'date': ('dc', 'date'),
-            'relation': ('dc', 'relation'),
-            'rights': ('dc', 'rights'),
+            "description": ("dc", "description"),
+            "long_description": ("upnp", "longDescription"),
+            "publisher": ("dc", "publisher"),
+            "contributor": ("dc", "contributor"),
+            "date": ("dc", "date"),
+            "relation": ("dc", "relation"),
+            "rights": ("dc", "rights"),
         }
     )
 
@@ -919,22 +962,22 @@ class DidlMusicAlbum(DidlAlbum):
     """Class that represents a music library album."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.album.musicAlbum'
+    item_class = "object.container.album.musicAlbum"
     # According to the spec, all musicAlbums should be represented in
     # XML by a <container> tag. Sonos sometimes uses <container> and
     # sometimes uses <item>. <container> seems to work here for the moment.
-    tag = 'container'
+    tag = "container"
     # name: (ns, tag)
     # pylint: disable=protected-access
     #:
     _translation = DidlAlbum._translation.copy()
     _translation.update(
         {
-            'artist': ('upnp', 'artist'),
-            'genre': ('upnp', 'genre'),
-            'producer': ('upnp', 'producer'),
-            'toc': ('upnp', 'toc'),
-            'album_art_uri': ('upnp', 'albumArtURI'),
+            "artist": ("upnp", "artist"),
+            "genre": ("upnp", "genre"),
+            "producer": ("upnp", "producer"),
+            "toc": ("upnp", "toc"),
+            "album_art_uri": ("upnp", "albumArtURI"),
         }
     )
 
@@ -947,11 +990,11 @@ class DidlMusicAlbumFavorite(DidlAlbum):
     """
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.album.musicAlbum.sonos-favorite'
+    item_class = "object.container.album.musicAlbum.sonos-favorite"
     # Despite the fact that the item derives from object.container, it's
     # XML does not include a <container> tag, but an <item> tag. This seems
     # to be an error by Sonos.
-    tag = 'item'
+    tag = "item"
 
 
 class DidlMusicAlbumCompilation(DidlAlbum):
@@ -960,12 +1003,13 @@ class DidlMusicAlbumCompilation(DidlAlbum):
 
     This class is not part of the DIDL spec and is Sonos specific.
     """
+
     # These classes appear when browsing the library and Sonos has been set
     # to group albums using compilations.
     # See https://github.com/SoCo/SoCo/issues/280
     # the DIDL Lite class for this object.
-    item_class = 'object.container.album.musicAlbum.compilation'
-    tag = 'container'
+    item_class = "object.container.album.musicAlbum.compilation"
+    tag = "container"
 
 
 class DidlPerson(DidlContainer):
@@ -973,14 +1017,12 @@ class DidlPerson(DidlContainer):
     """A content directory class representing a person."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.person'
-    tag = 'item'
+    item_class = "object.container.person"
+    tag = "item"
     #: dfdf
     _translation = DidlContainer._translation.copy()
     _translation.update(
-        {
-            'language': ('dc', 'language'),
-        }
+        {"language": ("dc", "language"),}
     )
 
 
@@ -991,7 +1033,7 @@ class DidlComposer(DidlPerson):
     # Not in the DIDL-Lite spec. Sonos specific??
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.person.composer'
+    item_class = "object.container.person.composer"
 
 
 class DidlMusicArtist(DidlPerson):
@@ -999,13 +1041,13 @@ class DidlMusicArtist(DidlPerson):
     """Class that represents a music library artist."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.person.musicArtist'
+    item_class = "object.container.person.musicArtist"
     # name: (ns, tag)
     _translation = DidlPerson._translation.copy()
     _translation.update(
         {
-            'genre': ('upnp', 'genre'),
-            'artist_discography_uri': ('upnp', 'artistDiscographyURI'),
+            "genre": ("upnp", "genre"),
+            "artist_discography_uri": ("upnp", "artistDiscographyURI"),
         }
     )
 
@@ -1017,7 +1059,7 @@ class DidlAlbumList(DidlContainer):
     # This does not appear (that I can find) in the DIDL-Lite specs.
     # Presumably Sonos specific
     # the DIDL Lite class for this object.
-    item_class = 'object.container.albumlist'
+    item_class = "object.container.albumlist"
 
 
 class DidlPlaylistContainer(DidlContainer):
@@ -1025,26 +1067,26 @@ class DidlPlaylistContainer(DidlContainer):
     """Class that represents a music library play list."""
 
     #:
-    item_class = 'object.container.playlistContainer'
+    item_class = "object.container.playlistContainer"
     # Yes, really. Sonos uses the item tag, not the container tag. But
     # sometimes it uses the container tag, eg:
     # >>> s=soco.SoCo('192.168.1.102')
     # >>> s.get_playlists()
     # See https://github.com/SoCo/SoCo/issues/353
-    tag = 'item'
+    tag = "item"
     # name: (ns, tag)
     _translation = DidlContainer._translation.copy()
     _translation.update(
         {
-            'artist': ('upnp', 'artist'),
-            'genre': ('upnp', 'genre'),
-            'long_description': ('upnp', 'longDescription'),
-            'producer': ('dc', 'producer'),
-            'contributor': ('dc', 'contributor'),
-            'description': ('dc', 'description'),
-            'date': ('dc', 'date'),
-            'language': ('dc', 'language'),
-            'rights': ('dc', 'rights'),
+            "artist": ("upnp", "artist"),
+            "genre": ("upnp", "genre"),
+            "long_description": ("upnp", "longDescription"),
+            "producer": ("dc", "producer"),
+            "contributor": ("dc", "contributor"),
+            "description": ("dc", "description"),
+            "date": ("dc", "date"),
+            "language": ("dc", "language"),
+            "rights": ("dc", "rights"),
         }
     )
 
@@ -1058,19 +1100,21 @@ class DidlSameArtist(DidlPlaylistContainer):
 
     # Not in the DIDL-Lite spec. Sonos specific?
     # the DIDL Lite class for this object.
-    item_class = 'object.container.playlistContainer.sameArtist'
+    item_class = "object.container.playlistContainer.sameArtist"
 
 
 class DidlPlaylistContainerFavorite(DidlPlaylistContainer):
 
     """Class that represents a Sonos favorite play list."""
-    item_class = 'object.container.playlistContainer.sonos-favorite'
+
+    item_class = "object.container.playlistContainer.sonos-favorite"
 
 
 class DidlPlaylistContainerTracklist(DidlPlaylistContainer):
 
     """Class that represents a Sonos tracklist."""
-    item_class = 'object.container.playlistContainer.tracklist'
+
+    item_class = "object.container.playlistContainer.tracklist"
 
 
 class DidlGenre(DidlContainer):
@@ -1078,16 +1122,16 @@ class DidlGenre(DidlContainer):
     """A content directory class representing a general genre."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.genre'
+    item_class = "object.container.genre"
     # name: (ns, tag)
 
     #:
     _translation = DidlContainer._translation.copy()
     _translation.update(
         {
-            'genre': ('upnp', 'genre'),
-            'long_description': ('upnp', 'longDescription'),
-            'description': ('dc', 'description'),
+            "genre": ("upnp", "genre"),
+            "long_description": ("upnp", "longDescription"),
+            "description": ("dc", "description"),
         }
     )
 
@@ -1097,21 +1141,22 @@ class DidlMusicGenre(DidlGenre):
     """Class that represents a music genre."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.genre.musicGenre'
-    tag = 'item'
+    item_class = "object.container.genre.musicGenre"
+    tag = "item"
 
 
 class DidlRadioShow(DidlContainer):
     """Class that represents a radio show."""
 
     # the DIDL Lite class for this object.
-    item_class = 'object.container.radioShow'
+    item_class = "object.container.radioShow"
     # A radio show doesn't seem to have any special attributes
 
 
 ###############################################################################
 # SPECIAL LISTS                                                               #
 ###############################################################################
+
 
 class ListOfMusicInfoItems(list):
 
@@ -1132,10 +1177,10 @@ class ListOfMusicInfoItems(list):
     def __init__(self, items, number_returned, total_matches, update_id):
         super(ListOfMusicInfoItems, self).__init__(items)
         self._metadata = {
-            'item_list': list(items),
-            'number_returned': number_returned,
-            'total_matches': total_matches,
-            'update_id': update_id,
+            "item_list": list(items),
+            "number_returned": number_returned,
+            "total_matches": total_matches,
+            "update_id": update_id,
         }
 
     def __getitem__(self, key):
@@ -1148,7 +1193,7 @@ class ListOfMusicInfoItems(list):
             attributes.
         """
         if key in self._metadata:
-            if key == 'item_list':
+            if key == "item_list":
                 message = """
                 Calling [\'item_list\'] on search results to obtain the objects
                 is no longer necessary, since the object returned from searches
@@ -1160,8 +1205,10 @@ class ListOfMusicInfoItems(list):
                 dictionary [\'{0}\'] is deprecated. Please use the named
                 attribute {1}.{0} instead. The deprecated way of retrieving the
                 metadata will be removed from the third release after
-                0.8""".format(key, self.__class__.__name__)
-            message = textwrap.dedent(message).replace('\n', ' ').lstrip()
+                0.8""".format(
+                    key, self.__class__.__name__
+                )
+            message = textwrap.dedent(message).replace("\n", " ").lstrip()
             warnings.warn(message, stacklevel=2)
             return self._metadata[key]
         else:
@@ -1170,17 +1217,17 @@ class ListOfMusicInfoItems(list):
     @property
     def number_returned(self):
         """str: the number of returned matches."""
-        return self._metadata['number_returned']
+        return self._metadata["number_returned"]
 
     @property
     def total_matches(self):
         """str: the number of total matches."""
-        return self._metadata['total_matches']
+        return self._metadata["total_matches"]
 
     @property
     def update_id(self):
         """str: the update ID."""
-        return self._metadata['update_id']
+        return self._metadata["update_id"]
 
 
 class SearchResult(ListOfMusicInfoItems):
@@ -1190,23 +1237,23 @@ class SearchResult(ListOfMusicInfoItems):
     Browse is just a special case of search.
     """
 
-    def __init__(self, items, search_type, number_returned,
-                 total_matches, update_id):
+    def __init__(self, items, search_type, number_returned, total_matches, update_id):
         super(SearchResult, self).__init__(
             items, number_returned, total_matches, update_id
         )
-        self._metadata['search_type'] = search_type
+        self._metadata["search_type"] = search_type
 
     def __repr__(self):
-        return '{0}(items={1}, search_type=\'{2}\')'.format(
+        return "{0}(items={1}, search_type='{2}')".format(
             self.__class__.__name__,
             super(SearchResult, self).__repr__(),
-            self.search_type)
+            self.search_type,
+        )
 
     @property
     def search_type(self):
         """str: the search type."""
-        return self._metadata['search_type']
+        return self._metadata["search_type"]
 
 
 class Queue(ListOfMusicInfoItems):
@@ -1214,7 +1261,6 @@ class Queue(ListOfMusicInfoItems):
     """Container class that represents a queue."""
 
     def __repr__(self):
-        return '{0}(items={1})'.format(
-            self.__class__.__name__,
-            super(Queue, self).__repr__(),
+        return "{0}(items={1})".format(
+            self.__class__.__name__, super(Queue, self).__repr__(),
         )

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -1,4 +1,3 @@
-
 """This module is for parsing and conversion functions that needs
 objects from both music library and music service data structures
 
@@ -8,9 +7,7 @@ from __future__ import absolute_import
 
 import logging
 
-from .xml import (
-    XML, ns_tag
-)
+from .xml import XML, ns_tag
 from .data_structures import _DIDL_CLASS_TO_CLASS
 from .exceptions import DIDLMetadataError
 from .compat import urlparse
@@ -20,7 +17,7 @@ from .music_services.music_service import desc_from_uri
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.NullHandler())
-_LOG.debug('%s imported', __name__)
+_LOG.debug("%s imported", __name__)
 
 
 def from_didl_string(string):
@@ -35,15 +32,15 @@ def from_didl_string(string):
         list: A list of one or more instances of `DidlObject` or a subclass
     """
     items = []
-    root = XML.fromstring(string.encode('utf-8'))
+    root = XML.fromstring(string.encode("utf-8"))
     for elt in root:
-        if elt.tag.endswith('item') or elt.tag.endswith('container'):
-            item_class = elt.findtext(ns_tag('upnp', 'class'))
+        if elt.tag.endswith("item") or elt.tag.endswith("container"):
+            item_class = elt.findtext(ns_tag("upnp", "class"))
 
             # In case this class has an # specified unofficial
             # subclass, ignore it by stripping it from item_class
-            if '.#' in item_class:
-                item_class = item_class[:item_class.find('.#')]
+            if ".#" in item_class:
+                item_class = item_class[: item_class.find(".#")]
 
             try:
                 cls = _DIDL_CLASS_TO_CLASS[item_class]
@@ -57,20 +54,18 @@ def from_didl_string(string):
             # according to the spec, but I have not seen one there in Sonos, so
             # we treat them as illegal. May need to fix this if this
             # causes problems.
-            raise DIDLMetadataError("Illegal child of DIDL element: <%s>"
-                                    % elt.tag)
+            raise DIDLMetadataError("Illegal child of DIDL element: <%s>" % elt.tag)
     _LOG.debug(
         'Created data structures: %.20s (CUT) from Didl string "%.20s" (CUT)',
-        items, string,
+        items,
+        string,
     )
     return items
 
 
 # Obviously imcomplete, but missing entries will not result in error, but just
 # a logged warning and no upgrade of the data structure
-DIDL_NAME_TO_QUALIFIED_MS_NAME = {
-    'DidlMusicTrack': 'MediaMetadataTrack'
-}
+DIDL_NAME_TO_QUALIFIED_MS_NAME = {"DidlMusicTrack": "MediaMetadataTrack"}
 
 
 def attempt_datastructure_upgrade(didl_item):
@@ -81,19 +76,19 @@ def attempt_datastructure_upgrade(didl_item):
     try:
         resource = didl_item.resources[0]
     except IndexError:
-        _LOG.debug('Upgrade not possible, no resources')
+        _LOG.debug("Upgrade not possible, no resources")
         return didl_item
 
-    if resource.uri.startswith('x-sonos-http'):
+    if resource.uri.startswith("x-sonos-http"):
         # Get data
         uri = resource.uri
         # Now we need to create a DIDL item id. It seems to be based on the uri
         path = urlparse(uri).path
         # Strip any extensions, eg .mp3, from the end of the path
-        path = path.rsplit('.', 1)[0]
+        path = path.rsplit(".", 1)[0]
         # The ID has an 8 (hex) digit prefix. But it doesn't seem to
         # matter what it is!
-        item_id = '11111111{0}'.format(path)
+        item_id = "11111111{0}".format(path)
 
         # Pass over all the available metadata in the metadata dict, in the
         # future ask ms data structure to upgrade metadata from the service
@@ -104,18 +99,18 @@ def attempt_datastructure_upgrade(didl_item):
 
         # Get class
         try:
-            cls = get_class(DIDL_NAME_TO_QUALIFIED_MS_NAME[
-                didl_item.__class__.__name__
-            ])
+            cls = get_class(
+                DIDL_NAME_TO_QUALIFIED_MS_NAME[didl_item.__class__.__name__]
+            )
         except KeyError:
             # The data structure should be upgraded, but there is an entry
             # missing from DIDL_NAME_TO_QUALIFIED_MS_NAME. Log this as a
             # warning.
             _LOG.warning(
-                'DATA STRUCTURE UPGRADE FAIL. Unable to upgrade music library '
-                'data structure to music service data structure because an '
-                'entry is missing for %s in DIDL_NAME_TO_QUALIFIED_MS_NAME. '
-                'This should be reported as a bug.',
+                "DATA STRUCTURE UPGRADE FAIL. Unable to upgrade music library "
+                "data structure to music service data structure because an "
+                "entry is missing for %s in DIDL_NAME_TO_QUALIFIED_MS_NAME. "
+                "This should be reported as a bug.",
                 didl_item.__class__.__name__,
             )
             return didl_item
@@ -130,5 +125,5 @@ def attempt_datastructure_upgrade(didl_item):
         _LOG.debug("Item %s upgraded to %s", didl_item, upgraded_item)
         return upgraded_item
 
-    _LOG.debug('Upgrade not necessary')
+    _LOG.debug("Upgrade not necessary")
     return didl_item

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -66,25 +66,29 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
         Create and return a socket with appropriate options set for multicast.
         """
 
-        _sock = socket.socket(
-            socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        _sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         # UPnP v1.0 requires a TTL of 4
-        _sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL,
-                         struct.pack("B", 4))
+        _sock.setsockopt(
+            socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("B", 4)
+        )
         if interface_addr is not None:
             _sock.setsockopt(
-                socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
-                socket.inet_aton(interface_addr))
+                socket.IPPROTO_IP,
+                socket.IP_MULTICAST_IF,
+                socket.inet_aton(interface_addr),
+            )
         return _sock
 
     # pylint: disable=invalid-name
-    PLAYER_SEARCH = dedent("""\
+    PLAYER_SEARCH = dedent(
+        """\
         M-SEARCH * HTTP/1.1
         HOST: 239.255.255.250:1900
         MAN: "ssdp:discover"
         MX: 1
         ST: urn:schemas-upnp-org:device:ZonePlayer:1
-        """).encode('utf-8')
+        """
+    ).encode("utf-8")
     MCAST_GRP = "239.255.255.250"
     MCAST_PORT = 1900
 
@@ -94,8 +98,9 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
         try:
             address = socket.inet_aton(interface_addr)
         except socket.error:
-            raise ValueError("{0} is not a valid IP address string".format(
-                interface_addr))
+            raise ValueError(
+                "{0} is not a valid IP address string".format(interface_addr)
+            )
         _sockets.append(create_socket(interface_addr))
         _LOG.info("Sending discovery packets on default interface")
     else:
@@ -115,8 +120,12 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
             try:
                 _sockets.append(create_socket(address))
             except socket.error as e:
-                _LOG.warning("Can't make a discovery socket for %s: %s: %s",
-                             address, e.__class__.__name__, e)
+                _LOG.warning(
+                    "Can't make a discovery socket for %s: %s: %s",
+                    address,
+                    e.__class__.__name__,
+                    e,
+                )
         # Add a socket using the system default address
         _sockets.append(create_socket())
         # Used to be logged as:
@@ -169,9 +178,7 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
         if response:
             for _sock in response:
                 data, addr = _sock.recvfrom(1024)
-                _LOG.debug(
-                    'Received discovery response from %s: "%s"', addr, data
-                )
+                _LOG.debug('Received discovery response from %s: "%s"', addr, data)
                 if b"Sonos" in data:
                     # Now we have an IP, we can build a SoCo instance and query
                     # that player for the topology to find the other players.
@@ -204,8 +211,9 @@ def any_soco():
         # as long as it is visible (i.e. not a bridge etc). Otherwise,
         # perform discovery (again, excluding invisibles) and return one of
         # those
-        device = next(d for d in cls._instances[cls._class_group].values()
-                      if d.is_visible)
+        device = next(
+            d for d in cls._instances[cls._class_group].values() if d.is_visible
+        )
     except (KeyError, StopIteration):
         devices = discover()
         return None if devices is None else devices.pop()

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -124,7 +124,7 @@ class SoCoFault(object):
         Args:
             exception (Exception): The exception which should be thrown on use
         """
-        self.__dict__['exception'] = exception
+        self.__dict__["exception"] = exception
 
     def __getattr__(self, name):
         raise self.exception
@@ -139,10 +139,9 @@ class SoCoFault(object):
         raise self.exception
 
     def __repr__(self):
-        return '<{0}: {1} at {2}>'.format(self.__class__.__name__,
-                                          repr(self.exception),
-                                          hex(id(self)))
+        return "<{0}: {1} at {2}>".format(
+            self.__class__.__name__, repr(self.exception), hex(id(self))
+        )
 
     def __str__(self):
-        return '<{0}: {1}>'.format(self.__class__.__name__,
-                                   repr(self.exception))
+        return "<{0}: {1}>".format(self.__class__.__name__, repr(self.exception))

--- a/soco/groups.py
+++ b/soco/groups.py
@@ -105,7 +105,8 @@ class ZoneGroup(object):
 
     def __repr__(self):
         return "{0}(uid='{1}', coordinator={2!r}, members={3!r})".format(
-            self.__class__.__name__, self.uid, self.coordinator, self.members)
+            self.__class__.__name__, self.uid, self.coordinator, self.members
+        )
 
     @property
     def label(self):
@@ -136,19 +137,18 @@ class ZoneGroup(object):
 
         An integer between 0 and 100.
         """
-        response = self.coordinator.groupRenderingControl.GetGroupVolume([
-            ('InstanceID', 0)
-        ])
-        return int(response['CurrentVolume'])
+        response = self.coordinator.groupRenderingControl.GetGroupVolume(
+            [("InstanceID", 0)]
+        )
+        return int(response["CurrentVolume"])
 
     @volume.setter
     def volume(self, group_volume):
         group_volume = int(group_volume)
         group_volume = max(0, min(group_volume, 100))  # Coerce in range
-        self.coordinator.groupRenderingControl.SetGroupVolume([
-            ('InstanceID', 0),
-            ('DesiredVolume', group_volume)
-        ])
+        self.coordinator.groupRenderingControl.SetGroupVolume(
+            [("InstanceID", 0), ("DesiredVolume", group_volume)]
+        )
 
     @property
     def mute(self):
@@ -156,19 +156,18 @@ class ZoneGroup(object):
 
         True or False.
         """
-        response = self.coordinator.groupRenderingControl.GetGroupMute([
-            ('InstanceID', 0)
-        ])
-        mute_state = response['CurrentMute']
+        response = self.coordinator.groupRenderingControl.GetGroupMute(
+            [("InstanceID", 0)]
+        )
+        mute_state = response["CurrentMute"]
         return bool(int(mute_state))
 
     @mute.setter
     def mute(self, group_mute):
-        mute_value = '1' if group_mute else '0'
-        self.coordinator.groupRenderingControl.SetGroupMute([
-            ('InstanceID', 0),
-            ('DesiredMute', mute_value)
-        ])
+        mute_value = "1" if group_mute else "0"
+        self.coordinator.groupRenderingControl.SetGroupMute(
+            [("InstanceID", 0), ("DesiredMute", mute_value)]
+        )
 
     def set_relative_volume(self, relative_group_volume):
         """Adjust the group volume up or down by a relative amount.
@@ -197,8 +196,7 @@ class ZoneGroup(object):
         """
         relative_group_volume = int(relative_group_volume)
         # Sonos automatically handles out-of-range values.
-        resp = self.coordinator.groupRenderingControl.SetRelativeGroupVolume([
-            ('InstanceID', 0),
-            ('Adjustment', relative_group_volume)
-        ])
-        return int(resp['NewVolume'])
+        resp = self.coordinator.groupRenderingControl.SetRelativeGroupVolume(
+            [("InstanceID", 0), ("Adjustment", relative_group_volume)]
+        )
+        return int(resp["NewVolume"])

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -13,9 +13,7 @@ from __future__ import unicode_literals
 
 from .exceptions import DIDLMetadataError
 from .utils import camel_to_underscore
-from .xml import (
-    NAMESPACES, XML, ns_tag
-)
+from .xml import NAMESPACES, XML, ns_tag
 
 
 def get_ms_item(xml, service, parent_id):
@@ -23,7 +21,7 @@ def get_ms_item(xml, service, parent_id):
 
     The class is identified by getting the type from the 'itemType' tag
     """
-    cls = MS_TYPE_TO_CLASS.get(xml.findtext(ns_tag('ms', 'itemType')))
+    cls = MS_TYPE_TO_CLASS.get(xml.findtext(ns_tag("ms", "itemType")))
     out = cls.from_xml(xml, service, parent_id)
     return out
 
@@ -39,7 +37,7 @@ def tags_with_text(xml, tags=None):
         elif len(element) > 0:  # pylint: disable=len-as-condition
             tags_with_text(element, tags)
         else:
-            message = 'Unknown XML structure: {}'.format(element)
+            message = "Unknown XML structure: {}".format(element)
             raise ValueError(message)
     return tags
 
@@ -108,42 +106,43 @@ class MusicServiceItem(object):
          </mediaMetadata>
         """
         # Add a few extra pieces of information
-        content = {'description': service.description,
-                   'service_id': service.service_id,
-                   'parent_id': parent_id}
+        content = {
+            "description": service.description,
+            "service_id": service.service_id,
+            "parent_id": parent_id,
+        }
         # Extract values from the XML
         all_text_elements = tags_with_text(xml)
         for item in all_text_elements:
-            tag = item.tag[len(NAMESPACES['ms']) + 2:]  # Strip namespace
+            tag = item.tag[len(NAMESPACES["ms"]) + 2 :]  # Strip namespace
             tag = camel_to_underscore(tag)  # Convert to nice names
             if tag not in cls.valid_fields:
-                message = 'The info tag \'{}\' is not allowed for this item'.\
-                    format(tag)
+                message = "The info tag '{}' is not allowed for this item".format(tag)
                 raise ValueError(message)
             content[tag] = item.text
 
         # Convert values for known types
         for key, value in content.items():
-            if key == 'duration':
+            if key == "duration":
                 content[key] = int(value)
-            if key in ['can_play', 'can_skip', 'can_add_to_favorites',
-                       'can_enumerate']:
-                content[key] = (value == 'true')
+            if key in ["can_play", "can_skip", "can_add_to_favorites", "can_enumerate"]:
+                content[key] = value == "true"
         # Rename a single item
-        content['item_id'] = content.pop('id')
+        content["item_id"] = content.pop("id")
         # And get the extended id
-        content['extended_id'] = service.id_to_extended_id(content['item_id'],
-                                                           cls)
+        content["extended_id"] = service.id_to_extended_id(content["item_id"], cls)
         # Add URI if there is one for the relevant class
         uri = service.form_uri(content, cls)
         if uri:
-            content['uri'] = uri
+            content["uri"] = uri
 
         # Check for all required values
         for key in cls.required_fields:
             if key not in content:
-                message = 'An XML field that correspond to the key \'{}\' '\
-                    'is required. See the docstring for help.'.format(key)
+                message = (
+                    "An XML field that correspond to the key '{}' "
+                    "is required. See the docstring for help.".format(key)
+                )
 
         return cls.from_dict(content)
 
@@ -185,13 +184,11 @@ class MusicServiceItem(object):
         """
         # 40 originates from terminal width (78) - (15) for address part and
         # (19) for the longest class name and a little left for buffer
-        if self.content.get('title') is not None:
-            middle = self.content['title'].encode('ascii', 'replace')[0:40]
+        if self.content.get("title") is not None:
+            middle = self.content["title"].encode("ascii", "replace")[0:40]
         else:
-            middle = str(self.content).encode('ascii', 'replace')[0:40]
-        return '<{} \'{}\' at {}>'.format(self.__class__.__name__,
-                                          middle,
-                                          hex(id(self)))
+            middle = str(self.content).encode("ascii", "replace")[0:40]
+        return "<{} '{}' at {}>".format(self.__class__.__name__, middle, hex(id(self)))
 
     def __str__(self):
         """Return the str value for the item::
@@ -235,120 +232,141 @@ class MusicServiceItem(object):
         """
         # Check if this item is meant to be played
         if not self.can_play:
-            message = 'This item is not meant to be played and therefore '\
-                'also not to create its own didl_metadata'
+            message = (
+                "This item is not meant to be played and therefore "
+                "also not to create its own didl_metadata"
+            )
             raise DIDLMetadataError(message)
         # Check if we have the attributes to create the didl metadata:
-        for key in ['extended_id', 'title', 'item_class']:
+        for key in ["extended_id", "title", "item_class"]:
             if not hasattr(self, key):
-                message = 'The property \'{}\' is not present on this item. '\
-                    'This indicates that this item was not meant to create '\
-                    'didl_metadata'.format(key)
+                message = (
+                    "The property '{}' is not present on this item. "
+                    "This indicates that this item was not meant to create "
+                    "didl_metadata".format(key)
+                )
                 raise DIDLMetadataError(message)
-        if 'description' not in self.content:
-            message = 'The item for \'description\' is not present in '\
-                'self.content. This indicates that this item was not meant '\
-                'to create didl_metadata'
+        if "description" not in self.content:
+            message = (
+                "The item for 'description' is not present in "
+                "self.content. This indicates that this item was not meant "
+                "to create didl_metadata"
+            )
             raise DIDLMetadataError(message)
 
         # Main element, ugly? yes! but I have given up on using namespaces
         # with xml.etree.ElementTree
-        xml = XML.Element(
-            '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}DIDL-Lite'
-        )
+        xml = XML.Element("{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}DIDL-Lite")
         # Item sub element
-        item_attrib = {
-            'parentID': '',
-            'restricted': 'true',
-            'id': self.extended_id
-        }
+        item_attrib = {"parentID": "", "restricted": "true", "id": self.extended_id}
         # Only add the parent_id if we have it
         if self.parent_id:
-            item_attrib['parentID'] = self.parent_id
+            item_attrib["parentID"] = self.parent_id
         item = XML.SubElement(
-            xml,
-            '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item',
-            item_attrib,
+            xml, "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item", item_attrib,
         )
 
         # Add title and class
         XML.SubElement(
-            item, '{http://purl.org/dc/elements/1.1/}title',
+            item, "{http://purl.org/dc/elements/1.1/}title",
         ).text = self.title
         XML.SubElement(
-            item, '{urn:schemas-upnp-org:metadata-1-0/upnp/}class',
+            item, "{urn:schemas-upnp-org:metadata-1-0/upnp/}class",
         ).text = self.item_class
         # Add the desc element
         desc_attrib = {
-            'id': 'cdudn',
-            'nameSpace': 'urn:schemas-rinconnetworks-com:metadata-1-0/'
+            "id": "cdudn",
+            "nameSpace": "urn:schemas-rinconnetworks-com:metadata-1-0/",
         }
         desc = XML.SubElement(
-            item,
-            '{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}desc',
-            desc_attrib,
+            item, "{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}desc", desc_attrib,
         )
-        desc.text = self.content['description']
+        desc.text = self.content["description"]
 
         return xml
 
     @property
     def item_id(self):
         """Return the item id."""
-        return self.content['item_id']
+        return self.content["item_id"]
 
     @property
     def extended_id(self):
         """Return the extended id."""
-        return self.content['extended_id']
+        return self.content["extended_id"]
 
     @property
     def title(self):
         """Return the title."""
-        return self.content['title']
+        return self.content["title"]
 
     @property
     def service_id(self):
         """Return the service ID."""
-        return self.content['service_id']
+        return self.content["service_id"]
 
     @property
     def can_play(self):
         """Return a boolean for whether the item can be played."""
-        return bool(self.content.get('can_play'))
+        return bool(self.content.get("can_play"))
 
     @property
     def parent_id(self):
         """Return the extended parent_id, if set, otherwise return None."""
-        return self.content.get('parent_id')
+        return self.content.get("parent_id")
 
     @property
     def album_art_uri(self):
         """Return the album art URI if set, otherwise return None."""
-        return self.content.get('album_art_uri')
+        return self.content.get("album_art_uri")
 
 
 class MSTrack(MusicServiceItem):
 
     """Class that represents a music service track."""
 
-    item_class = 'object.item.audioItem.musicTrack'
+    item_class = "object.item.audioItem.musicTrack"
     valid_fields = [
-        'album', 'can_add_to_favorites', 'artist', 'album_artist_id', 'title',
-        'album_id', 'album_art_uri', 'album_artist', 'composer_id',
-        'item_type', 'composer', 'duration', 'can_skip', 'artist_id',
-        'can_play', 'id', 'mime_type', 'description'
+        "album",
+        "can_add_to_favorites",
+        "artist",
+        "album_artist_id",
+        "title",
+        "album_id",
+        "album_art_uri",
+        "album_artist",
+        "composer_id",
+        "item_type",
+        "composer",
+        "duration",
+        "can_skip",
+        "artist_id",
+        "can_play",
+        "id",
+        "mime_type",
+        "description",
     ]
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'uri', 'description',
-                       'service_id']
+    required_fields = [
+        "title",
+        "item_id",
+        "extended_id",
+        "uri",
+        "description",
+        "service_id",
+    ]
 
-    def __init__(self, title, item_id, extended_id, uri, description,
-                 service_id, **kwargs):
+    def __init__(
+        self, title, item_id, extended_id, uri, description, service_id, **kwargs
+    ):
         """Initialize MSTrack item."""
         content = {
-            'title': title, 'item_id': item_id, 'extended_id': extended_id,
-            'uri': uri, 'description': description, 'service_id': service_id,
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "uri": uri,
+            "description": description,
+            "service_id": service_id,
         }
         content.update(kwargs)
         super(MSTrack, self).__init__(**content)
@@ -356,44 +374,65 @@ class MSTrack(MusicServiceItem):
     @property
     def album(self):
         """Return the album title if set, otherwise return None."""
-        return self.content.get('album')
+        return self.content.get("album")
 
     @property
     def artist(self):
         """Return the artist if set, otherwise return None."""
-        return self.content.get('artist')
+        return self.content.get("artist")
 
     @property
     def duration(self):
         """Return the duration if set, otherwise return None."""
-        return self.content.get('duration')
+        return self.content.get("duration")
 
     @property
     def uri(self):
         """Return the URI."""
         # x-sonos-http:trackid_19356232.mp4?sid=20&amp;flags=32
-        return self.content['uri']
+        return self.content["uri"]
 
 
 class MSAlbum(MusicServiceItem):
 
     """Class that represents a Music Service Album."""
 
-    item_class = 'object.container.album.musicAlbum'
+    item_class = "object.container.album.musicAlbum"
     valid_fields = [
-        'username', 'can_add_to_favorites', 'artist', 'title', 'album_art_uri',
-        'can_play', 'item_type', 'service_id', 'id', 'description',
-        'can_cache', 'artist_id', 'can_skip'
+        "username",
+        "can_add_to_favorites",
+        "artist",
+        "title",
+        "album_art_uri",
+        "can_play",
+        "item_type",
+        "service_id",
+        "id",
+        "description",
+        "can_cache",
+        "artist_id",
+        "can_skip",
     ]
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'uri', 'description',
-                       'service_id']
+    required_fields = [
+        "title",
+        "item_id",
+        "extended_id",
+        "uri",
+        "description",
+        "service_id",
+    ]
 
-    def __init__(self, title, item_id, extended_id, uri, description,
-                 service_id, **kwargs):
+    def __init__(
+        self, title, item_id, extended_id, uri, description, service_id, **kwargs
+    ):
         content = {
-            'title': title, 'item_id': item_id, 'extended_id': extended_id,
-            'uri': uri, 'description': description, 'service_id': service_id,
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "uri": uri,
+            "description": description,
+            "service_id": service_id,
         }
         content.update(kwargs)
         super(MSAlbum, self).__init__(**content)
@@ -401,33 +440,52 @@ class MSAlbum(MusicServiceItem):
     @property
     def artist(self):
         """Return the artist if set, otherwise return None."""
-        return self.content.get('artist')
+        return self.content.get("artist")
 
     @property
     def uri(self):
         """Return the URI."""
         # x-rincon-cpcontainer:0004002calbumid_22757081
-        return self.content['uri']
+        return self.content["uri"]
 
 
 class MSAlbumList(MusicServiceItem):
 
     """Class that represents a Music Service Album List."""
 
-    item_class = 'object.container.albumlist'
+    item_class = "object.container.albumlist"
     valid_fields = [
-        'id', 'title', 'item_type', 'artist', 'artist_id', 'can_play',
-        'can_enumerate', 'can_add_to_favorites', 'album_art_uri', 'can_cache'
+        "id",
+        "title",
+        "item_type",
+        "artist",
+        "artist_id",
+        "can_play",
+        "can_enumerate",
+        "can_add_to_favorites",
+        "album_art_uri",
+        "can_cache",
     ]
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'uri', 'description',
-                       'service_id']
+    required_fields = [
+        "title",
+        "item_id",
+        "extended_id",
+        "uri",
+        "description",
+        "service_id",
+    ]
 
-    def __init__(self, title, item_id, extended_id, uri, description,
-                 service_id, **kwargs):
+    def __init__(
+        self, title, item_id, extended_id, uri, description, service_id, **kwargs
+    ):
         content = {
-            'title': title, 'item_id': item_id, 'extended_id': extended_id,
-            'uri': uri, 'description': description, 'service_id': service_id,
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "uri": uri,
+            "description": description,
+            "service_id": service_id,
         }
         content.update(kwargs)
         super(MSAlbumList, self).__init__(**content)
@@ -437,26 +495,46 @@ class MSAlbumList(MusicServiceItem):
         """Return the URI."""
         # x-rincon-cpcontainer:000d006cplaylistid_26b18dbb-fd35-40bd-8d4f-
         # 8669bfc9f712
-        return self.content['uri']
+        return self.content["uri"]
 
 
 class MSPlaylist(MusicServiceItem):
 
     """Class that represents a Music Service Play List."""
 
-    item_class = 'object.container.albumlist'
-    valid_fields = ['id', 'item_type', 'title', 'can_play', 'can_cache',
-                    'album_art_uri', 'artist', 'can_enumerate',
-                    'can_add_to_favorites', 'artist_id']
+    item_class = "object.container.albumlist"
+    valid_fields = [
+        "id",
+        "item_type",
+        "title",
+        "can_play",
+        "can_cache",
+        "album_art_uri",
+        "artist",
+        "can_enumerate",
+        "can_add_to_favorites",
+        "artist_id",
+    ]
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'uri', 'description',
-                       'service_id']
+    required_fields = [
+        "title",
+        "item_id",
+        "extended_id",
+        "uri",
+        "description",
+        "service_id",
+    ]
 
-    def __init__(self, title, item_id, extended_id, uri, description,
-                 service_id, **kwargs):
+    def __init__(
+        self, title, item_id, extended_id, uri, description, service_id, **kwargs
+    ):
         content = {
-            'title': title, 'item_id': item_id, 'extended_id': extended_id,
-            'uri': uri, 'description': description, 'service_id': service_id,
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "uri": uri,
+            "description": description,
+            "service_id": service_id,
         }
         content.update(kwargs)
         super(MSPlaylist, self).__init__(**content)
@@ -466,24 +544,35 @@ class MSPlaylist(MusicServiceItem):
         """Return the URI."""
         # x-rincon-cpcontainer:000d006cplaylistid_c86ddf26-8ec5-483e-b292-
         # abe18848e89e
-        return self.content['uri']
+        return self.content["uri"]
 
 
 class MSArtistTracklist(MusicServiceItem):
 
     """Class that represents a Music Service Artist Track List."""
 
-    item_class = 'object.container.playlistContainer.sameArtist'
-    valid_fields = ['id', 'title', 'item_type', 'can_play', 'album_art_uri']
+    item_class = "object.container.playlistContainer.sameArtist"
+    valid_fields = ["id", "title", "item_type", "can_play", "album_art_uri"]
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'uri', 'description',
-                       'service_id']
+    required_fields = [
+        "title",
+        "item_id",
+        "extended_id",
+        "uri",
+        "description",
+        "service_id",
+    ]
 
-    def __init__(self, title, item_id, extended_id, uri, description,
-                 service_id, **kwargs):
+    def __init__(
+        self, title, item_id, extended_id, uri, description, service_id, **kwargs
+    ):
         content = {
-            'title': title, 'item_id': item_id, 'extended_id': extended_id,
-            'uri': uri, 'description': description, 'service_id': service_id,
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "uri": uri,
+            "description": description,
+            "service_id": service_id,
         }
         content.update(kwargs)
         super(MSArtistTracklist, self).__init__(**content)
@@ -492,7 +581,7 @@ class MSArtistTracklist(MusicServiceItem):
     def uri(self):
         """Return the URI."""
         # x-rincon-cpcontainer:100f006cartistpopsongsid_1566
-        return 'x-rincon-cpcontainer:100f006c{}'.format(self.item_id)
+        return "x-rincon-cpcontainer:100f006c{}".format(self.item_id)
 
 
 class MSArtist(MusicServiceItem):
@@ -500,18 +589,30 @@ class MSArtist(MusicServiceItem):
     """Class that represents a Music Service Artist."""
 
     valid_fields = [
-        'username', 'can_add_to_favorites', 'artist', 'title', 'album_art_uri',
-        'item_type', 'id', 'service_id', 'description', 'can_cache'
+        "username",
+        "can_add_to_favorites",
+        "artist",
+        "title",
+        "album_art_uri",
+        "item_type",
+        "id",
+        "service_id",
+        "description",
+        "can_cache",
     ]
     # Since MSArtist cannot produce didl_metadata, they are not strictly
     # required, but it makes sense to require them anyway, since they are the
     # fields that that describe the item
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'service_id']
+    required_fields = ["title", "item_id", "extended_id", "service_id"]
 
     def __init__(self, title, item_id, extended_id, service_id, **kwargs):
-        content = {'title': title, 'item_id': item_id,
-                   'extended_id': extended_id, 'service_id': service_id}
+        content = {
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "service_id": service_id,
+        }
         content.update(kwargs)
         super(MSArtist, self).__init__(**content)
 
@@ -520,17 +621,27 @@ class MSFavorites(MusicServiceItem):
 
     """Class that represents a Music Service Favorite."""
 
-    valid_fields = ['id', 'item_type', 'title', 'can_play', 'can_cache',
-                    'album_art_uri']
+    valid_fields = [
+        "id",
+        "item_type",
+        "title",
+        "can_play",
+        "can_cache",
+        "album_art_uri",
+    ]
     # Since MSFavorites cannot produce didl_metadata, they are not strictly
     # required, but it makes sense to require them anyway, since they are the
     # fields that that describe the item
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'service_id']
+    required_fields = ["title", "item_id", "extended_id", "service_id"]
 
     def __init__(self, title, item_id, extended_id, service_id, **kwargs):
-        content = {'title': title, 'item_id': item_id,
-                   'extended_id': extended_id, 'service_id': service_id}
+        content = {
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "service_id": service_id,
+        }
         content.update(kwargs)
         super(MSFavorites, self).__init__(**content)
 
@@ -539,22 +650,38 @@ class MSCollection(MusicServiceItem):
 
     """Class that represents a Music Service Collection."""
 
-    valid_fields = ['id', 'item_type', 'title', 'can_play', 'can_cache',
-                    'album_art_uri']
+    valid_fields = [
+        "id",
+        "item_type",
+        "title",
+        "can_play",
+        "can_cache",
+        "album_art_uri",
+    ]
     # Since MSCollection cannot produce didl_metadata, they are not strictly
     # required, but it makes sense to require them anyway, since they are the
     # fields that that describe the item
     # IMPORTANT. Keep this list, __init__ args and content in __init__ in sync
-    required_fields = ['title', 'item_id', 'extended_id', 'service_id']
+    required_fields = ["title", "item_id", "extended_id", "service_id"]
 
     def __init__(self, title, item_id, extended_id, service_id, **kwargs):
-        content = {'title': title, 'item_id': item_id,
-                   'extended_id': extended_id, 'service_id': service_id}
+        content = {
+            "title": title,
+            "item_id": item_id,
+            "extended_id": extended_id,
+            "service_id": service_id,
+        }
         content.update(kwargs)
         super(MSCollection, self).__init__(**content)
 
 
-MS_TYPE_TO_CLASS = {'artist': MSArtist, 'album': MSAlbum, 'track': MSTrack,
-                    'albumList': MSAlbumList, 'favorites': MSFavorites,
-                    'collection': MSCollection, 'playlist': MSPlaylist,
-                    'artistTrackList': MSArtistTracklist}
+MS_TYPE_TO_CLASS = {
+    "artist": MSArtist,
+    "album": MSAlbum,
+    "track": MSTrack,
+    "albumList": MSAlbumList,
+    "favorites": MSFavorites,
+    "collection": MSCollection,
+    "playlist": MSPlaylist,
+    "artistTrackList": MSArtistTracklist,
+}

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -15,12 +15,7 @@ import logging
 import xmltodict
 
 from . import discovery
-from .data_structures import (
-    SearchResult,
-    DidlResource,
-    DidlObject,
-    DidlMusicAlbum
-)
+from .data_structures import SearchResult, DidlResource, DidlObject, DidlMusicAlbum
 from .data_structures_entry import from_didl_string
 from .exceptions import SoCoUPnPException
 from .utils import url_escape_path, really_unicode, camel_to_underscore
@@ -32,19 +27,21 @@ class MusicLibrary(object):
     """The Music Library."""
 
     # Key words used when performing searches
-    SEARCH_TRANSLATION = {'artists': 'A:ARTIST',
-                          'album_artists': 'A:ALBUMARTIST',
-                          'albums': 'A:ALBUM',
-                          'genres': 'A:GENRE',
-                          'composers': 'A:COMPOSER',
-                          'tracks': 'A:TRACKS',
-                          'playlists': 'A:PLAYLISTS',
-                          'share': 'S:',
-                          'sonos_playlists': 'SQ:',
-                          'categories': 'A:',
-                          'sonos_favorites': 'FV:2',
-                          'radio_stations': 'R:0/0',
-                          'radio_shows': 'R:0/1'}
+    SEARCH_TRANSLATION = {
+        "artists": "A:ARTIST",
+        "album_artists": "A:ALBUMARTIST",
+        "albums": "A:ALBUM",
+        "genres": "A:GENRE",
+        "composers": "A:COMPOSER",
+        "tracks": "A:TRACKS",
+        "playlists": "A:PLAYLISTS",
+        "share": "S:",
+        "sonos_playlists": "SQ:",
+        "categories": "A:",
+        "sonos_favorites": "FV:2",
+        "radio_stations": "R:0/0",
+        "radio_shows": "R:0/1",
+    }
 
     # pylint: disable=invalid-name, protected-access
     def __init__(self, soco=None):
@@ -68,8 +65,8 @@ class MusicLibrary(object):
         """
         # Add on the full album art link, as the URI version
         # does not include the ipaddress
-        if not url.startswith(('http:', 'https:')):
-            url = 'http://' + self.soco.ip_address + ':1400' + url
+        if not url.startswith(("http:", "https:")):
+            url = "http://" + self.soco.ip_address + ":1400" + url
         return url
 
     def _update_album_art_to_full_uri(self, item):
@@ -78,9 +75,8 @@ class MusicLibrary(object):
         Args:
             item: The item to update the URI for
         """
-        if getattr(item, 'album_art_uri', False):
-            item.album_art_uri = self.build_album_art_full_uri(
-                item.album_art_uri)
+        if getattr(item, "album_art_uri", False):
+            item.album_art_uri = self.build_album_art_full_uri(item.album_art_uri)
 
     def get_artists(self, *args, **kwargs):
         """Convenience method for `get_music_library_formation`
@@ -89,7 +85,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['artists'] + list(args))
+        args = tuple(["artists"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_album_artists(self, *args, **kwargs):
@@ -99,7 +95,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['album_artists'] + list(args))
+        args = tuple(["album_artists"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_albums(self, *args, **kwargs):
@@ -109,7 +105,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['albums'] + list(args))
+        args = tuple(["albums"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_genres(self, *args, **kwargs):
@@ -119,7 +115,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['genres'] + list(args))
+        args = tuple(["genres"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_composers(self, *args, **kwargs):
@@ -129,7 +125,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['composers'] + list(args))
+        args = tuple(["composers"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_tracks(self, *args, **kwargs):
@@ -139,7 +135,7 @@ class MusicLibrary(object):
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
 
         """
-        args = tuple(['tracks'] + list(args))
+        args = tuple(["tracks"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_playlists(self, *args, **kwargs):
@@ -153,7 +149,7 @@ class MusicLibrary(object):
             from the music library, they are not the Sonos playlists.
 
         """
-        args = tuple(['playlists'] + list(args))
+        args = tuple(["playlists"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_sonos_favorites(self, *args, **kwargs):
@@ -162,7 +158,7 @@ class MusicLibrary(object):
         see `that method
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
         """
-        args = tuple(['sonos_favorites'] + list(args))
+        args = tuple(["sonos_favorites"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_favorite_radio_stations(self, *args, **kwargs):
@@ -171,7 +167,7 @@ class MusicLibrary(object):
         see `that method
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
         """
-        args = tuple(['radio_stations'] + list(args))
+        args = tuple(["radio_stations"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
     def get_favorite_radio_shows(self, *args, **kwargs):
@@ -180,16 +176,22 @@ class MusicLibrary(object):
         see `that method
         <#soco.music_library.MusicLibrary.get_music_library_information>`_.
         """
-        args = tuple(['radio_shows'] + list(args))
+        args = tuple(["radio_shows"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
         # pylint: disable=too-many-locals, too-many-arguments,
         # too-many-branches
 
-    def get_music_library_information(self, search_type, start=0,
-                                      max_items=100, full_album_art_uri=False,
-                                      search_term=None, subcategories=None,
-                                      complete_result=False):
+    def get_music_library_information(
+        self,
+        search_type,
+        start=0,
+        max_items=100,
+        full_album_art_uri=False,
+        search_term=None,
+        subcategories=None,
+        complete_result=False,
+    ):
         """Retrieve music information objects from the music library.
 
         This method is the main method to get music information items, like
@@ -290,31 +292,30 @@ class MusicLibrary(object):
         # Add sub categories
         if subcategories is not None:
             for category in subcategories:
-                search += '/' + url_escape_path(really_unicode(category))
+                search += "/" + url_escape_path(really_unicode(category))
         # Add fuzzy search
         if search_term is not None:
-            search += ':' + url_escape_path(really_unicode(search_term))
+            search += ":" + url_escape_path(really_unicode(search_term))
 
         item_list = []
-        metadata = {'total_matches': 100000}
-        while len(item_list) < metadata['total_matches']:
+        metadata = {"total_matches": 100000}
+        while len(item_list) < metadata["total_matches"]:
             # Change start and max for complete searches
             if complete_result:
                 start, max_items = len(item_list), 100000
 
             # Try and get this batch of results
             try:
-                response, metadata = \
-                    self._music_lib_search(search, start, max_items)
+                response, metadata = self._music_lib_search(search, start, max_items)
             except SoCoUPnPException as exception:
                 # 'No such object' UPnP errors
-                if exception.error_code == '701':
+                if exception.error_code == "701":
                     return SearchResult([], search_type, 0, 0, None)
                 else:
                     raise exception
 
             # Parse the results
-            items = from_didl_string(response['Result'])
+            items = from_didl_string(response["Result"])
             for item in items:
                 # Check if the album art URI should be fully qualified
                 if full_album_art_uri:
@@ -327,15 +328,22 @@ class MusicLibrary(object):
             if not complete_result:
                 break
 
-        metadata['search_type'] = search_type
+        metadata["search_type"] = search_type
         if complete_result:
-            metadata['number_returned'] = len(item_list)
+            metadata["number_returned"] = len(item_list)
 
         # pylint: disable=star-args
         return SearchResult(item_list, **metadata)
 
-    def browse(self, ml_item=None, start=0, max_items=100,
-               full_album_art_uri=False, search_term=None, subcategories=None):
+    def browse(
+        self,
+        ml_item=None,
+        start=0,
+        max_items=100,
+        full_album_art_uri=False,
+        search_term=None,
+        subcategories=None,
+    ):
         """Browse (get sub-elements from) a music library item.
 
         Args:
@@ -363,31 +371,30 @@ class MusicLibrary(object):
                 browsed.
         """
         if ml_item is None:
-            search = 'A:'
+            search = "A:"
         else:
             search = ml_item.item_id
 
         # Add sub categories
         if subcategories is not None:
             for category in subcategories:
-                search += '/' + url_escape_path(really_unicode(category))
+                search += "/" + url_escape_path(really_unicode(category))
         # Add fuzzy search
         if search_term is not None:
-            search += ':' + url_escape_path(really_unicode(search_term))
+            search += ":" + url_escape_path(really_unicode(search_term))
 
         try:
-            response, metadata = \
-                self._music_lib_search(search, start, max_items)
+            response, metadata = self._music_lib_search(search, start, max_items)
         except SoCoUPnPException as exception:
             # 'No such object' UPnP errors
-            if exception.error_code == '701':
-                return SearchResult([], 'browse', 0, 0, None)
+            if exception.error_code == "701":
+                return SearchResult([], "browse", 0, 0, None)
             else:
                 raise exception
-        metadata['search_type'] = 'browse'
+        metadata["search_type"] = "browse"
 
         # Parse the results
-        containers = from_didl_string(response['Result'])
+        containers = from_didl_string(response["Result"])
         item_list = []
         for container in containers:
             # Check if the album art URI should be fully qualified
@@ -398,8 +405,9 @@ class MusicLibrary(object):
         # pylint: disable=star-args
         return SearchResult(item_list, **metadata)
 
-    def browse_by_idstring(self, search_type, idstring, start=0,
-                           max_items=100, full_album_art_uri=False):
+    def browse_by_idstring(
+        self, search_type, idstring, start=0, max_items=100, full_album_art_uri=False
+    ):
         """Browse (get sub-elements from) a given music library item,
         specified by a string.
 
@@ -429,17 +437,16 @@ class MusicLibrary(object):
         # Check if the string ID already has the type, if so we do not want to
         # add one also Imported playlist have a full path to them, so they do
         # not require the A:PLAYLISTS part first
-        if idstring.startswith(search) or (search_type == 'playlists'):
+        if idstring.startswith(search) or (search_type == "playlists"):
             search = ""
 
         search_item_id = search + idstring
         search_uri = "#" + search_item_id
         # Not sure about the res protocol. But this seems to work
-        res = [DidlResource(
-            uri=search_uri, protocol_info="x-rincon-playlist:*:*:*")]
+        res = [DidlResource(uri=search_uri, protocol_info="x-rincon-playlist:*:*:*")]
         search_item = DidlObject(
-            resources=res, title='', parent_id='',
-            item_id=search_item_id)
+            resources=res, title="", parent_id="", item_id=search_item_id
+        )
 
         # Call the base version
         return self.browse(search_item, start, max_items, full_album_art_uri)
@@ -471,18 +478,20 @@ class MusicLibrary(object):
                 and metadata is a dict with the 'number_returned',
                 'total_matches' and 'update_id' integers
         """
-        response = self.contentDirectory.Browse([
-            ('ObjectID', search),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', start),
-            ('RequestedCount', max_items),
-            ('SortCriteria', '')
-        ])
+        response = self.contentDirectory.Browse(
+            [
+                ("ObjectID", search),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", start),
+                ("RequestedCount", max_items),
+                ("SortCriteria", ""),
+            ]
+        )
 
         # Get result information
         metadata = {}
-        for tag in ['NumberReturned', 'TotalMatches', 'UpdateID']:
+        for tag in ["NumberReturned", "TotalMatches", "UpdateID"]:
             metadata[camel_to_underscore(tag)] = int(response[tag])
         return response, metadata
 
@@ -491,21 +500,20 @@ class MusicLibrary(object):
         """bool: whether the music library is in the process of being updated.
         """
         result = self.contentDirectory.GetShareIndexInProgress()
-        return result['IsIndexing'] != '0'
+        return result["IsIndexing"] != "0"
 
-    def start_library_update(self, album_artist_display_option=''):
+    def start_library_update(self, album_artist_display_option=""):
         """Start an update of the music library.
 
         Args:
             album_artist_display_option (str): a value for the album artist
                 compilation setting (see `album_artist_display_option`).
         """
-        return self.contentDirectory.RefreshShareIndex([
-            ('AlbumArtistDisplayOption', album_artist_display_option),
-        ])
+        return self.contentDirectory.RefreshShareIndex(
+            [("AlbumArtistDisplayOption", album_artist_display_option),]
+        )
 
-    def search_track(self, artist, album=None, track=None,
-                     full_album_art_uri=False):
+    def search_track(self, artist, album=None, track=None, full_album_art_uri=False):
         """Search for an artist, an artist's albums, or specific track.
 
         Args:
@@ -519,14 +527,16 @@ class MusicLibrary(object):
             A `SearchResult` instance.
         """
         subcategories = [artist]
-        subcategories.append(album or '')
+        subcategories.append(album or "")
 
         # Perform the search
         result = self.get_album_artists(
             full_album_art_uri=full_album_art_uri,
-            subcategories=subcategories, search_term=track,
-            complete_result=True)
-        result._metadata['search_type'] = 'search_track'
+            subcategories=subcategories,
+            search_term=track,
+            complete_result=True,
+        )
+        result._metadata["search_type"] = "search_track"
         return result
 
     def get_albums_for_artist(self, artist, full_album_art_uri=False):
@@ -544,18 +554,21 @@ class MusicLibrary(object):
         result = self.get_album_artists(
             full_album_art_uri=full_album_art_uri,
             subcategories=subcategories,
-            complete_result=True)
+            complete_result=True,
+        )
 
         reduced = [item for item in result if item.__class__ == DidlMusicAlbum]
         # It is necessary to update the list of items in two places, due to
         # a bug in SearchResult
         result[:] = reduced
-        result._metadata.update({
-            'item_list': reduced,
-            'search_type': 'albums_for_artist',
-            'number_returned': len(reduced),
-            'total_matches': len(reduced)
-        })
+        result._metadata.update(
+            {
+                "item_list": reduced,
+                "search_type": "albums_for_artist",
+                "number_returned": len(reduced),
+                "total_matches": len(reduced),
+            }
+        )
         return result
 
     def get_tracks_for_album(self, artist, album, full_album_art_uri=False):
@@ -574,8 +587,9 @@ class MusicLibrary(object):
         result = self.get_album_artists(
             full_album_art_uri=full_album_art_uri,
             subcategories=subcategories,
-            complete_result=True)
-        result._metadata['search_type'] = 'tracks_for_album'
+            complete_result=True,
+        )
+        result._metadata["search_type"] = "tracks_for_album"
         return result
 
     @property
@@ -597,7 +611,7 @@ class MusicLibrary(object):
         pass the new setting.
         """
         result = self.contentDirectory.GetAlbumArtistDisplayOption()
-        return result['AlbumArtistDisplayOption']
+        return result["AlbumArtistDisplayOption"]
 
     def list_library_shares(self):
         """Return a list of the music library shares.
@@ -606,28 +620,30 @@ class MusicLibrary(object):
             list: The music library shares, which are strings of the form
                 ``'//hostname_or_IP/share_path'``.
         """
-        response = self.contentDirectory.Browse([
-            ('ObjectID', 'S:'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', '0'),
-            ('RequestedCount', '100'),
-            ('SortCriteria', '')
-        ])
+        response = self.contentDirectory.Browse(
+            [
+                ("ObjectID", "S:"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", "0"),
+                ("RequestedCount", "100"),
+                ("SortCriteria", ""),
+            ]
+        )
         shares = []
-        matches = response['TotalMatches']
+        matches = response["TotalMatches"]
         # Zero matches
-        if matches == '0':
+        if matches == "0":
             return shares
-        xml_dict = xmltodict.parse(response['Result'])
-        unpacked = xml_dict['DIDL-Lite']['container']
+        xml_dict = xmltodict.parse(response["Result"])
+        unpacked = xml_dict["DIDL-Lite"]["container"]
         # One match
-        if matches == '1':
-            shares.append(unpacked['dc:title'])
+        if matches == "1":
+            shares.append(unpacked["dc:title"])
             return shares
         # Otherwise it's multiple matches
         for share in unpacked:
-            shares.append(share['dc:title'])
+            shares.append(share["dc:title"])
         return shares
 
     def delete_library_share(self, share_name):
@@ -640,6 +656,4 @@ class MusicLibrary(object):
         :raises: `SoCoUPnPException`
         """
         # share_name must be prefixed with 'S:'
-        self.contentDirectory.DestroyObject([
-            ('ObjectID', 'S:' + share_name)
-        ])
+        self.contentDirectory.DestroyObject([("ObjectID", "S:" + share_name)])

--- a/soco/music_services/__init__.py
+++ b/soco/music_services/__init__.py
@@ -7,8 +7,4 @@ with Sonos."""
 from .music_service import MusicService, desc_from_uri
 from .accounts import Account
 
-__all__ = [
-    'MusicService',
-    'desc_from_uri',
-    'Account'
-]
+__all__ = ["MusicService", "desc_from_uri", "Account"]

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -5,9 +5,7 @@
 
 """This module contains classes relating to Third Party music services."""
 
-from __future__ import (
-    absolute_import, unicode_literals
-)
+from __future__ import absolute_import, unicode_literals
 
 import logging
 import weakref
@@ -35,21 +33,21 @@ class Account(object):
         super(Account, self).__init__()
         #: str: A unique identifier for the music service to which this
         #: account relates, eg ``'2311'`` for Spotify.
-        self.service_type = ''
+        self.service_type = ""
         #: str: A unique identifier for this account
-        self.serial_number = ''
+        self.serial_number = ""
         #: str: The account's nickname
-        self.nickname = ''
+        self.nickname = ""
         #: bool: `True` if this account has been deleted
         self.deleted = False
         #: str: The username used for logging into the music service
-        self.username = ''
+        self.username = ""
         #: str: Metadata for the account
-        self.metadata = ''
+        self.metadata = ""
         #: str: Used for OpenAuth id for some services
-        self.oa_device_id = ''
+        self.oa_device_id = ""
         #: str: Used for OpenAuthid for some services
-        self.key = ''
+        self.key = ""
 
     def __repr__(self):
         return "<{} '{}:{}:{}' at {}>".format(
@@ -57,7 +55,7 @@ class Account(object):
             self.serial_number,
             self.service_type,
             self.nickname,
-            hex(id(self))
+            hex(id(self)),
         )
 
     def __str__(self):
@@ -80,8 +78,7 @@ class Account(object):
         # This returns an encrypted string, and, so far, we cannot decrypt it
         device = soco or discovery.any_soco()
         log.debug("Fetching account data from %s", device)
-        settings_url = "http://{}:1400/status/accounts".format(
-            device.ip_address)
+        settings_url = "http://{}:1400/status/accounts".format(device.ip_address)
         result = requests.get(settings_url).content
         log.debug("Account data: %s", result)
         return result
@@ -128,11 +125,11 @@ class Account(object):
         # ...
         #   <Accounts />
 
-        xml_accounts = root.findall('.//Account')
+        xml_accounts = root.findall(".//Account")
         result = {}
         for xml_account in xml_accounts:
-            serial_number = xml_account.get('SerialNum')
-            is_deleted = (xml_account.get('Deleted') == '1')
+            serial_number = xml_account.get("SerialNum")
+            is_deleted = xml_account.get("Deleted") == "1"
             # cls._all_accounts is a weakvaluedict keyed by serial number.
             # We use it as a database to store details of the accounts we
             # know about. We need to update it with info obtained from the
@@ -161,28 +158,28 @@ class Account(object):
                 cls._all_accounts[serial_number] = account
 
             # Now, update the entry in our database with the details from XML
-            account.service_type = xml_account.get('Type')
+            account.service_type = xml_account.get("Type")
             account.deleted = is_deleted
-            account.username = xml_account.findtext('UN')
+            account.username = xml_account.findtext("UN")
             # Not sure what 'MD' stands for.  Metadata? May Delete?
-            account.metadata = xml_account.findtext('MD')
-            account.nickname = xml_account.findtext('NN')
-            account.oa_device_id = xml_account.findtext('OADevID')
-            account.key = xml_account.findtext('Key')
+            account.metadata = xml_account.findtext("MD")
+            account.nickname = xml_account.findtext("NN")
+            account.oa_device_id = xml_account.findtext("OADevID")
+            account.key = xml_account.findtext("Key")
             result[serial_number] = account
             # There is always a TuneIn account, but it is handled separately
             #  by Sonos, and does not appear in the xml account data. We
             # need to add it ourselves.
             tunein = Account()
-            tunein.service_type = '65031'  # Is this always the case?
+            tunein.service_type = "65031"  # Is this always the case?
             tunein.deleted = False
-            tunein.username = ''
-            tunein.metadata = ''
-            tunein.nickname = ''
-            tunein.oa_device_id = ''
-            tunein.key = ''
-            tunein.serial_number = '0'
-            result['0'] = tunein
+            tunein.username = ""
+            tunein.metadata = ""
+            tunein.nickname = ""
+            tunein.oa_device_id = ""
+            tunein.key = ""
+            tunein.serial_number = "0"
+            result["0"] = tunein
 
         return result
 
@@ -197,6 +194,5 @@ class Account(object):
             list: A list of `Account` instances.
         """
         return [
-            a for a in cls.get_accounts().values()
-            if a.service_type == service_type
+            a for a in cls.get_accounts().values() if a.service_type == service_type
         ]

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Disable while we have Python 2.x compatability
-# pylint: disable=useless-object-inheritance
+# pylint: disable=useless-object-inheritance, too-many-arguments
 
 """Data structures for music service items
 

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -91,11 +91,11 @@ def get_class(class_key):
         for basecls in (MediaMetadata, MediaCollection):
             if class_key.startswith(basecls.__name__):
                 # So MediaMetadataTrack turns into MSTrack
-                class_name = 'MS' + class_key.replace(basecls.__name__, '')
+                class_name = "MS" + class_key.replace(basecls.__name__, "")
                 if sys.version_info[0] == 2:
-                    class_name = class_name.encode('ascii')
+                    class_name = class_name.encode("ascii")
                 CLASSES[class_key] = type(class_name, (basecls,), {})
-                _LOG.info('Class %s created', CLASSES[class_key])
+                _LOG.info("Class %s created", CLASSES[class_key])
     return CLASSES[class_key]
 
 
@@ -111,27 +111,33 @@ def parse_response(service, response, search_type):
     Returns:
         SearchResult: A SearchResult object
     """
-    _LOG.debug('Parse response "%s" from service "%s" of type "%s"', response,
-               service, search_type)
+    _LOG.debug(
+        'Parse response "%s" from service "%s" of type "%s"',
+        response,
+        service,
+        search_type,
+    )
     items = []
     # The result to be parsed is in either searchResult or getMetadataResult
-    if 'searchResult' in response:
-        response = response['searchResult']
-    elif 'getMetadataResult' in response:
-        response = response['getMetadataResult']
+    if "searchResult" in response:
+        response = response["searchResult"]
+    elif "getMetadataResult" in response:
+        response = response["getMetadataResult"]
     else:
-        raise ValueError('"response" should contain either the key '
-                         '"searchResult" or "getMetadataResult"')
+        raise ValueError(
+            '"response" should contain either the key '
+            '"searchResult" or "getMetadataResult"'
+        )
 
     # Form the search metadata
     search_metadata = {
-        'number_returned': response['count'],
-        'total_matches': None,
-        'search_type': search_type,
-        'update_id': None,
+        "number_returned": response["count"],
+        "total_matches": None,
+        "search_type": search_type,
+        "update_id": None,
     }
 
-    for result_type in ('mediaCollection', 'mediaMetadata'):
+    for result_type in ("mediaCollection", "mediaMetadata"):
         # Upper case the first letter (used for the class_key)
         result_type_proper = result_type[0].upper() + result_type[1:]
         raw_items = response.get(result_type, [])
@@ -143,7 +149,7 @@ def parse_response(service, response, search_type):
             # Form the class_key, which is a unique string for this type,
             # formed by concatenating the result type with the item type. Turns
             # into e.g: MediaMetadataTrack
-            class_key = result_type_proper + raw_item['itemType'].title()
+            class_key = result_type_proper + raw_item["itemType"].title()
             cls = get_class(class_key)
             items.append(cls.from_music_service(service, raw_item))
     return SearchResult(items, **search_metadata)
@@ -163,19 +169,19 @@ def form_uri(item_id, service, is_track):
     if is_track:
         uri = service.sonos_uri_from_id(item_id)
     else:
-        uri = 'x-rincon-cpcontainer:' + item_id
+        uri = "x-rincon-cpcontainer:" + item_id
     return uri
 
 
 # Type Helper
-BOOL_STRS = set(('true', 'false'))
+BOOL_STRS = set(("true", "false"))
 
 
 def bool_str(string):
     """Returns a boolean from a string imput of 'true' or 'false'"""
     if string not in BOOL_STRS:
         raise ValueError('Invalid boolean string: "{}"'.format(string))
-    return string == 'true'
+    return string == "true"
 
 
 # Music Service item base classes
@@ -193,12 +199,11 @@ class MetadataDictBase(object):
 
     def __init__(self, metadata_dict):
         """Initialize local variables"""
-        _LOG.debug('MetadataDictBase.__init__ with: %s', metadata_dict)
+        _LOG.debug("MetadataDictBase.__init__ with: %s", metadata_dict)
         for key in metadata_dict:
             # Check for invalid fields
             if key not in self._valid_fields:
-                message = ('%s instantiated with invalid field "%s" and '
-                           'value: %s')
+                message = '%s instantiated with invalid field "%s" and ' "value: %s"
                 # Really wanted to raise exceptions here, but as it
                 # turns out I have already encountered invalid fields
                 # from music services.
@@ -228,8 +233,15 @@ class MusicServiceItem(MetadataDictBase):
     _valid_fields = {}
     _types = {}
 
-    def __init__(self, item_id, desc,  # pylint: disable=too-many-arguments
-                 resources, uri, metadata_dict, music_service=None):
+    def __init__(
+        self,
+        item_id,
+        desc,  # pylint: disable=too-many-arguments
+        resources,
+        uri,
+        metadata_dict,
+        music_service=None,
+    ):
         """Init music service item
 
         Args:
@@ -241,10 +253,16 @@ class MusicServiceItem(MetadataDictBase):
             music_service (MusicService): The MusicService instance the item
                 originates from
         """
-        _LOG.debug('%s.__init__ with item_id=%s, desc=%s, resources=%s, '
-                   'uri=%s, metadata_dict=..., music_service=%s',
-                   self.__class__.__name__, item_id, desc, resources, uri,
-                   music_service)
+        _LOG.debug(
+            "%s.__init__ with item_id=%s, desc=%s, resources=%s, "
+            "uri=%s, metadata_dict=..., music_service=%s",
+            self.__class__.__name__,
+            item_id,
+            desc,
+            resources,
+            uri,
+            music_service,
+        )
         super(MusicServiceItem, self).__init__(metadata_dict)
         self.item_id = item_id
         self.desc = desc
@@ -267,21 +285,22 @@ class MusicServiceItem(MetadataDictBase):
             MusicServiceItem: A MusicServiceItem instance
         """
         # Form the item_id
-        quoted_id = quote_url(content_dict['id'].encode('utf-8'))
+        quoted_id = quote_url(content_dict["id"].encode("utf-8"))
         # The hex prefix remains a mistery for now
-        item_id = '0fffffff{}'.format(quoted_id)
+        item_id = "0fffffff{}".format(quoted_id)
         # Form the uri
-        is_track = cls == get_class('MediaMetadataTrack')
+        is_track = cls == get_class("MediaMetadataTrack")
         uri = form_uri(item_id, music_service, is_track)
         # Form resources and get desc
         resources = [DidlResource(uri=uri, protocol_info="DUMMY")]
         desc = music_service.desc
-        return cls(item_id, desc, resources, uri, content_dict,
-                   music_service=music_service)
+        return cls(
+            item_id, desc, resources, uri, content_dict, music_service=music_service
+        )
 
     def __str__(self):
         """Return custom string representation"""
-        title = self.metadata.get('title')
+        title = self.metadata.get("title")
         str_ = '<{} title="{}">'
         return str_.format(self.__class__.__name__, title)
 
@@ -303,7 +322,7 @@ class MusicServiceItem(MetadataDictBase):
             parent_id="DUMMY",  # Ditto
             item_id=self.item_id,
             desc=self.desc,
-            resources=self.resources
+            resources=self.resources,
         )
         return didl_item.to_element(include_namespaces=include_namespaces)
 
@@ -312,36 +331,38 @@ class TrackMetadata(MetadataDictBase):
     """Track metadata class"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = set((
-        'artistId',
-        'artist',
-        'composerId',
-        'composer',
-        'albumId',
-        'album',
-        'albumArtURI',
-        'albumArtistId',
-        'albumArtist',
-        'genreId',
-        'genre',
-        'duration',
-        'canPlay',
-        'canSkip',
-        'canAddToFavorites',
-        'rating',
-        'trackNumber',
-        'isFavorite',
-    ))
+    _valid_fields = set(
+        (
+            "artistId",
+            "artist",
+            "composerId",
+            "composer",
+            "albumId",
+            "album",
+            "albumArtURI",
+            "albumArtistId",
+            "albumArtist",
+            "genreId",
+            "genre",
+            "duration",
+            "canPlay",
+            "canSkip",
+            "canAddToFavorites",
+            "rating",
+            "trackNumber",
+            "isFavorite",
+        )
+    )
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'duration': int,
-        'canPlay': bool_str,
-        'canSkip': bool_str,
-        'canAddToFavorites': bool_str,
-        'rating': int,
-        'trackNumber': int,
-        'isFavorite': bool_str,
+        "duration": int,
+        "canPlay": bool_str,
+        "canSkip": bool_str,
+        "canAddToFavorites": bool_str,
+        "rating": int,
+        "trackNumber": int,
+        "isFavorite": bool_str,
     }
 
 
@@ -349,26 +370,28 @@ class StreamMetadata(MetadataDictBase):
     """Stream metadata class"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = set((
-        'currentHost',
-        'currentShowId',
-        'currentShow',
-        'secondsRemaining',
-        'secondsToNextShow',
-        'bitrate',
-        'logo',
-        'hasOutOfBandMetadata',
-        'description',
-        'isEphemeral',
-    ))
+    _valid_fields = set(
+        (
+            "currentHost",
+            "currentShowId",
+            "currentShow",
+            "secondsRemaining",
+            "secondsToNextShow",
+            "bitrate",
+            "logo",
+            "hasOutOfBandMetadata",
+            "description",
+            "isEphemeral",
+        )
+    )
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'secondsRemaining': int,
-        'secondsToNextShow': int,
-        'bitrate': int,
-        'hasOutOfBandMetadata': bool_str,
-        'isEphemeral': bool_str,
+        "secondsRemaining": int,
+        "secondsToNextShow": int,
+        "bitrate": int,
+        "hasOutOfBandMetadata": bool_str,
+        "isEphemeral": bool_str,
     }
 
 
@@ -376,22 +399,24 @@ class MediaMetadata(MusicServiceItem):
     """Base class for all media metadata items"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = set((
-        'id',
-        'title',
-        'mimeType',
-        'itemType',
-        'displayType',
-        'summary',
-        'trackMetadata',
-        'streamMetadata',
-        'dynamic',
-    ))
+    _valid_fields = set(
+        (
+            "id",
+            "title",
+            "mimeType",
+            "itemType",
+            "displayType",
+            "summary",
+            "trackMetadata",
+            "streamMetadata",
+            "dynamic",
+        )
+    )
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'trackMetadata': TrackMetadata,
-        'streamMetadata': StreamMetadata,
+        "trackMetadata": TrackMetadata,
+        "streamMetadata": StreamMetadata,
         # We ignore types on the dynamic field
         # 'dynamic': ???,
     }
@@ -401,32 +426,34 @@ class MediaCollection(MusicServiceItem):
     """Base class for all mediaCollection items"""
 
     # _valid_fields is a set of valid fields
-    _valid_fields = set((
-        'id',
-        'title',
-        'itemType',
-        'displayType',
-        'summary',
-        'artistId',
-        'artist',
-        'albumArtURI',
-        'canPlay',
-        'canEnumerate',
-        'canAddToFavorites',
-        'containsFavorite',
-        'canScroll',
-        'canSkip',
-        'isFavorite',
-    ))
+    _valid_fields = set(
+        (
+            "id",
+            "title",
+            "itemType",
+            "displayType",
+            "summary",
+            "artistId",
+            "artist",
+            "albumArtURI",
+            "canPlay",
+            "canEnumerate",
+            "canAddToFavorites",
+            "containsFavorite",
+            "canScroll",
+            "canSkip",
+            "isFavorite",
+        )
+    )
 
     # _types is a dict of fields with non-string types and their
     # convertion callables
     _types = {
-        'canPlay': bool_str,
-        'canEnumerate': bool_str,
-        'canAddToFavorites': bool_str,
-        'containsFavorite': bool_str,
-        'canScroll': bool_str,
-        'canSkip': bool_str,
-        'isFavorite': bool_str,
+        "canPlay": bool_str,
+        "canEnumerate": bool_str,
+        "canAddToFavorites": bool_str,
+        "containsFavorite": bool_str,
+        "canScroll": bool_str,
+        "canSkip": bool_str,
+        "isFavorite": bool_str,
     }

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -51,7 +51,7 @@ class MusicServiceSoapClient(object):
         self.endpoint = endpoint
         self.timeout = timeout
         self.music_service = music_service
-        self.namespace = 'http://www.sonos.com/Services/1.1'
+        self.namespace = "http://www.sonos.com/Services/1.1"
 
         self._cached_soap_header = None
 
@@ -66,12 +66,13 @@ class MusicServiceSoapClient(object):
         # Play does not like it anyway.
 
         self.http_headers = {
-            'Accept-Encoding': 'gzip, deflate',
-            'User-Agent': 'Linux UPnP/1.0 Sonos/26.99-12345'
+            "Accept-Encoding": "gzip, deflate",
+            "User-Agent": "Linux UPnP/1.0 Sonos/26.99-12345",
         }
         self._device = discovery.any_soco()
         self._device_id = self._device.systemProperties.GetString(
-            [('VariableName', 'R_TrialZPSerial')])['StringValue']
+            [("VariableName", "R_TrialZPSerial")]
+        )["StringValue"]
 
     def get_soap_header(self):
         """Generate the SOAP authentication header for the related service.
@@ -90,38 +91,41 @@ class MusicServiceSoapClient(object):
             return self._cached_soap_header
         music_service = self.music_service
         credentials_header = XML.Element(
-            "credentials", {'xmlns': "http://www.sonos.com/Services/1.1"})
-        device_id = XML.SubElement(credentials_header, 'deviceId')
+            "credentials", {"xmlns": "http://www.sonos.com/Services/1.1"}
+        )
+        device_id = XML.SubElement(credentials_header, "deviceId")
         device_id.text = self._device_id
-        device_provider = XML.SubElement(credentials_header, 'deviceProvider')
-        device_provider.text = 'Sonos'
+        device_provider = XML.SubElement(credentials_header, "deviceProvider")
+        device_provider.text = "Sonos"
         if music_service.account.oa_device_id:
             # OAuth account credentials are present. We must use them to
             # authenticate.
-            login_token = XML.Element('loginToken')
-            token = XML.SubElement(login_token, 'token')
+            login_token = XML.Element("loginToken")
+            token = XML.SubElement(login_token, "token")
             token.text = music_service.account.oa_device_id
-            key = XML.SubElement(login_token, 'key')
+            key = XML.SubElement(login_token, "key")
             key.text = music_service.account.key
-            household_id = XML.SubElement(login_token, 'householdId')
+            household_id = XML.SubElement(login_token, "householdId")
             household_id.text = self._device.household_id
             credentials_header.append(login_token)
 
         # otherwise, perhaps use DeviceLink or UserId auth
-        elif music_service.auth_type in ['DeviceLink', 'UserId']:
+        elif music_service.auth_type in ["DeviceLink", "UserId"]:
             # We need a session ID from Sonos
-            session_id = self._device.musicServices.GetSessionId([
-                ('ServiceId', music_service.service_id),
-                ('Username', music_service.account.username)
-            ])['SessionId']
-            session_elt = XML.Element('sessionId')
+            session_id = self._device.musicServices.GetSessionId(
+                [
+                    ("ServiceId", music_service.service_id),
+                    ("Username", music_service.account.username),
+                ]
+            )["SessionId"]
+            session_elt = XML.Element("sessionId")
             session_elt.text = session_id
             credentials_header.append(session_elt)
 
         # Anonymous auth. No need for anything further.
         self._cached_soap_header = XML.tostring(
-            credentials_header,
-            encoding='utf-8').decode(encoding='utf-8')
+            credentials_header, encoding="utf-8"
+        ).decode(encoding="utf-8")
         return self._cached_soap_header
 
     def call(self, method, args=None):
@@ -145,17 +149,17 @@ class MusicServiceSoapClient(object):
             method=method,
             parameters=[] if args is None else args,
             http_headers=self.http_headers,
-            soap_action="http://www.sonos.com/Services/1"
-                        ".1#{0}".format(method),
+            soap_action="http://www.sonos.com/Services/1" ".1#{0}".format(method),
             soap_header=self.get_soap_header(),
             namespace=self.namespace,
-            timeout=self.timeout)
+            timeout=self.timeout,
+        )
 
         try:
             result_elt = message.call()
         except SoapFault as exc:
-            if 'Client.TokenRefreshRequired' in exc.faultcode:
-                log.debug('Token refresh required. Trying again')
+            if "Client.TokenRefreshRequired" in exc.faultcode:
+                log.debug("Token refresh required. Trying again")
                 # Remove any cached value for the SOAP header
                 self._cached_soap_header = None
 
@@ -165,8 +169,8 @@ class MusicServiceSoapClient(object):
                 #       <privateKey>zzzzzz</privateKey>
                 #   </refreshAuthTokenResult>
                 # </detail>
-                auth_token = exc.detail.findtext('.//authToken')
-                private_key = exc.detail.findtext('.//privateKey')
+                auth_token = exc.detail.findtext(".//authToken")
+                private_key = exc.detail.findtext(".//privateKey")
                 # We have new details - update the account
                 self.music_service.account.oa_device_id = auth_token
                 self.music_service.account.key = private_key
@@ -176,10 +180,11 @@ class MusicServiceSoapClient(object):
                     parameters=args,
                     http_headers=self.http_headers,
                     soap_action="http://www.sonos.com/Services/1"
-                                ".1#{0}".format(method),
+                    ".1#{0}".format(method),
                     soap_header=self.get_soap_header(),
                     namespace=self.namespace,
-                    timeout=self.timeout)
+                    timeout=self.timeout,
+                )
                 result_elt = message.call()
 
             else:
@@ -187,10 +192,13 @@ class MusicServiceSoapClient(object):
 
         # The top key in the OrderedDict will be the methodResult. Its
         # value may be None if no results were returned.
-        result = list(parse(
-            XML.tostring(result_elt), process_namespaces=True,
-            namespaces={'http://www.sonos.com/Services/1.1': None}
-        ).values())[0]
+        result = list(
+            parse(
+                XML.tostring(result_elt),
+                process_namespaces=True,
+                namespaces={"http://www.sonos.com/Services/1.1": None},
+            ).values()
+        )[0]
 
         return result if result is not None else {}
 
@@ -330,17 +338,17 @@ class MusicService(object):
         self.service_name = service_name
         # Look up the data for this service
         data = self.get_data_for_name(service_name)
-        self.uri = data['Uri']
-        self.secure_uri = data['SecureUri']
-        self.capabilities = data['Capabilities']
-        self.version = data['Version']
-        self.container_type = data['ContainerType']
-        self.service_id = data['Id']
+        self.uri = data["Uri"]
+        self.secure_uri = data["SecureUri"]
+        self.capabilities = data["Capabilities"]
+        self.version = data["Version"]
+        self.container_type = data["ContainerType"]
+        self.service_id = data["Id"]
         # Auth_type can be 'Anonymous', 'UserId, 'DeviceLink'
-        self.auth_type = data['Auth']
-        self.presentation_map_uri = data.get('PresentationMapUri', None)
+        self.auth_type = data["Auth"]
+        self.presentation_map_uri = data.get("PresentationMapUri", None)
         self._search_prefix_map = None
-        self.service_type = data['ServiceType']
+        self.service_type = data["ServiceType"]
         if account is not None:
             self.account = account
         else:
@@ -351,18 +359,17 @@ class MusicService(object):
                     break
             else:
                 raise MusicServiceException(
-                    "No account found for service: '%s'" % service_name)
+                    "No account found for service: '%s'" % service_name
+                )
 
         self.soap_client = MusicServiceSoapClient(
-            endpoint=self.secure_uri,
-            timeout=9,  # The default is 60
-            music_service=self
+            endpoint=self.secure_uri, timeout=9, music_service=self  # The default is 60
         )
 
     def __repr__(self):
-        return '<{0} \'{1}\' at {2}>'.format(self.__class__.__name__,
-                                             self.service_name,
-                                             hex(id(self)))
+        return "<{0} '{1}' at {2}>".format(
+            self.__class__.__name__, self.service_name, hex(id(self))
+        )
 
     def __str__(self):
         return self.__repr__()
@@ -381,8 +388,7 @@ class MusicService(object):
         device = soco or discovery.any_soco()
         log.debug("Fetching music services data from %s", device)
         available_services = device.musicServices.ListAvailableServices()
-        descriptor_list_xml = available_services[
-            'AvailableServiceDescriptorList']
+        descriptor_list_xml = available_services["AvailableServiceDescriptorList"]
         log.debug("Services descriptor list: %s", descriptor_list_xml)
         return descriptor_list_xml
 
@@ -399,9 +405,7 @@ class MusicService(object):
             return cls._music_services_data
 
         result = {}
-        root = XML.fromstring(
-            cls._get_music_services_data_xml().encode('utf-8')
-        )
+        root = XML.fromstring(cls._get_music_services_data_xml().encode("utf-8"))
         # <Services SchemaVersion="1">
         #     <Service Id="163" Name="Spreaker" Version="1.1"
         #         Uri="http://sonos.spreaker.com/sonos/service/v1"
@@ -425,27 +429,26 @@ class MusicService(object):
         # elements at any level, but Python 2.6 breaks with this if Service
         # is a child of the current element. Since 'Service' works here, we use
         # that instead
-        services = root.findall('Service')
+        services = root.findall("Service")
         for service in services:
             result_value = service.attrib.copy()
-            name = service.get('Name')
-            result_value['Name'] = name
-            auth_element = (service.find('Policy'))
+            name = service.get("Name")
+            result_value["Name"] = name
+            auth_element = service.find("Policy")
             auth = auth_element.attrib
             result_value.update(auth)
-            presentation_element = (service.find('.//PresentationMap'))
+            presentation_element = service.find(".//PresentationMap")
             if presentation_element is not None:
-                result_value['PresentationMapUri'] = \
-                    presentation_element.get('Uri')
-            result_value['ServiceID'] = service.get('Id')
+                result_value["PresentationMapUri"] = presentation_element.get("Uri")
+            result_value["ServiceID"] = service.get("Id")
             # ServiceType is used elsewhere in Sonos, eg to form tokens,
             # and get_subscribed_music_services() below. It is also the
             # 'Type' used in account_xml (see above). Its value always
             # seems to be (ID*256) + 7. Some serviceTypes are also
             # listed in available_services['AvailableServiceTypeList']
             # but this does not seem to be comprehensive
-            service_type = str(int(service.get('Id')) * 256 + 7)
-            result_value['ServiceType'] = service_type
+            service_type = str(int(service.get("Id")) * 256 + 7)
+            result_value["ServiceType"] = service_type
             result[service_type] = result_value
         # Cache this so we don't need to do it again.
         cls._music_services_data = result
@@ -460,10 +463,7 @@ class MusicService(object):
         Returns:
             list: A list of strings.
         """
-        return [
-            service['Name'] for service in
-            cls._get_music_services_data().values()
-        ]
+        return [service["Name"] for service in cls._get_music_services_data().values()]
 
     @classmethod
     def get_subscribed_services_names(cls):
@@ -478,10 +478,9 @@ class MusicService(object):
         accounts_for_service = Account.get_accounts_for_service
         service_data = cls._get_music_services_data().values()
         return [
-            service['Name'] for service in service_data
-            if len(
-                accounts_for_service(service['ServiceType'])
-            ) > 0
+            service["Name"]
+            for service in service_data
+            if len(accounts_for_service(service["ServiceType"])) > 0
         ]
 
     @classmethod
@@ -501,8 +500,7 @@ class MusicService(object):
         for service in cls._get_music_services_data().values():
             if service_name == service["Name"]:
                 return service
-        raise MusicServiceException(
-            "Unknown music service: '%s'" % service_name)
+        raise MusicServiceException("Unknown music service: '%s'" % service_name)
 
     def _get_search_prefix_map(self):
         """Fetch and parse the service search category mapping.
@@ -528,16 +526,15 @@ class MusicService(object):
         # Tunein is a special case. It has no pmap, but supports searching
         if self.service_name == "TuneIn":
             self._search_prefix_map = {
-                'stations': 'search:station',
-                'shows': 'search:show',
-                'hosts': 'search:host',
+                "stations": "search:station",
+                "shows": "search:show",
+                "hosts": "search:host",
             }
             return self._search_prefix_map
         if self.presentation_map_uri is None:
             # Assume not searchable?
             return self._search_prefix_map
-        log.info('Fetching presentation map from %s',
-                 self.presentation_map_uri)
+        log.info("Fetching presentation map from %s", self.presentation_map_uri)
         pmap = requests.get(self.presentation_map_uri, timeout=9)
         pmap_root = XML.fromstring(pmap.content)
         # Search translations can appear in Category or CustomCategory elements
@@ -545,11 +542,10 @@ class MusicService(object):
         if categories is None:
             return self._search_prefix_map
         for cat in categories:
-            self._search_prefix_map[cat.get('id')] = cat.get('mappedId')
-        custom_categories = pmap_root.findall(
-            ".//SearchCategories/CustomCategory")
+            self._search_prefix_map[cat.get("id")] = cat.get("mappedId")
+        custom_categories = pmap_root.findall(".//SearchCategories/CustomCategory")
         for cat in custom_categories:
-            self._search_prefix_map[cat.get('stringId')] = cat.get('mappedId')
+            self._search_prefix_map[cat.get("stringId")] = cat.get("mappedId")
         return self._search_prefix_map
 
     @property
@@ -606,12 +602,11 @@ class MusicService(object):
 
         # quote_url will break if given unicode on Py2.6, and early 2.7. So
         # we need to encode.
-        item_id = quote_url(item_id.encode('utf-8'))
+        item_id = quote_url(item_id.encode("utf-8"))
         # Add the account info to the end as query params
         account = self.account
         result = "soco://{}?sid={}&sn={}".format(
-            item_id, self.service_id,
-            account.serial_number
+            item_id, self.service_id, account.serial_number
         )
         return result
 
@@ -622,9 +617,7 @@ class MusicService(object):
         The Sonos descriptor is used as the content of the <desc> tag in
         DIDL metadata, to indicate the relevant music service id and username.
         """
-        desc = "SA_RINCON{}_{}".format(
-            self.account.service_type, self.account.username
-        )
+        desc = "SA_RINCON{}_{}".format(self.account.service_type, self.account.username)
         return desc
 
     ########################################################################
@@ -658,8 +651,7 @@ class MusicService(object):
     #    search(xs:string id, xs:string term, xs:string index, xs:int count)
     #    setPlayedSeconds(id id, xs:int seconds)
 
-    def get_metadata(
-            self, item='root', index=0, count=100, recursive=False):
+    def get_metadata(self, item="root", index=0, count=100, recursive=False):
         """Get metadata for a container or item.
 
         Args:
@@ -685,14 +677,17 @@ class MusicService(object):
         else:
             item_id = item
         response = self.soap_client.call(
-            'getMetadata', [
-                ('id', item_id),
-                ('index', index), ('count', count),
-                ('recursive', 1 if recursive else 0)]
+            "getMetadata",
+            [
+                ("id", item_id),
+                ("index", index),
+                ("count", count),
+                ("recursive", 1 if recursive else 0),
+            ],
         )
-        return parse_response(self, response, 'browse')
+        return parse_response(self, response, "browse")
 
-    def search(self, category, term='', index=0, count=100):
+    def search(self, category, term="", index=0, count=100):
         """Search for an item in a category.
 
         Args:
@@ -714,14 +709,19 @@ class MusicService(object):
         search_category = self._get_search_prefix_map().get(category, None)
         if search_category is None:
             raise MusicServiceException(
-                "%s does not support the '%s' search category" % (
-                    self.service_name, category))
+                "%s does not support the '%s' search category"
+                % (self.service_name, category)
+            )
 
         response = self.soap_client.call(
-            'search',
+            "search",
             [
-                ('id', search_category), ('term', term), ('index', index),
-                ('count', count)])
+                ("id", search_category),
+                ("term", term),
+                ("index", index),
+                ("count", count),
+            ],
+        )
 
         return parse_response(self, response, category)
 
@@ -738,10 +738,8 @@ class MusicService(object):
             The Sonos `getMediaMetadata API
             <http://musicpartners.sonos.com/node/83>`_
         """
-        response = self.soap_client.call(
-            'getMediaMetadata',
-            [('id', item_id)])
-        return response.get('getMediaMetadataResult', None)
+        response = self.soap_client.call("getMediaMetadata", [("id", item_id)])
+        return response.get("getMediaMetadataResult", None)
 
     def get_media_uri(self, item_id):
         """Get a streaming URI for an item.
@@ -761,10 +759,8 @@ class MusicService(object):
         Returns:
             str: The item's streaming URI.
         """
-        response = self.soap_client.call(
-            'getMediaURI',
-            [('id', item_id)])
-        return response.get('getMediaURIResult', None)
+        response = self.soap_client.call("getMediaURI", [("id", item_id)])
+        return response.get("getMediaURIResult", None)
 
     def get_last_update(self):
         """Get last_update details for this music service.
@@ -777,8 +773,8 @@ class MusicService(object):
         """
         # TODO: Maybe create a favorites/catalog cache which is invalidated
         # TODO: when these values change?
-        response = self.soap_client.call('getLastUpdate')
-        return response.get('getLastUpdateResult', None)
+        response = self.soap_client.call("getLastUpdate")
+        return response.get("getLastUpdateResult", None)
 
     def get_extended_metadata(self, item_id):
         """Get extended metadata for a media item, such as related items.
@@ -793,10 +789,8 @@ class MusicService(object):
             The Sonos `getExtendedMetadata API
             <http://musicpartners.sonos.com/node/128>`_
         """
-        response = self.soap_client.call(
-            'getExtendedMetadata',
-            [('id', item_id)])
-        return response.get('getExtendedMetadataResult', None)
+        response = self.soap_client.call("getExtendedMetadata", [("id", item_id)])
+        return response.get("getExtendedMetadataResult", None)
 
     def get_extended_metadata_text(self, item_id, metadata_type):
         """Get extended metadata text for a media item.
@@ -816,9 +810,9 @@ class MusicService(object):
             <http://musicpartners.sonos.com/node/127>`_
         """
         response = self.soap_client.call(
-            'getExtendedMetadataText',
-            [('id', item_id), ('type', metadata_type)])
-        return response.get('getExtendedMetadataTextResult', None)
+            "getExtendedMetadataText", [("id", item_id), ("type", metadata_type)]
+        )
+        return response.get("getExtendedMetadataTextResult", None)
 
 
 def desc_from_uri(uri):
@@ -847,21 +841,20 @@ def desc_from_uri(uri):
     # the uri as if it were http
     if ":" in uri:
         _, uri = uri.split(":", 1)
-    query_string = parse_qs(urlparse(uri, 'http').query)
+    query_string = parse_qs(urlparse(uri, "http").query)
     # Is there an account serial number?
-    if query_string.get('sn'):
-        account_serial_number = query_string['sn'][0]
+    if query_string.get("sn"):
+        account_serial_number = query_string["sn"][0]
         try:
             account = Account.get_accounts()[account_serial_number]
-            desc = "SA_RINCON{}_{}".format(
-                account.service_type, account.username)
+            desc = "SA_RINCON{}_{}".format(account.service_type, account.username)
             return desc
         except KeyError:
             # There is no account matching this serial number. Fall back to
             # using the service id to find an account
             pass
-    if query_string.get('sid'):
-        service_id = query_string['sid'][0]
+    if query_string.get("sid"):
+        service_id = query_string["sid"][0]
         for service in MusicService._get_music_services_data().values():
             if service_id == service["ServiceID"]:
                 service_type = service["ServiceType"]
@@ -870,10 +863,9 @@ def desc_from_uri(uri):
                     break
                 # Use the first account we find
                 account = account[0]
-                desc = "SA_RINCON{}_{}".format(
-                    account.service_type, account.username)
+                desc = "SA_RINCON{}_{}".format(account.service_type, account.username)
                 return desc
     # Nothing found. Default to the standard desc value. Is this the right
     # thing to do?
-    desc = 'RINCON_AssociatedZPUDN'
+    desc = "RINCON_AssociatedZPUDN"
     return desc

--- a/soco/plugins/__init__.py
+++ b/soco/plugins/__init__.py
@@ -22,27 +22,27 @@ class SoCoPlugin(object):
 
     def __init__(self, soco):
         cls = self.__class__.__name__
-        _LOG.info('Initializing SoCo plugin %s', cls)
+        _LOG.info("Initializing SoCo plugin %s", cls)
         self.soco = soco
 
     @property
     def name(self):
         """ human-readable name of the plugin """
-        raise NotImplementedError('Plugins should overwrite the name property')
+        raise NotImplementedError("Plugins should overwrite the name property")
 
     @classmethod
     def from_name(cls, fullname, soco, *args, **kwargs):
         """Instantiate a plugin by its full name."""
 
-        _LOG.info('Loading plugin %s', fullname)
+        _LOG.info("Loading plugin %s", fullname)
 
-        parts = fullname.split('.')
-        modname = '.'.join(parts[:-1])
+        parts = fullname.split(".")
+        modname = ".".join(parts[:-1])
         clsname = parts[-1]
 
         mod = importlib.import_module(modname)
         class_ = getattr(mod, clsname)
 
-        _LOG.info('Loaded class %s', class_)
+        _LOG.info("Loaded class %s", class_)
 
         return class_(soco, *args, **kwargs)

--- a/soco/plugins/example.py
+++ b/soco/plugins/example.py
@@ -2,13 +2,11 @@
 
 """Example implementation of a plugin."""
 
-from __future__ import (
-    print_function, unicode_literals
-)
+from __future__ import print_function, unicode_literals
 
 from ..plugins import SoCoPlugin
 
-__all__ = ['ExamplePlugin']
+__all__ = ["ExamplePlugin"]
 
 
 class ExamplePlugin(SoCoPlugin):
@@ -27,7 +25,7 @@ class ExamplePlugin(SoCoPlugin):
 
     @property
     def name(self):
-        return 'Example Plugin for {}'.format(self.username)
+        return "Example Plugin for {}".format(self.username)
 
     def music_plugin_play(self):
         """Play some music.
@@ -36,12 +34,9 @@ class ExamplePlugin(SoCoPlugin):
         to show how we can use the general upnp methods from soco
         """
 
-        print('Hi,', self.username)
+        print("Hi,", self.username)
 
-        self.soco.avTransport.Play([
-            ('InstanceID', 0),
-            ('Speed', 1)
-        ])
+        self.soco.avTransport.Play([("InstanceID", 0), ("Speed", 1)])
 
     def music_plugin_stop(self):
         """Stop the music.
@@ -50,5 +45,5 @@ class ExamplePlugin(SoCoPlugin):
         functionality from inside the plugins
         """
 
-        print('Bye,', self.username)
+        print("Bye,", self.username)
         self.soco.stop()

--- a/soco/plugins/spotify.py
+++ b/soco/plugins/spotify.py
@@ -28,7 +28,7 @@ after 0.12.
 
 import sys
 import os
+
 # Only raise this import error if we are not building the docs
-if not (os.environ.get('READTHEDOCS', None) == 'True' or
-        'sphinx' in sys.modules):
+if not (os.environ.get("READTHEDOCS", None) == "True" or "sphinx" in sys.modules):
     raise RuntimeError(__doc__)

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -10,19 +10,24 @@ import socket
 
 import requests
 
-from ..exceptions import (
-    SoCoUPnPException, UnknownXMLStructure
-)
+from ..exceptions import SoCoUPnPException, UnknownXMLStructure
 from ..ms_data_structures import (
-    MSAlbum, MSAlbumList, MSArtist, MSArtistTracklist,
-    MSCollection, MSFavorites, MSPlaylist, MSTrack, get_ms_item
+    MSAlbum,
+    MSAlbumList,
+    MSArtist,
+    MSArtistTracklist,
+    MSCollection,
+    MSFavorites,
+    MSPlaylist,
+    MSTrack,
+    get_ms_item,
 )
 from ..services import MusicServices
 from ..utils import really_utf8
 from ..xml import XML
 from .__init__ import SoCoPlugin
 
-__all__ = ['Wimp']
+__all__ = ["Wimp"]
 
 
 def _post(url, headers, body, retries=3, timeout=3.0):
@@ -42,8 +47,7 @@ def _post(url, headers, body, retries=3, timeout=3.0):
     out = None
     while out is None:
         try:
-            out = requests.post(url, headers=headers, data=body,
-                                timeout=timeout)
+            out = requests.post(url, headers=headers, data=body, timeout=timeout)
         # Due to a bug in requests, the post command will sometimes fail to
         # properly wrap a socket.timeout exception in requests own exception.
         # See https://github.com/kennethreitz/requests/issues/2045
@@ -66,7 +70,7 @@ def _ns_tag(ns_id, tag):
     :param tag: The tag
     :type str: str
     """
-    return '{{{}}}{}'.format(NS[ns_id], tag)
+    return "{{{}}}{}".format(NS[ns_id], tag)
 
 
 def _get_header(soap_action):
@@ -82,16 +86,16 @@ def _get_header(soap_action):
     # the available music in each country is bound to the account.
     language, _ = locale.getdefaultlocale()
     if language is None:
-        language = ''
+        language = ""
     else:
-        language = language.replace('_', '-') + ', '
+        language = language.replace("_", "-") + ", "
 
     header = {
-        'CONNECTION': 'close',
-        'ACCEPT-ENCODING': 'gzip',
-        'ACCEPT-LANGUAGE': '{}en-US;q=0.9'.format(language),
-        'Content-Type': 'text/xml; charset="utf-8"',
-        'SOAPACTION': SOAP_ACTION[soap_action]
+        "CONNECTION": "close",
+        "ACCEPT-ENCODING": "gzip",
+        "ACCEPT-LANGUAGE": "{}en-US;q=0.9".format(language),
+        "Content-Type": 'text/xml; charset="utf-8"',
+        "SOAPACTION": SOAP_ACTION[soap_action],
     }
     return header
 
@@ -154,24 +158,23 @@ class Wimp(SoCoPlugin):
         super(Wimp, self).__init__(soco)
 
         # Instantiate variables
-        self._url = 'http://client.wimpmusic.com/sonos/services/Sonos'
-        self._serial_number = soco.get_speaker_info()['serial_number']
+        self._url = "http://client.wimpmusic.com/sonos/services/Sonos"
+        self._serial_number = soco.get_speaker_info()["serial_number"]
         self._username = username
         self._service_id = 20
-        self._http_vars = {'retries': retries, 'timeout': timeout}
+        self._http_vars = {"retries": retries, "timeout": timeout}
 
         # Get a session id for the searches
         self._music_services = MusicServices(soco)
-        response = self._music_services.GetSessionId([
-            ('ServiceId', 20),
-            ('Username', username)
-        ])
-        self._session_id = response['SessionId']
+        response = self._music_services.GetSessionId(
+            [("ServiceId", 20), ("Username", username)]
+        )
+        self._session_id = response["SessionId"]
 
     @property
     def name(self):
         """Return the human read-able name for the plugin"""
-        return 'Wimp Plugin for {}'.format(self._username)
+        return "Wimp Plugin for {}".format(self._username)
 
     @property
     def username(self):
@@ -187,31 +190,28 @@ class Wimp(SoCoPlugin):
     def description(self):
         """Return the music service description for the DIDL metadata on the
         form ``'SA_RINCON5127_...self.username...'``"""
-        return 'SA_RINCON5127_{}'.format(self._username)
+        return "SA_RINCON5127_{}".format(self._username)
 
     def get_tracks(self, search, start=0, max_items=100):
         """Search for tracks.
 
         See get_music_service_information for details on the arguments
         """
-        return self.get_music_service_information('tracks', search, start,
-                                                  max_items)
+        return self.get_music_service_information("tracks", search, start, max_items)
 
     def get_albums(self, search, start=0, max_items=100):
         """Search for albums.
 
         See get_music_service_information for details on the arguments
         """
-        return self.get_music_service_information('albums', search, start,
-                                                  max_items)
+        return self.get_music_service_information("albums", search, start, max_items)
 
     def get_artists(self, search, start=0, max_items=100):
         """Search for artists.
 
         See get_music_service_information for details on the arguments
         """
-        return self.get_music_service_information('artists', search, start,
-                                                  max_items)
+        return self.get_music_service_information("artists", search, start, max_items)
 
     def get_playlists(self, search, start=0, max_items=100):
         """Search for playlists.
@@ -223,11 +223,11 @@ class Wimp(SoCoPlugin):
             Un-intuitively this method returns MSAlbumList items. See
             note in class doc string for details.
         """
-        return self.get_music_service_information('playlists', search, start,
-                                                  max_items)
+        return self.get_music_service_information("playlists", search, start, max_items)
 
-    def get_music_service_information(self, search_type, search, start=0,
-                                      max_items=100):
+    def get_music_service_information(
+        self, search_type, search, start=0, max_items=100
+    ):
         """Search for music service information items.
 
         :param search_type: The type of search to perform, possible values are:
@@ -245,34 +245,32 @@ class Wimp(SoCoPlugin):
             items. See note in class doc string for details.
         """
         # Check input
-        if search_type not in ['artists', 'albums', 'tracks', 'playlists']:
-            message = 'The requested search {} is not valid'\
-                .format(search_type)
+        if search_type not in ["artists", "albums", "tracks", "playlists"]:
+            message = "The requested search {} is not valid".format(search_type)
             raise ValueError(message)
         # Transform search: tracks -> tracksearch
-        search_type = '{}earch'.format(search_type)
-        parent_id = SEARCH_PREFIX.format(search_type=search_type,
-                                         search=search)
+        search_type = "{}earch".format(search_type)
+        parent_id = SEARCH_PREFIX.format(search_type=search_type, search=search)
 
         # Perform search
         body = self._search_body(search_type, search, start, max_items)
-        headers = _get_header('search')
+        headers = _get_header("search")
         response = _post(self._url, headers, body, **self._http_vars)
         self._check_for_errors(response)
-        result_dom = XML.fromstring(response.text.encode('utf-8'))
+        result_dom = XML.fromstring(response.text.encode("utf-8"))
 
         # Parse results
-        search_result = result_dom.find('.//' + _ns_tag('', 'searchResult'))
-        out = {'item_list': []}
-        for element in ['index', 'count', 'total']:
-            out[element] = search_result.findtext(_ns_tag('', element))
+        search_result = result_dom.find(".//" + _ns_tag("", "searchResult"))
+        out = {"item_list": []}
+        for element in ["index", "count", "total"]:
+            out[element] = search_result.findtext(_ns_tag("", element))
 
-        if search_type == 'tracksearch':
-            item_name = 'mediaMetadata'
+        if search_type == "tracksearch":
+            item_name = "mediaMetadata"
         else:
-            item_name = 'mediaCollection'
-        for element in search_result.findall(_ns_tag('', item_name)):
-            out['item_list'].append(get_ms_item(element, self, parent_id))
+            item_name = "mediaCollection"
+        for element in search_result.findall(_ns_tag("", item_name)):
+            out["item_list"].append(get_ms_item(element, self, parent_id))
 
         return out
 
@@ -295,7 +293,7 @@ class Wimp(SoCoPlugin):
         """
         # Check for correct service
         if ms_item is not None and ms_item.service_id != self._service_id:
-            message = 'This music service item is not for this service'
+            message = "This music service item is not for this service"
             raise ValueError(message)
 
         # Form HTTP body and set parent_id
@@ -303,37 +301,39 @@ class Wimp(SoCoPlugin):
             body = self._browse_body(ms_item.item_id)
             parent_id = ms_item.extended_id
             if parent_id is None:
-                parent_id = ''
+                parent_id = ""
         else:
-            body = self._browse_body('root')
-            parent_id = '0'
+            body = self._browse_body("root")
+            parent_id = "0"
 
         # Get HTTP header and post
-        headers = _get_header('get_metadata')
+        headers = _get_header("get_metadata")
         response = _post(self._url, headers, body, **self._http_vars)
 
         # Check for errors and get XML
         self._check_for_errors(response)
         result_dom = XML.fromstring(really_utf8(response.text))
         # Find the getMetadataResult item ...
-        xpath_search = './/' + _ns_tag('', 'getMetadataResult')
+        xpath_search = ".//" + _ns_tag("", "getMetadataResult")
         metadata_result = list(result_dom.findall(xpath_search))
         # ... and make sure there is exactly 1
         if len(metadata_result) != 1:
             raise UnknownXMLStructure(
-                'The results XML has more than 1 \'getMetadataResult\'. This '
-                'is unexpected and parsing will dis-continue.'
+                "The results XML has more than 1 'getMetadataResult'. This "
+                "is unexpected and parsing will dis-continue."
             )
         metadata_result = metadata_result[0]
 
         # Browse the children of metadata result
-        out = {'item_list': []}
-        for element in ['index', 'count', 'total']:
-            out[element] = metadata_result.findtext(_ns_tag('', element))
+        out = {"item_list": []}
+        for element in ["index", "count", "total"]:
+            out[element] = metadata_result.findtext(_ns_tag("", element))
         for result in metadata_result:
-            if result.tag in [_ns_tag('', 'mediaCollection'),
-                              _ns_tag('', 'mediaMetadata')]:
-                out['item_list'].append(get_ms_item(result, self, parent_id))
+            if result.tag in [
+                _ns_tag("", "mediaCollection"),
+                _ns_tag("", "mediaMetadata"),
+            ]:
+                out["item_list"].append(get_ms_item(result, self, parent_id))
         return out
 
     @staticmethod
@@ -366,8 +366,8 @@ class Wimp(SoCoPlugin):
             :py:class:`soco.data_structures.MusicServiceItem`
         """
         extension = None
-        if 'mime_type' in item_content:
-            extension = MIME_TYPE_TO_EXTENSION[item_content['mime_type']]
+        if "mime_type" in item_content:
+            extension = MIME_TYPE_TO_EXTENSION[item_content["mime_type"]]
         out = URIS.get(item_class)
         if out:
             out = out.format(extension=extension, **item_content)
@@ -402,15 +402,13 @@ class Wimp(SoCoPlugin):
         xml = self._base_body()
 
         # Add the Body part
-        XML.SubElement(xml, 's:Body')
-        item_attrib = {
-            'xmlns': 'http://www.sonos.com/Services/1.1'
-        }
-        search = XML.SubElement(xml[1], 'search', item_attrib)
-        XML.SubElement(search, 'id').text = search_type
-        XML.SubElement(search, 'term').text = search_term
-        XML.SubElement(search, 'index').text = str(start)
-        XML.SubElement(search, 'count').text = str(max_items)
+        XML.SubElement(xml, "s:Body")
+        item_attrib = {"xmlns": "http://www.sonos.com/Services/1.1"}
+        search = XML.SubElement(xml[1], "search", item_attrib)
+        XML.SubElement(search, "id").text = search_type
+        XML.SubElement(search, "term").text = search_term
+        XML.SubElement(search, "index").text = str(start)
+        XML.SubElement(search, "count").text = str(max_items)
 
         return XML.tostring(xml)
 
@@ -437,15 +435,13 @@ class Wimp(SoCoPlugin):
         xml = self._base_body()
 
         # Add the Body part
-        XML.SubElement(xml, 's:Body')
-        item_attrib = {
-            'xmlns': 'http://www.sonos.com/Services/1.1'
-        }
-        search = XML.SubElement(xml[1], 'getMetadata', item_attrib)
-        XML.SubElement(search, 'id').text = search_id
+        XML.SubElement(xml, "s:Body")
+        item_attrib = {"xmlns": "http://www.sonos.com/Services/1.1"}
+        search = XML.SubElement(xml[1], "getMetadata", item_attrib)
+        XML.SubElement(search, "id").text = search_id
         # Investigate this index, count stuff more
-        XML.SubElement(search, 'index').text = '0'
-        XML.SubElement(search, 'count').text = '100'
+        XML.SubElement(search, "index").text = "0"
+        XML.SubElement(search, "count").text = "100"
 
         return XML.tostring(xml)
 
@@ -465,19 +461,17 @@ class Wimp(SoCoPlugin):
          </s:Envelope>
         """
         item_attrib = {
-            'xmlns:s': 'http://schemas.xmlsoap.org/soap/envelope/',
+            "xmlns:s": "http://schemas.xmlsoap.org/soap/envelope/",
         }
-        xml = XML.Element('s:Envelope', item_attrib)
+        xml = XML.Element("s:Envelope", item_attrib)
 
         # Add the Header part
-        XML.SubElement(xml, 's:Header')
-        item_attrib = {
-            'xmlns': 'http://www.sonos.com/Services/1.1'
-        }
-        credentials = XML.SubElement(xml[0], 'credentials', item_attrib)
-        XML.SubElement(credentials, 'sessionId').text = self._session_id
-        XML.SubElement(credentials, 'deviceId').text = self._serial_number
-        XML.SubElement(credentials, 'deviceProvider').text = 'Sonos'
+        XML.SubElement(xml, "s:Header")
+        item_attrib = {"xmlns": "http://www.sonos.com/Services/1.1"}
+        credentials = XML.SubElement(xml[0], "credentials", item_attrib)
+        XML.SubElement(credentials, "sessionId").text = self._session_id
+        XML.SubElement(credentials, "deviceId").text = self._serial_number
+        XML.SubElement(credentials, "deviceProvider").text = "Sonos"
 
         return xml
 
@@ -489,52 +483,47 @@ class Wimp(SoCoPlugin):
         if response.status_code != 200:
             xml_error = really_utf8(response.text)
             error_dom = XML.fromstring(xml_error)
-            fault = error_dom.find('.//' + _ns_tag('s', 'Fault'))
-            error_description = fault.find('faultstring').text
+            fault = error_dom.find(".//" + _ns_tag("s", "Fault"))
+            error_description = fault.find("faultstring").text
             error_code = EXCEPTION_STR_TO_CODE[error_description]
-            message = 'UPnP Error {} received: {} from {}'.format(
-                error_code, error_description, self._url)
+            message = "UPnP Error {} received: {} from {}".format(
+                error_code, error_description, self._url
+            )
             raise SoCoUPnPException(
                 message=message,
                 error_code=error_code,
                 error_description=error_description,
-                error_xml=really_utf8(response.text)
+                error_xml=really_utf8(response.text),
             )
 
 
 SOAP_ACTION = {
-    'get_metadata': '"http://www.sonos.com/Services/1.1#getMetadata"',
-    'search': '"http://www.sonos.com/Services/1.1#search"'
+    "get_metadata": '"http://www.sonos.com/Services/1.1#getMetadata"',
+    "search": '"http://www.sonos.com/Services/1.1#search"',
 }
 # Note UPnP exception 802 while trying to add a Wimp track indicates that these
 # are tracks that not available in Wimp. Do something with that.
-EXCEPTION_STR_TO_CODE = {
-    'unknown': 20000,
-    'ItemNotFound': 20001
-}
-SEARCH_PREFIX = '00020064{search_type}:{search}'
+EXCEPTION_STR_TO_CODE = {"unknown": 20000, "ItemNotFound": 20001}
+SEARCH_PREFIX = "00020064{search_type}:{search}"
 ID_PREFIX = {
-    MSTrack: '00030020',
-    MSAlbum: '0004002c',
-    MSArtist: '10050024',
-    MSAlbumList: '000d006c',
-    MSPlaylist: '0006006c',
-    MSArtistTracklist: '100f006c',
+    MSTrack: "00030020",
+    MSAlbum: "0004002c",
+    MSArtist: "10050024",
+    MSAlbumList: "000d006c",
+    MSPlaylist: "0006006c",
+    MSArtistTracklist: "100f006c",
     MSFavorites: None,  # This one is unknown
-    MSCollection: None  # This one is unknown
-
+    MSCollection: None,  # This one is unknown
 }
-MIME_TYPE_TO_EXTENSION = {
-    'audio/aac': 'mp4'
-}
+MIME_TYPE_TO_EXTENSION = {"audio/aac": "mp4"}
 URIS = {
-    MSTrack: 'x-sonos-http:{item_id}.{extension}?sid={service_id}&flags=32',
-    MSAlbum: 'x-rincon-cpcontainer:{extended_id}',
-    MSAlbumList: 'x-rincon-cpcontainer:{extended_id}',
-    MSPlaylist: 'x-rincon-cpcontainer:{extended_id}',
-    MSArtistTracklist: 'x-rincon-cpcontainer:{extended_id}'
+    MSTrack: "x-sonos-http:{item_id}.{extension}?sid={service_id}&flags=32",
+    MSAlbum: "x-rincon-cpcontainer:{extended_id}",
+    MSAlbumList: "x-rincon-cpcontainer:{extended_id}",
+    MSPlaylist: "x-rincon-cpcontainer:{extended_id}",
+    MSArtistTracklist: "x-rincon-cpcontainer:{extended_id}",
 }
 NS = {
-    's': 'http://schemas.xmlsoap.org/soap/envelope/',
-    '': 'http://www.sonos.com/Services/1.1'
+    "s": "http://schemas.xmlsoap.org/soap/envelope/",
+    "": "http://www.sonos.com/Services/1.1",
 }

--- a/soco/services.py
+++ b/soco/services.py
@@ -32,9 +32,7 @@ Argument(name='CurrentDateFormat', vartype='string')] ...
 
 # UPnP Spec at http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.0.pdf
 
-from __future__ import (
-    absolute_import, unicode_literals
-)
+from __future__ import absolute_import, unicode_literals
 
 import logging
 from collections import namedtuple
@@ -45,9 +43,7 @@ import requests
 from .cache import Cache
 from . import events
 from . import config
-from .exceptions import (
-    SoCoUPnPException, UnknownSoCoException
-)
+from .exceptions import SoCoUPnPException, UnknownSoCoException
 from .utils import prettify
 from .xml import XML, illegal_xml_re
 
@@ -71,30 +67,33 @@ if config.EVENTS_MODULE is None:
     config.EVENTS_MODULE = events
 
 
-class Action(namedtuple('ActionBase', 'name, in_args, out_args')):
+class Action(namedtuple("ActionBase", "name, in_args, out_args")):
     """A UPnP Action and its arguments."""
+
     def __str__(self):
-        args = ', '.join(str(arg) for arg in self.in_args)
-        returns = ', '.join(str(arg) for arg in self.out_args)
-        return '{0}({1}) -> {{{2}}}'.format(self.name, args, returns)
+        args = ", ".join(str(arg) for arg in self.in_args)
+        returns = ", ".join(str(arg) for arg in self.out_args)
+        return "{0}({1}) -> {{{2}}}".format(self.name, args, returns)
 
 
-class Argument(namedtuple('ArgumentBase', 'name, vartype')):
+class Argument(namedtuple("ArgumentBase", "name, vartype")):
     """A UPnP Argument and its type."""
+
     def __str__(self):
         argument = self.name
         if self.vartype.default:
             argument = "{0}={1}".format(self.name, self.vartype.default)
-        return '{0}: {1}'.format(argument, str(self.vartype))
+        return "{0}: {1}".format(argument, str(self.vartype))
 
 
-class Vartype(namedtuple('VartypeBase', 'datatype, default, list, range')):
+class Vartype(namedtuple("VartypeBase", "datatype, default, list, range")):
     """An argument type with default value and range."""
+
     def __str__(self):
         if self.list:
-            return '[{0}]'.format(', '.join(self.list))
+            return "[{0}]".format(", ".join(self.list))
         if self.range:
-            return '[{0}..{1}]'.format(self.range[0], self.range[1])
+            return "[{0}..{1}]".format(self.range[0], self.range[1])
         return self.datatype
 
 
@@ -115,18 +114,20 @@ class Service(object):
     defined here are dispatched automatically to the service action with the
     same name.
     """
+
     # pylint: disable=bad-continuation
     soap_body_template = (
         '<?xml version="1.0"?>'
         '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"'
         ' s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
-            '<s:Body>'
-                '<u:{action} xmlns:u="urn:schemas-upnp-org:service:'
-                    '{service_type}:{version}">'
-                    '{arguments}'
-                '</u:{action}>'
-            '</s:Body>'
-        '</s:Envelope>')  # noqa PEP8
+        "<s:Body>"
+        '<u:{action} xmlns:u="urn:schemas-upnp-org:service:'
+        '{service_type}:{version}">'
+        "{arguments}"
+        "</u:{action}>"
+        "</s:Body>"
+        "</s:Envelope>"
+    )  # noqa PEP8
 
     def __init__(self, soco):
         """
@@ -149,14 +150,13 @@ class Service(object):
         self.version = 1
         self.service_id = self.service_type
         #: str: The base URL for sending UPnP Actions.
-        self.base_url = 'http://{}:1400'.format(self.soco.ip_address)
+        self.base_url = "http://{}:1400".format(self.soco.ip_address)
         #: str: The UPnP Control URL.
-        self.control_url = '/{}/Control'.format(self.service_type)
+        self.control_url = "/{}/Control".format(self.service_type)
         #: str: The service control protocol description URL.
-        self.scpd_url = '/xml/{}{}.xml'.format(
-            self.service_type, self.version)
+        self.scpd_url = "/xml/{}{}.xml".format(self.service_type, self.version)
         #: str: The service eventing subscription URL.
-        self.event_subscription_url = '/{}/Event'.format(self.service_type)
+        self.event_subscription_url = "/{}/Event".format(self.service_type)
         #: A cache for storing the result of network calls. By default, this is
         #: a `TimedCache` with a default timeout=0.
         self.cache = Cache(default_timeout=0)
@@ -176,25 +176,25 @@ class Service(object):
 
         # pylint: disable=invalid-name
         self.UPNP_ERRORS = {
-            400: 'Bad Request',
-            401: 'Invalid Action',
-            402: 'Invalid Args',
-            404: 'Invalid Var',
-            412: 'Precondition Failed',
-            501: 'Action Failed',
-            600: 'Argument Value Invalid',
-            601: 'Argument Value Out of Range',
-            602: 'Optional Action Not Implemented',
-            603: 'Out Of Memory',
-            604: 'Human Intervention Required',
-            605: 'String Argument Too Long',
-            606: 'Action Not Authorized',
-            607: 'Signature Failure',
-            608: 'Signature Missing',
-            609: 'Not Encrypted',
-            610: 'Invalid Sequence',
-            611: 'Invalid Control URL',
-            612: 'No Such Session',
+            400: "Bad Request",
+            401: "Invalid Action",
+            402: "Invalid Args",
+            404: "Invalid Var",
+            412: "Precondition Failed",
+            501: "Action Failed",
+            600: "Argument Value Invalid",
+            601: "Argument Value Out of Range",
+            602: "Optional Action Not Implemented",
+            603: "Out Of Memory",
+            604: "Human Intervention Required",
+            605: "String Argument Too Long",
+            606: "Action Not Authorized",
+            607: "Signature Failure",
+            608: "Signature Missing",
+            609: "Not Encrypted",
+            610: "Invalid Sequence",
+            611: "Invalid Control URL",
+            612: "No Such Session",
         }
         self.DEFAULT_ARGS = {}
 
@@ -258,7 +258,8 @@ class Service(object):
         tags = []
         for name, value in args:
             tag = "<{name}>{value}</{name}>".format(
-                name=name, value=escape("%s" % value, {'"': "&quot;"}))
+                name=name, value=escape("%s" % value, {'"': "&quot;"})
+            )
             # % converts to unicode because we are using unicode literals.
             # Avoids use of 'unicode' function which does not exist in python 3
             tags.append(tag)
@@ -301,22 +302,24 @@ class Service(object):
 
         # Get all tags in order. Elementree (in python 2.x) seems to prefer to
         # be fed bytes, rather than unicode
-        xml_response = xml_response.encode('utf-8')
+        xml_response = xml_response.encode("utf-8")
         try:
             tree = XML.fromstring(xml_response)
         except XML.ParseError:
             # Try to filter illegal xml chars (as unicode), in case that is
             # the reason for the parse error
-            filtered = illegal_xml_re.sub('', xml_response.decode('utf-8'))\
-                                     .encode('utf-8')
+            filtered = illegal_xml_re.sub("", xml_response.decode("utf-8")).encode(
+                "utf-8"
+            )
             tree = XML.fromstring(filtered)
 
         # Get the first child of the <Body> tag which will be
         # <{actionNameResponse}> (depends on what actionName is). Turn the
         # children of this into a {tagname, content} dict. XML unescaping
         # is carried out for us by elementree.
-        action_response = tree.find(
-            "{http://schemas.xmlsoap.org/soap/envelope/}Body")[0]
+        action_response = tree.find("{http://schemas.xmlsoap.org/soap/envelope/}Body")[
+            0
+        ]
         return dict((i.tag, i.text or "") for i in action_response)
 
     def compose_args(self, action_name, in_argdict):
@@ -343,17 +346,17 @@ class Service(object):
                 # The found 'action' will be visible from outside the loop
                 break
         else:
-            raise AttributeError('Unknown Action: {0}'.format(action_name))
+            raise AttributeError("Unknown Action: {0}".format(action_name))
 
         # Check for given argument names which do not occur in the expected
         # argument list
         # pylint: disable=undefined-loop-variable
-        unexpected = set(in_argdict) - \
-            set(argument.name for argument in action.in_args)
+        unexpected = set(in_argdict) - set(argument.name for argument in action.in_args)
         if unexpected:
             raise ValueError(
-                "Unexpected argument '{0}'. Method signature: {1}"
-                .format(next(iter(unexpected)), str(action))
+                "Unexpected argument '{0}'. Method signature: {1}".format(
+                    next(iter(unexpected)), str(action)
+                )
             )
 
         # List the (name, value) tuples for each argument in the argument list
@@ -369,8 +372,9 @@ class Service(object):
             if argument.vartype.default is not None:
                 composed.append((name, argument.vartype.default))
             raise ValueError(
-                "Missing argument '{0}'. Method signature: {1}"
-                .format(argument.name, str(action))
+                "Missing argument '{0}'. Method signature: {1}".format(
+                    argument.name, str(action)
+                )
             )
         return composed
 
@@ -413,22 +417,27 @@ class Service(object):
 
         arguments = self.wrap_arguments(args)
         body = self.soap_body_template.format(
-            arguments=arguments, action=action, service_type=self.service_type,
-            version=self.version)
-        soap_action_template = \
+            arguments=arguments,
+            action=action,
+            service_type=self.service_type,
+            version=self.version,
+        )
+        soap_action_template = (
             "urn:schemas-upnp-org:service:{service_type}:{version}#{action}"
+        )
         soap_action = soap_action_template.format(
-            service_type=self.service_type, version=self.version,
-            action=action)
-        headers = {'Content-Type': 'text/xml; charset="utf-8"',
-                   'SOAPACTION': soap_action}
+            service_type=self.service_type, version=self.version, action=action
+        )
+        headers = {
+            "Content-Type": 'text/xml; charset="utf-8"',
+            "SOAPACTION": soap_action,
+        }
         # Note that although we set the charset to utf-8 here, in fact the
         # body is still unicode. It will only be converted to bytes when it
         # is set over the network
         return (headers, body)
 
-    def send_command(self, action, args=None, cache=None, cache_timeout=None,
-                     **kwargs):
+    def send_command(self, action, args=None, cache=None, cache_timeout=None, **kwargs):
         """Send a command to a Sonos device.
 
         Args:
@@ -476,14 +485,11 @@ class Service(object):
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
         response = requests.post(
-            self.base_url + self.control_url,
-            headers=headers,
-            data=body.encode('utf-8')
+            self.base_url + self.control_url, headers=headers, data=body.encode("utf-8")
         )
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
-        log.info(
-            "Received status %s from %s", status, self.soco.ip_address)
+        log.info("Received status %s from %s", status, self.soco.ip_address)
         if status == 200:
             # The response is good. Get the output params, and return them.
             # NB an empty dict is a valid result. It just means that no
@@ -545,19 +551,19 @@ class Service(object):
         # errorDescription is not required, and Sonos does not seem to use it.
 
         # NB need to encode unicode strings before passing to ElementTree
-        xml_error = xml_error.encode('utf-8')
+        xml_error = xml_error.encode("utf-8")
         error = XML.fromstring(xml_error)
         log.debug("Error %s", xml_error)
-        error_code = error.findtext(
-            './/{urn:schemas-upnp-org:control-1-0}errorCode')
+        error_code = error.findtext(".//{urn:schemas-upnp-org:control-1-0}errorCode")
         if error_code is not None:
-            description = self.UPNP_ERRORS.get(int(error_code), '')
+            description = self.UPNP_ERRORS.get(int(error_code), "")
             raise SoCoUPnPException(
-                message='UPnP Error {} received: {} from {}'.format(
-                    error_code, description, self.soco.ip_address),
+                message="UPnP Error {} received: {} from {}".format(
+                    error_code, description, self.soco.ip_address
+                ),
                 error_code=error_code,
                 error_description=description,
-                error_xml=xml_error
+                error_xml=xml_error,
             )
 
         # Unknown error, so just return the entire response
@@ -565,8 +571,8 @@ class Service(object):
         raise UnknownSoCoException(xml_error)
 
     def subscribe(
-            self, requested_timeout=None, auto_renew=False, event_queue=None,
-            strict=True):
+        self, requested_timeout=None, auto_renew=False, event_queue=None, strict=True
+    ):
         """Subscribe to the service's events.
 
         Args:
@@ -595,11 +601,10 @@ class Service(object):
 
         To unsubscribe, call the `unsubscribe` method on the returned object.
         """
-        subscription = config.EVENTS_MODULE.Subscription(
-            self, event_queue)
+        subscription = config.EVENTS_MODULE.Subscription(self, event_queue)
         return subscription.subscribe(
-            requested_timeout=requested_timeout, auto_renew=auto_renew,
-            strict=strict)
+            requested_timeout=requested_timeout, auto_renew=auto_renew, strict=strict
+        )
 
     def _update_cache_on_event(self, event):
         """Update the cache when an event is received.
@@ -676,44 +681,42 @@ class Service(object):
 
         # pylint: disable=too-many-locals
         # pylint: disable=invalid-name
-        ns = '{urn:schemas-upnp-org:service-1-0}'
+        ns = "{urn:schemas-upnp-org:service-1-0}"
         # get the scpd body as bytes, and feed directly to elementtree
         # which likes to receive bytes
         scpd_body = requests.get(self.base_url + self.scpd_url).content
         tree = XML.fromstring(scpd_body)
         # parse the state variables to get the relevant variable types
         vartypes = {}
-        srvStateTables = tree.findall('{}serviceStateTable'.format(ns))
+        srvStateTables = tree.findall("{}serviceStateTable".format(ns))
         for srvStateTable in srvStateTables:
-            statevars = srvStateTable.findall('{}stateVariable'.format(ns))
+            statevars = srvStateTable.findall("{}stateVariable".format(ns))
             for state in statevars:
-                name = state.findtext('{}name'.format(ns))
-                datatype = state.findtext('{}dataType'.format(ns))
-                default = state.findtext('{}defaultValue'.format(ns))
-                value_list_elt = state.find('{}allowedValueList'.format(ns))\
-                    or ()
+                name = state.findtext("{}name".format(ns))
+                datatype = state.findtext("{}dataType".format(ns))
+                default = state.findtext("{}defaultValue".format(ns))
+                value_list_elt = state.find("{}allowedValueList".format(ns)) or ()
                 value_list = [item.text for item in value_list_elt] or None
-                value_range_elt = state.find('{}allowedValueRange'.format(ns))\
-                    or ()
+                value_range_elt = state.find("{}allowedValueRange".format(ns)) or ()
                 value_range = [item.text for item in value_range_elt] or None
-                vartypes[name] = Vartype(datatype, default, value_list,
-                                         value_range)
+                vartypes[name] = Vartype(datatype, default, value_list, value_range)
         # find all the actions
-        actionLists = tree.findall('{}actionList'.format(ns))
+        actionLists = tree.findall("{}actionList".format(ns))
         for actionList in actionLists:
-            actions = actionList.findall('{}action'.format(ns))
+            actions = actionList.findall("{}action".format(ns))
             for i in actions:
-                action_name = i.findtext('{}name'.format(ns))
-                argLists = i.findall('{}argumentList'.format(ns))
+                action_name = i.findtext("{}name".format(ns))
+                argLists = i.findall("{}argumentList".format(ns))
                 for argList in argLists:
-                    args_iter = argList.findall('{}argument'.format(ns))
+                    args_iter = argList.findall("{}argument".format(ns))
                     in_args = []
                     out_args = []
                     for arg in args_iter:
-                        arg_name = arg.findtext('{}name'.format(ns))
-                        direction = arg.findtext('{}direction'.format(ns))
+                        arg_name = arg.findtext("{}name".format(ns))
+                        direction = arg.findtext("{}direction".format(ns))
                         related_variable = arg.findtext(
-                            '{}relatedStateVariable'.format(ns))
+                            "{}relatedStateVariable".format(ns)
+                        )
                         vartype = vartypes[related_variable]
                         if direction == "in":
                             in_args.append(Argument(arg_name, vartype))
@@ -740,17 +743,17 @@ class Service(object):
         """
 
         # pylint: disable=invalid-name
-        ns = '{urn:schemas-upnp-org:service-1-0}'
+        ns = "{urn:schemas-upnp-org:service-1-0}"
         scpd_body = requests.get(self.base_url + self.scpd_url).text
-        tree = XML.fromstring(scpd_body.encode('utf-8'))
+        tree = XML.fromstring(scpd_body.encode("utf-8"))
         # parse the state variables to get the relevant variable types
-        statevars = tree.findall('{}stateVariable'.format(ns))
+        statevars = tree.findall("{}stateVariable".format(ns))
         for state in statevars:
             # We are only interested if 'sendEvents' is 'yes', i.e this
             # is an eventable variable
-            if state.attrib['sendEvents'] == "yes":
-                name = state.findtext('{}name'.format(ns))
-                vartype = state.findtext('{}dataType'.format(ns))
+            if state.attrib["sendEvents"] == "yes":
+                name = state.findtext("{}name".format(ns))
+                vartype = state.findtext("{}dataType".format(ns))
                 yield (name, vartype)
 
 
@@ -761,9 +764,8 @@ class AlarmClock(Service):
     def __init__(self, soco):
         super(AlarmClock, self).__init__(soco)
         self.UPNP_ERRORS.update(
-            {
-                801: 'Already an alarm for this time',
-            })
+            {801: "Already an alarm for this time",}
+        )
 
 
 class MusicServices(Service):
@@ -792,8 +794,8 @@ class ZoneGroupTopology(Service):
     def GetZoneGroupState(self, *args, **kwargs):
         """Overrides default handling to use the global shared zone group state
         cache, unless another cache is specified."""
-        kwargs['cache'] = kwargs.get('cache', zone_group_state_shared_cache)
-        return self.send_command('GetZoneGroupState', *args, **kwargs)
+        kwargs["cache"] = kwargs.get("cache", zone_group_state_shared_cache)
+        return self.send_command("GetZoneGroupState", *args, **kwargs)
 
 
 class GroupManagement(Service):
@@ -817,27 +819,29 @@ class ContentDirectory(Service):
         self.event_subscription_url = "/MediaServer/ContentDirectory/Event"
         # For error codes, see table 2.7.16 in
         # http://upnp.org/specs/av/UPnP-av-ContentDirectory-v1-Service.pdf
-        self.UPNP_ERRORS.update({
-            701: 'No such object',
-            702: 'Invalid CurrentTagValue',
-            703: 'Invalid NewTagValue',
-            704: 'Required tag',
-            705: 'Read only tag',
-            706: 'Parameter Mismatch',
-            708: 'Unsupported or invalid search criteria',
-            709: 'Unsupported or invalid sort criteria',
-            710: 'No such container',
-            711: 'Restricted object',
-            712: 'Bad metadata',
-            713: 'Restricted parent object',
-            714: 'No such source resource',
-            715: 'Resource access denied',
-            716: 'Transfer busy',
-            717: 'No such file transfer',
-            718: 'No such destination resource',
-            719: 'Destination resource access denied',
-            720: 'Cannot process the request',
-        })
+        self.UPNP_ERRORS.update(
+            {
+                701: "No such object",
+                702: "Invalid CurrentTagValue",
+                703: "Invalid NewTagValue",
+                704: "Required tag",
+                705: "Read only tag",
+                706: "Parameter Mismatch",
+                708: "Unsupported or invalid search criteria",
+                709: "Unsupported or invalid sort criteria",
+                710: "No such container",
+                711: "Restricted object",
+                712: "Bad metadata",
+                713: "Restricted parent object",
+                714: "No such source resource",
+                715: "Resource access denied",
+                716: "Transfer busy",
+                717: "No such file transfer",
+                718: "No such destination resource",
+                719: "Destination resource access denied",
+                720: "Cannot process the request",
+            }
+        )
 
 
 class MS_ConnectionManager(Service):  # pylint: disable=invalid-name
@@ -860,7 +864,7 @@ class RenderingControl(Service):
         super(RenderingControl, self).__init__(soco)
         self.control_url = "/MediaRenderer/RenderingControl/Control"
         self.event_subscription_url = "/MediaRenderer/RenderingControl/Event"
-        self.DEFAULT_ARGS.update({'InstanceID': 0})
+        self.DEFAULT_ARGS.update({"InstanceID": 0})
 
 
 class MR_ConnectionManager(Service):  # pylint: disable=invalid-name
@@ -885,30 +889,32 @@ class AVTransport(Service):
         self.event_subscription_url = "/MediaRenderer/AVTransport/Event"
         # For error codes, see
         # http://upnp.org/specs/av/UPnP-av-AVTransport-v1-Service.pdf
-        self.UPNP_ERRORS.update({
-            701: 'Transition not available',
-            702: 'No contents',
-            703: 'Read error',
-            704: 'Format not supported for playback',
-            705: 'Transport is locked',
-            706: 'Write error',
-            707: 'Media is protected or not writeable',
-            708: 'Format not supported for recording',
-            709: 'Media is full',
-            710: 'Seek mode not supported',
-            711: 'Illegal seek target',
-            712: 'Play mode not supported',
-            713: 'Record quality not supported',
-            714: 'Illegal MIME-Type',
-            715: 'Content "BUSY"',
-            716: 'Resource Not found',
-            717: 'Play speed not supported',
-            718: 'Invalid InstanceID',
-            737: 'No DNS Server',
-            738: 'Bad Domain Name',
-            739: 'Server Error',
-        })
-        self.DEFAULT_ARGS.update({'InstanceID': 0})
+        self.UPNP_ERRORS.update(
+            {
+                701: "Transition not available",
+                702: "No contents",
+                703: "Read error",
+                704: "Format not supported for playback",
+                705: "Transport is locked",
+                706: "Write error",
+                707: "Media is protected or not writeable",
+                708: "Format not supported for recording",
+                709: "Media is full",
+                710: "Seek mode not supported",
+                711: "Illegal seek target",
+                712: "Play mode not supported",
+                713: "Record quality not supported",
+                714: "Illegal MIME-Type",
+                715: 'Content "BUSY"',
+                716: "Resource Not found",
+                717: "Play speed not supported",
+                718: "Invalid InstanceID",
+                737: "No DNS Server",
+                738: "Bad Domain Name",
+                739: "Server Error",
+            }
+        )
+        self.DEFAULT_ARGS.update({"InstanceID": 0})
 
 
 class Queue(Service):
@@ -930,6 +936,5 @@ class GroupRenderingControl(Service):
     def __init__(self, soco):
         super(GroupRenderingControl, self).__init__(soco)
         self.control_url = "/MediaRenderer/GroupRenderingControl/Control"
-        self.event_subscription_url = \
-            "/MediaRenderer/GroupRenderingControl/Event"
-        self.DEFAULT_ARGS.update({'InstanceID': 0})
+        self.event_subscription_url = "/MediaRenderer/GroupRenderingControl/Event"
+        self.DEFAULT_ARGS.update({"InstanceID": 0})

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -96,8 +96,8 @@ class Snapshot(object):
         self.is_coordinator = self.device.is_coordinator
 
         # Get information about the currently playing media
-        media_info = self.device.avTransport.GetMediaInfo([('InstanceID', 0)])
-        self.media_uri = media_info['CurrentURI']
+        media_info = self.device.avTransport.GetMediaInfo([("InstanceID", 0)])
+        self.media_uri = media_info["CurrentURI"]
         # Extract source from media uri - below some media URI value examples:
         #  'x-rincon-queue:RINCON_000E5859E49601400#0'
         #       - playing a local queue always #0 for local queue)
@@ -108,11 +108,11 @@ class Snapshot(object):
         #  -'x-rincon:RINCON_000E5859E49601400'
         #       - a slave player pointing to coordinator player
 
-        if self.media_uri.split(':')[0] == 'x-rincon-queue':
+        if self.media_uri.split(":")[0] == "x-rincon-queue":
             # The pylint error below is a false positive, see about removing it
             # in the future
             # pylint: disable=simplifiable-if-statement
-            if self.media_uri.split('#')[1] == '0':
+            if self.media_uri.split("#")[1] == "0":
                 # playing local queue
                 self.is_playing_queue = True
             else:
@@ -135,21 +135,20 @@ class Snapshot(object):
             # Get information about the currently playing track
             track_info = self.device.get_current_track_info()
             if track_info is not None:
-                position = track_info['playlist_position']
+                position = track_info["playlist_position"]
                 if position != "":
                     # save as integer
                     self.playlist_position = int(position)
-                self.track_position = track_info['position']
+                self.track_position = track_info["position"]
         else:
             # playing from a stream - save media metadata
-            self.media_metadata = media_info['CurrentURIMetaData']
+            self.media_metadata = media_info["CurrentURIMetaData"]
 
         # Work out what the playing state is - if a coordinator
         if self.is_coordinator:
             transport_info = self.device.get_current_transport_info()
             if transport_info is not None:
-                self.transport_state = transport_info[
-                    'current_transport_state']
+                self.transport_state = transport_info["current_transport_state"]
 
         # Save of the current queue if we need to
         self._save_queue()
@@ -175,7 +174,7 @@ class Snapshot(object):
             # include things like audio
             transport_info = self.device.get_current_transport_info()
             if transport_info is not None:
-                if transport_info['current_transport_state'] == 'PLAYING':
+                if transport_info["current_transport_state"] == "PLAYING":
                     self.device.pause()
 
             # Check if the queue should be restored
@@ -213,7 +212,8 @@ class Snapshot(object):
                 # reinstate uri and meta data
                 if self.media_uri != "":
                     self.device.play_uri(
-                        self.media_uri, self.media_metadata, start=False)
+                        self.media_uri, self.media_metadata, start=False
+                    )
 
         # For all devices:
         # Reinstate all the properties that are pretty easy to do
@@ -229,7 +229,8 @@ class Snapshot(object):
         # So only checked fixed volume if volume is 100.
         if self.volume == 100:
             fixed_vol = self.device.renderingControl.GetOutputFixed(
-                [('InstanceID', 0)])['CurrentFixed']
+                [("InstanceID", 0)]
+            )["CurrentFixed"]
         else:
             fixed_vol = False
 
@@ -247,9 +248,9 @@ class Snapshot(object):
         # Now everything is set, see if we need to be playing, stopped
         # or paused ( only for coordinators)
         if self.is_coordinator:
-            if self.transport_state == 'PLAYING':
+            if self.transport_state == "PLAYING":
                 self.device.play()
-            elif self.transport_state == 'STOPPED':
+            elif self.transport_state == "STOPPED":
                 self.device.stop()
 
     def _save_queue(self):

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -5,17 +5,13 @@
 
 """This class contains utility functions used internally by SoCo."""
 
-from __future__ import (
-    absolute_import, print_function, unicode_literals
-)
+from __future__ import absolute_import, print_function, unicode_literals
 
 import functools
 import re
 import warnings
 
-from .compat import (
-    StringType, UnicodeType, quote_url
-)
+from .compat import StringType, UnicodeType, quote_url
 from .xml import XML
 
 
@@ -35,7 +31,7 @@ def really_unicode(in_string):
         ValueError
         """
     if isinstance(in_string, StringType):
-        for args in (('utf-8',), ('latin-1',), ('ascii', 'replace')):
+        for args in (("utf-8",), ("latin-1",), ("ascii", "replace")):
             try:
                 # pylint: disable=star-args
                 in_string = in_string.decode(*args)
@@ -43,7 +39,7 @@ def really_unicode(in_string):
             except UnicodeDecodeError:
                 continue
     if not isinstance(in_string, UnicodeType):
-        raise ValueError('%s is not a string at all.' % in_string)
+        raise ValueError("%s is not a string at all." % in_string)
     return in_string
 
 
@@ -63,11 +59,11 @@ def really_utf8(in_string):
     Returns:
         str: utf-encoded data.
     """
-    return really_unicode(in_string).encode('utf-8')
+    return really_unicode(in_string).encode("utf-8")
 
 
-FIRST_CAP_RE = re.compile('(.)([A-Z][a-z]+)')
-ALL_CAP_RE = re.compile('([a-z0-9])([A-Z])')
+FIRST_CAP_RE = re.compile("(.)([A-Z][a-z]+)")
+ALL_CAP_RE = re.compile("([a-z0-9])([A-Z])")
 
 
 def camel_to_underscore(string):
@@ -81,8 +77,8 @@ def camel_to_underscore(string):
     Returns:
         str: The converted string.
     """
-    string = FIRST_CAP_RE.sub(r'\1_\2', string)
-    return ALL_CAP_RE.sub(r'\1_\2', string).lower()
+    string = FIRST_CAP_RE.sub(r"\1_\2", string)
+    return ALL_CAP_RE.sub(r"\1_\2", string).lower()
 
 
 def prettify(unicode_text):
@@ -99,7 +95,8 @@ def prettify(unicode_text):
 
     """
     import xml.dom.minidom
-    reparsed = xml.dom.minidom.parseString(unicode_text.encode('utf-8'))
+
+    reparsed = xml.dom.minidom.parseString(unicode_text.encode("utf-8"))
     return reparsed.toprettyxml(indent="  ", newl="\n")
 
 
@@ -138,6 +135,7 @@ class deprecated(object):
             def old_function(args):
                 pass
     """
+
     # pylint really doesn't like decorators!
     # pylint: disable=invalid-name, too-few-public-methods
     # pylint: disable=missing-docstring
@@ -148,15 +146,14 @@ class deprecated(object):
         self.will_be_removed_in = will_be_removed_in
 
     def __call__(self, deprecated_fn):
-
         @functools.wraps(deprecated_fn)
         def decorated(*args, **kwargs):
 
-            message = "Call to deprecated function {}.".format(
-                deprecated_fn.__name__)
+            message = "Call to deprecated function {}.".format(deprecated_fn.__name__)
             if self.will_be_removed_in is not None:
                 message += " Will be removed in version {}.".format(
-                    self.will_be_removed_in)
+                    self.will_be_removed_in
+                )
             if self.alternative is not None:
                 message += " Use {} instead.".format(self.alternative)
             warnings.warn(message, stacklevel=2)
@@ -166,11 +163,12 @@ class deprecated(object):
         docs = "\n\n  .. deprecated:: {}\n".format(self.since_version)
         if self.will_be_removed_in is not None:
             docs += "\n     Will be removed in version {}.".format(
-                self.will_be_removed_in)
+                self.will_be_removed_in
+            )
         if self.alternative is not None:
             docs += "\n     Use `{}` instead.".format(self.alternative)
         if decorated.__doc__ is None:
-            decorated.__doc__ = ''
+            decorated.__doc__ = ""
         decorated.__doc__ += docs
         return decorated
 
@@ -188,4 +186,4 @@ def url_escape_path(path):
     u'Foo%2C%20bar%20%26%20baz%20%2F%20the%20hackers'
     """
     # Using 'safe' arg does not seem to work for python 2.6
-    return quote_url(path.encode('utf-8')).replace('/', '%2F')
+    return quote_url(path.encode("utf-8")).replace("/", "%2F")

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -3,9 +3,7 @@
 
 """This class contains XML related utility functions."""
 
-from __future__ import (
-    absolute_import, unicode_literals
-)
+from __future__ import absolute_import, unicode_literals
 
 import sys
 import re
@@ -20,31 +18,48 @@ if sys.version_info[0] >= 3:
     unichr = chr
 
 illegal_unichrs = [
-    (0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F), (0x7F, 0x84),
-    (0x86, 0x9F), (0xD800, 0xDFFF), (0xFDD0, 0xFDDF),
+    (0x00, 0x08),
+    (0x0B, 0x0C),
+    (0x0E, 0x1F),
+    (0x7F, 0x84),
+    (0x86, 0x9F),
+    (0xD800, 0xDFFF),
+    (0xFDD0, 0xFDDF),
     (0xFFFE, 0xFFFF),
-    (0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF), (0x3FFFE, 0x3FFFF),
-    (0x4FFFE, 0x4FFFF), (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
-    (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF), (0x9FFFE, 0x9FFFF),
-    (0xAFFFE, 0xAFFFF), (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
-    (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF), (0xFFFFE, 0xFFFFF),
-    (0x10FFFE, 0x10FFFF)
+    (0x1FFFE, 0x1FFFF),
+    (0x2FFFE, 0x2FFFF),
+    (0x3FFFE, 0x3FFFF),
+    (0x4FFFE, 0x4FFFF),
+    (0x5FFFE, 0x5FFFF),
+    (0x6FFFE, 0x6FFFF),
+    (0x7FFFE, 0x7FFFF),
+    (0x8FFFE, 0x8FFFF),
+    (0x9FFFE, 0x9FFFF),
+    (0xAFFFE, 0xAFFFF),
+    (0xBFFFE, 0xBFFFF),
+    (0xCFFFE, 0xCFFFF),
+    (0xDFFFE, 0xDFFFF),
+    (0xEFFFE, 0xEFFFF),
+    (0xFFFFE, 0xFFFFF),
+    (0x10FFFE, 0x10FFFF),
 ]
 
-illegal_ranges = ["%s-%s" % (unichr(low), unichr(high))
-                  for (low, high) in illegal_unichrs
-                  if low < sys.maxunicode]
+illegal_ranges = [
+    "%s-%s" % (unichr(low), unichr(high))
+    for (low, high) in illegal_unichrs
+    if low < sys.maxunicode
+]
 
-illegal_xml_re = re.compile(u'[%s]' % u''.join(illegal_ranges))
+illegal_xml_re = re.compile("[%s]" % "".join(illegal_ranges))
 
 
 #: Commonly used namespaces, and abbreviations, used by `ns_tag`.
 NAMESPACES = {
-    'dc': 'http://purl.org/dc/elements/1.1/',
-    'upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/',
-    '': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
-    'ms': 'http://www.sonos.com/Services/1.1',
-    'r': 'urn:schemas-rinconnetworks-com:metadata-1-0/'
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "upnp": "urn:schemas-upnp-org:metadata-1-0/upnp/",
+    "": "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
+    "ms": "http://www.sonos.com/Services/1.1",
+    "r": "urn:schemas-rinconnetworks-com:metadata-1-0/",
 }
 
 # Register common namespaces to assist in serialisation (avoids the ns:0
@@ -69,4 +84,4 @@ def ns_tag(ns_id, tag):
         >>> xml.ns_tag('dc','author')
         '{http://purl.org/dc/elements/1.1/}author'
     """
-    return '{{{}}}{}'.format(NAMESPACES[ns_id], tag)
+    return "{{{}}}{}".format(NAMESPACES[ns_id], tag)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,12 @@ import pytest
 def pytest_addoption(parser):
     """ Add the --ip commandline option """
     parser.addoption(
-        '--ip',
+        "--ip",
         type=str,
         default=None,
-        action='store',
-        dest='IP',
-        help='the IP address for the zone to be used for the integration tests'
+        action="store",
+        dest="IP",
+        help="the IP address for the zone to be used for the integration tests",
     )
 
 

--- a/tests/soco_unittest.py
+++ b/tests/soco_unittest.py
@@ -38,23 +38,28 @@ def init(**kwargs):
     """Initialize variables for the unittests that are only known at run
     time."""
     global SOCO  # pylint: disable-msg=W0603
-    SOCO = soco.SoCo(kwargs['ip'])
+    SOCO = soco.SoCo(kwargs["ip"])
 
     if len(SOCO.get_queue()) == 0:
-        raise SoCoUnitTestInitError('Unit tests on the SoCo class must be run '
-                                    'with at least 1 item in the playlist')
+        raise SoCoUnitTestInitError(
+            "Unit tests on the SoCo class must be run "
+            "with at least 1 item in the playlist"
+        )
 
     transport_info = SOCO.get_current_transport_info()
-    if transport_info['current_transport_state'] != 'PLAYING':
-        raise SoCoUnitTestInitError('Unit tests on the SoCo class must be run '
-                                    'with the sonos unit playing')
+    if transport_info["current_transport_state"] != "PLAYING":
+        raise SoCoUnitTestInitError(
+            "Unit tests on the SoCo class must be run " "with the sonos unit playing"
+        )
 
 
 def get_state():
     """Utility function to get the entire playing state before the unit tests
     starts to change it."""
-    state = {'queue': SOCO.get_queue(0, 1000),
-             'current_track_info': SOCO.get_current_track_info()}
+    state = {
+        "queue": SOCO.get_queue(0, 1000),
+        "current_track_info": SOCO.get_current_track_info(),
+    }
     return state
 
 
@@ -65,11 +70,10 @@ def set_state(state):
     """
     SOCO.stop()
     SOCO.clear_queue()
-    for track in state['queue']:
-        SOCO.add_to_queue(track['uri'])
-    SOCO.play_from_queue(
-        int(state['current_track_info']['playlist_position']) - 1)
-    SOCO.seek(state['current_track_info']['position'])
+    for track in state["queue"]:
+        SOCO.add_to_queue(track["uri"])
+    SOCO.play_from_queue(int(state["current_track_info"]["playlist_position"]) - 1)
+    SOCO.seek(state["current_track_info"]["position"])
     SOCO.play()
 
 
@@ -79,10 +83,10 @@ def wait(interval=0.1):
 
 
 # Test return strings that are used a lot
-NOT_TRUE = 'The method did not return True'
-NOT_EXP = 'The method did not return the expected value'
-NOT_TYPE = 'The return value of the method did not have the expected type: {}'
-NOT_IN_RANGE = 'The returned value is not in the expected range'
+NOT_TRUE = "The method did not return True"
+NOT_EXP = "The method did not return the expected value"
+NOT_TYPE = "The return value of the method did not have the expected type: {}"
+NOT_IN_RANGE = "The returned value is not in the expected range"
 
 
 # functions for running via pytest
@@ -220,9 +224,18 @@ class GetCurrentTrackInfo(unittest.TestCase):
     def setUp(self):  # pylint: disable-msg=C0103
         # The value in this list must be kept up to date with the values in
         # the test_get doc string
-        self.info_keys = sorted(['album', 'artist', 'title', 'uri',
-                                 'playlist_position', 'duration', 'album_art',
-                                 'position'])
+        self.info_keys = sorted(
+            [
+                "album",
+                "artist",
+                "title",
+                "uri",
+                "playlist_position",
+                "duration",
+                "album_art",
+                "position",
+            ]
+        )
 
     def test_get(self):
         """ Test is the return value is a dictinary and contains the following
@@ -230,9 +243,10 @@ class GetCurrentTrackInfo(unittest.TestCase):
         album_art and position
         """
         info = SOCO.get_current_track_info()
-        self.assertIsInstance(info, dict, 'Returned info is not a dict')
-        self.assertEqual(sorted(info.keys()), self.info_keys,
-                         'Info does not contain the proper keys')
+        self.assertIsInstance(info, dict, "Returned info is not a dict")
+        self.assertEqual(
+            sorted(info.keys()), self.info_keys, "Info does not contain the proper keys"
+        )
 
 
 class AddToQueue(unittest.TestCase):
@@ -246,8 +260,9 @@ class AddToQueue(unittest.TestCase):
         SOCO.pause()
         old_queue = SOCO.get_queue(0, 1000)
         # Add new element and check
-        self.assertEqual(SOCO.add_to_queue(old_queue[-1]['uri']),
-                         len(old_queue) + 1, '')
+        self.assertEqual(
+            SOCO.add_to_queue(old_queue[-1]["uri"]), len(old_queue) + 1, ""
+        )
         wait()
         new_queue = SOCO.get_queue()
         self.assertEqual(len(new_queue) - 1, len(old_queue))
@@ -263,8 +278,9 @@ class GetQueue(unittest.TestCase):
     def setUp(self):  # pylint: disable-msg=C0103
         # The values in this list must be kept up to date with the values in
         # the test_get doc string
-        self.qeueu_element_keys = sorted(['album', 'artist', 'uri',
-                                          'album_art', 'title'])
+        self.qeueu_element_keys = sorted(
+            ["album", "artist", "uri", "album_art", "title"]
+        )
 
     def test_get(self):
         """ Tests is return value is a list of dictionaries and if each of
@@ -272,14 +288,15 @@ class GetQueue(unittest.TestCase):
         title
         """
         queue = SOCO.get_queue()
-        self.assertIsInstance(queue, list, NOT_TYPE.format('list'))
+        self.assertIsInstance(queue, list, NOT_TYPE.format("list"))
         for item in queue:
-            self.assertIsInstance(item, dict,
-                                  'Item in queue is not a dictionary')
-            self.assertEqual(sorted(item.keys()), self.qeueu_element_keys,
-                             'The keys in the queue element dict are not the '
-                             'expected ones: {}'.
-                             format(self.qeueu_element_keys))
+            self.assertIsInstance(item, dict, "Item in queue is not a dictionary")
+            self.assertEqual(
+                sorted(item.keys()),
+                self.qeueu_element_keys,
+                "The keys in the queue element dict are not the "
+                "expected ones: {}".format(self.qeueu_element_keys),
+            )
 
 
 class GetCurrentTransportInfo(unittest.TestCase):
@@ -288,9 +305,13 @@ class GetCurrentTransportInfo(unittest.TestCase):
     def setUp(self):  # pylint: disable-msg=C0103
         # The values in this list must be kept up to date with the values in
         # the test doc string
-        self.transport_info_keys = sorted(['current_transport_status',
-                                           'current_transport_state',
-                                           'current_transport_speed'])
+        self.transport_info_keys = sorted(
+            [
+                "current_transport_status",
+                "current_transport_state",
+                "current_transport_speed",
+            ]
+        )
 
     def test(self):
         """ Tests if the return value is a dictionary that contains the keys:
@@ -299,15 +320,20 @@ class GetCurrentTransportInfo(unittest.TestCase):
         and that values have been found for all keys, i.e. they are not None
         """
         transport_info = SOCO.get_current_transport_info()
-        self.assertIsInstance(transport_info, dict, NOT_TYPE.format('dict'))
-        self.assertEqual(self.transport_info_keys,
-                         sorted(transport_info.keys()),
-                         'The keys in the speaker info dict are not the '
-                         'expected ones: {}'.format(self.transport_info_keys))
+        self.assertIsInstance(transport_info, dict, NOT_TYPE.format("dict"))
+        self.assertEqual(
+            self.transport_info_keys,
+            sorted(transport_info.keys()),
+            "The keys in the speaker info dict are not the "
+            "expected ones: {}".format(self.transport_info_keys),
+        )
         for key, value in transport_info.items():
-            self.assertIsNotNone(value, 'The value for the key "{}" is None '
-                                 'which indicate that no value was found for '
-                                 'it'.format(key))
+            self.assertIsNotNone(
+                value,
+                'The value for the key "{}" is None '
+                "which indicate that no value was found for "
+                "it".format(key),
+            )
 
 
 class GetSpeakerInfo(unittest.TestCase):
@@ -316,11 +342,20 @@ class GetSpeakerInfo(unittest.TestCase):
     def setUp(self):  # pylint: disable-msg=C0103
         # The values in this list must be kept up to date with the values in
         # the test doc string
-        self.info_keys = sorted(['zone_name', 'player_icon', 'uid',
-                                 'serial_number', 'software_version',
-                                 'hardware_version', 'mac_address',
-                                 'model_name', 'model_number',
-                                 'display_version'])
+        self.info_keys = sorted(
+            [
+                "zone_name",
+                "player_icon",
+                "uid",
+                "serial_number",
+                "software_version",
+                "hardware_version",
+                "mac_address",
+                "model_name",
+                "model_number",
+                "display_version",
+            ]
+        )
 
     def test(self):
         """ Tests if the return value is a dictionary that contains the keys:
@@ -329,23 +364,30 @@ class GetSpeakerInfo(unittest.TestCase):
         and that values have been found for all keys, i.e. they are not None
         """
         speaker_info = SOCO.get_speaker_info()
-        self.assertIsInstance(speaker_info, dict, NOT_TYPE.format('dict'))
-        self.assertEqual(self.info_keys, sorted(speaker_info.keys()), 'The '
-                         'keys in speaker info are not the expected ones: {}'
-                         ''.format(self.info_keys))
+        self.assertIsInstance(speaker_info, dict, NOT_TYPE.format("dict"))
+        self.assertEqual(
+            self.info_keys,
+            sorted(speaker_info.keys()),
+            "The "
+            "keys in speaker info are not the expected ones: {}"
+            "".format(self.info_keys),
+        )
         for key, value in speaker_info.items():
-            self.assertIsNotNone(value, 'The value for the key "{}" is None '
-                                 'which indicate that no value was found for '
-                                 'it'.format(key))
+            self.assertIsNotNone(
+                value,
+                'The value for the key "{}" is None '
+                "which indicate that no value was found for "
+                "it".format(key),
+            )
 
 
 # class GetSpeakersIp(unittest.TestCase):
-    #""" Unit tests for the get_speakers_ip method """
+# """ Unit tests for the get_speakers_ip method """
 
-    # TODO: Awaits https://github.com/rahims/SoCo/issues/26
+# TODO: Awaits https://github.com/rahims/SoCo/issues/26
 
-    # def test(self):
-        # print SOCO.get_speakers_ip()
+# def test(self):
+# print SOCO.get_speakers_ip()
 
 
 class Pause(unittest.TestCase):
@@ -355,9 +397,10 @@ class Pause(unittest.TestCase):
         """Tests if the pause method works."""
         SOCO.pause()
         wait(1)
-        new = SOCO.get_current_transport_info()['current_transport_state']
-        self.assertEqual(new, 'PAUSED_PLAYBACK', 'State after pause is not '
-                         '"PAUSED_PLAYBACK"')
+        new = SOCO.get_current_transport_info()["current_transport_state"]
+        self.assertEqual(
+            new, "PAUSED_PLAYBACK", "State after pause is not " '"PAUSED_PLAYBACK"'
+        )
         SOCO.play()
         wait(1)
 
@@ -370,8 +413,8 @@ class Stop(unittest.TestCase):
         state = get_state()
         SOCO.stop()
         wait(1)
-        new = SOCO.get_current_transport_info()['current_transport_state']
-        self.assertEqual(new, 'STOPPED', 'State after stop is not "STOPPED"')
+        new = SOCO.get_current_transport_info()["current_transport_state"]
+        self.assertEqual(new, "STOPPED", 'State after stop is not "STOPPED"')
         set_state(state)  # Reset unit the way it was before the test
         wait(1)
 
@@ -383,14 +426,16 @@ class Play(unittest.TestCase):
         """Tests if the play method works."""
         SOCO.pause()
         wait(1)
-        on_pause = SOCO.get_current_transport_info()['current_transport_state']
-        self.assertEqual(on_pause, 'PAUSED_PLAYBACK', 'State after pause is '
-                         'not "PAUSED_PLAYBACK"')
+        on_pause = SOCO.get_current_transport_info()["current_transport_state"]
+        self.assertEqual(
+            on_pause, "PAUSED_PLAYBACK", "State after pause is " 'not "PAUSED_PLAYBACK"'
+        )
         SOCO.play()
         wait(1)
-        on_play = SOCO.get_current_transport_info()['current_transport_state']
-        self.assertEqual(on_play, 'PLAYING', 'State after play is not '
-                         '"PAUSED_PLAYBACK"')
+        on_play = SOCO.get_current_transport_info()["current_transport_state"]
+        self.assertEqual(
+            on_play, "PLAYING", "State after play is not " '"PAUSED_PLAYBACK"'
+        )
 
 
 class Mute(unittest.TestCase):
@@ -399,12 +444,13 @@ class Mute(unittest.TestCase):
     def test(self):
         """Tests of the mute method works."""
         old = SOCO.mute
-        self.assertEqual(old, 0, 'The unit should not be muted when running '
-                         'the unit tests')
+        self.assertEqual(
+            old, 0, "The unit should not be muted when running " "the unit tests"
+        )
         SOCO.mute = True
         wait()
         new = SOCO.mute
-        self.assertEqual(new, 1, 'The unit did not successfully mute')
+        self.assertEqual(new, 1, "The unit did not successfully mute")
         SOCO.mute = False
         wait()
 
@@ -419,15 +465,20 @@ class RemoveFromQueue(unittest.TestCase):
         SOCO.remove_from_queue(len(old_queue))
         wait()
         new_queue = SOCO.get_queue()
-        self.assertNotEqual(old_queue, new_queue, 'No difference between '
-                            'queues before and after removing the last item')
-        self.assertEqual(len(new_queue), len(old_queue) - 1, 'The length of '
-                         'queue after removing a track is not length before - '
-                         '1')
+        self.assertNotEqual(
+            old_queue,
+            new_queue,
+            "No difference between " "queues before and after removing the last item",
+        )
+        self.assertEqual(
+            len(new_queue),
+            len(old_queue) - 1,
+            "The length of " "queue after removing a track is not length before - " "1",
+        )
         # Clean up
-        SOCO.add_to_queue(track_to_remove['uri'])
+        SOCO.add_to_queue(track_to_remove["uri"])
         wait()
-        self.assertEqual(old_queue, SOCO.get_queue(), 'Clean up unsuccessful')
+        self.assertEqual(old_queue, SOCO.get_queue(), "Clean up unsuccessful")
 
 
 class Seek(unittest.TestCase):
@@ -435,24 +486,24 @@ class Seek(unittest.TestCase):
 
     def test_valid(self):
         """Tests if the seek method works with valid input."""
-        original_position = SOCO.get_current_track_info()['position']
+        original_position = SOCO.get_current_track_info()["position"]
         # Format 1
-        SOCO.seek('0:00:00')
+        SOCO.seek("0:00:00")
         wait()
-        position = SOCO.get_current_track_info()['position']
-        self.assertIn(position, ['0:00:00', '0:00:01'])
+        position = SOCO.get_current_track_info()["position"]
+        self.assertIn(position, ["0:00:00", "0:00:01"])
         # Reset and format 2
         SOCO.seek(original_position)
-        SOCO.seek('00:00:00')
+        SOCO.seek("00:00:00")
         wait()
-        position = SOCO.get_current_track_info()['position']
-        self.assertIn(position, ['0:00:00', '0:00:01'])
+        position = SOCO.get_current_track_info()["position"]
+        self.assertIn(position, ["0:00:00", "0:00:01"])
         # Clean up
         SOCO.seek(original_position)
         wait()
 
     def test_invald(self):
         """Tests if the seek method properly fails with invalid input."""
-        for string in ['invalid_time_string', '5:12', '6', 'aa:aa:aa']:
+        for string in ["invalid_time_string", "5:12", "6", "aa:aa:aa"]:
             with self.assertRaises(ValueError):
                 SOCO.seek(string)

--- a/tests/test_alarms.py
+++ b/tests/test_alarms.py
@@ -7,12 +7,12 @@ from soco.alarms import is_valid_recurrence
 
 
 def test_recurrence():
-    for recur in ('DAILY', 'WEEKDAYS', 'WEEKENDS', 'ONCE'):
+    for recur in ("DAILY", "WEEKDAYS", "WEEKENDS", "ONCE"):
         assert is_valid_recurrence(recur)
 
-    assert is_valid_recurrence('ON_1')
-    assert is_valid_recurrence('ON_123412')
-    assert not is_valid_recurrence('on_1')
-    assert not is_valid_recurrence('ON_123456789')
-    assert not is_valid_recurrence('ON_')
-    assert not is_valid_recurrence(' ON_1')
+    assert is_valid_recurrence("ON_1")
+    assert is_valid_recurrence("ON_123412")
+    assert not is_valid_recurrence("on_1")
+    assert not is_valid_recurrence("ON_123456789")
+    assert not is_valid_recurrence("ON_")
+    assert not is_valid_recurrence(" ON_1")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,14 +3,13 @@
 
 from __future__ import unicode_literals
 
-from soco.cache import (
-    Cache, NullCache, TimedCache
-)
+from soco.cache import Cache, NullCache, TimedCache
 
 
 def test_instance_creation():
     assert isinstance(Cache(), TimedCache)
     from soco import config
+
     config.CACHE_ENABLED = False
     assert isinstance(Cache(), NullCache)
     config.CACHE_ENABLED = True
@@ -19,19 +18,19 @@ def test_instance_creation():
 def test_cache_put_get():
     """Test putting items into, and getting them from, the cache."""
     from time import sleep
-    cache = Cache()
-    cache.put("item", 'some', kw='args', timeout=3)
-    assert not cache.get('some', 'otherargs') == "item"
-    assert cache.get('some', kw='args') == "item"
-    sleep(2)
-    assert cache.get('some', kw='args') == "item"
-    sleep(2)
-    assert not cache.get('some', kw='args') == "item"
 
-    cache.put("item", 'some', 'args', and_a='keyword', timeout=3)
-    assert cache.get('some', 'args', and_a='keyword') == "item"
-    assert not cache.get(
-        'some', 'otherargs', and_a='keyword') == "item"
+    cache = Cache()
+    cache.put("item", "some", kw="args", timeout=3)
+    assert not cache.get("some", "otherargs") == "item"
+    assert cache.get("some", kw="args") == "item"
+    sleep(2)
+    assert cache.get("some", kw="args") == "item"
+    sleep(2)
+    assert not cache.get("some", kw="args") == "item"
+
+    cache.put("item", "some", "args", and_a="keyword", timeout=3)
+    assert cache.get("some", "args", and_a="keyword") == "item"
+    assert not cache.get("some", "otherargs", and_a="keyword") == "item"
 
 
 def test_cache_clear_del():
@@ -39,37 +38,48 @@ def test_cache_clear_del():
     cache = Cache()
     cache.put("item", "some", kw="args", timeout=2)
     # Check it's there
-    assert cache.get('some', kw='args') == "item"
+    assert cache.get("some", kw="args") == "item"
     # delete it
-    cache.delete('some', kw='args')
-    assert not cache.get('some', kw='args') == "item"
+    cache.delete("some", kw="args")
+    assert not cache.get("some", kw="args") == "item"
     # put it back
     cache.put("item", "some", kw="args", timeout=3)
     cache.clear()
-    assert not cache.get('some', kw='args') == "item"
+    assert not cache.get("some", kw="args") == "item"
 
 
 def test_with_typical_args():
     cache = Cache()
-    cache.put("result", 'SetAVTransportURI', [
-        ('InstanceID', 1),
-        ('CurrentURI', 'URI2'),
-        ('CurrentURIMetaData', 'abcd'),
-        ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-    ], timeout=3)
-    assert cache.get('SetAVTransportURI', [
-        ('InstanceID', 1),
-        ('CurrentURI', 'URI2'),
-        ('CurrentURIMetaData', 'abcd'),
-        ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-    ]) == "result"
+    cache.put(
+        "result",
+        "SetAVTransportURI",
+        [
+            ("InstanceID", 1),
+            ("CurrentURI", "URI2"),
+            ("CurrentURIMetaData", "abcd"),
+            ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+        ],
+        timeout=3,
+    )
+    assert (
+        cache.get(
+            "SetAVTransportURI",
+            [
+                ("InstanceID", 1),
+                ("CurrentURI", "URI2"),
+                ("CurrentURIMetaData", "abcd"),
+                ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+            ],
+        )
+        == "result"
+    )
 
 
 def test_cache_disable():
     cache = Cache()
     assert cache.enabled is True
     cache.enabled = False
-    cache.put("item", 'args', timeout=3)
-    assert cache.get('args') == None
+    cache.put("item", "args", timeout=3)
+    assert cache.get("args") == None
     # Check it's there
-    assert cache.get('some', kw='args') is None
+    assert cache.get("some", kw="args") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -80,6 +80,6 @@ def test_cache_disable():
     assert cache.enabled is True
     cache.enabled = False
     cache.put("item", "args", timeout=3)
-    assert cache.get("args") == None
+    assert cache.get("args") is None
     # Check it's there
     assert cache.get("some", kw="args") is None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,7 +63,8 @@ def moco_only_on_master():
         patch.stop()
 
 
-ZGS = """<ZoneGroupState>
+ZGS = (
+    """<ZoneGroupState>
       <ZoneGroups>
         <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000E5876A0E801400:210">
           <ZoneGroupMember
@@ -119,7 +120,8 @@ ZGS = """<ZoneGroupState>
               IdleState="1"
               MoreInfo=""/>
         </ZoneGroup>
-        <ZoneGroup Coordinator="RINCON_000E58A53FAE01400" ID="RINCON_000E58A53FAE01400:107">
+        <ZoneGroup Coordinator="RINCON_000E58A53FAE01400" """
+    """ID="RINCON_000E58A53FAE01400:107">
           <ZoneGroupMember
               UUID="RINCON_000E58A53FAE01400"
               Location="http://192.168.1.173:1400/xml/device_description.xml"
@@ -147,7 +149,8 @@ ZGS = """<ZoneGroupState>
               IdleState="1"
               MoreInfo=""/>
         </ZoneGroup>
-        <ZoneGroup Coordinator="RINCON_000E5884455C01400" ID="RINCON_000E5884455C01400:114">
+        <ZoneGroup Coordinator="RINCON_000E5884455C01400" """
+    """ID="RINCON_000E5884455C01400:114">
           <ZoneGroupMember
               UUID="RINCON_000E5884455C01400"
               Location="http://192.168.1.197:1400/xml/device_description.xml"
@@ -178,6 +181,7 @@ ZGS = """<ZoneGroupState>
       </ZoneGroups>
       <VanishedDevices></VanishedDevices>
     </ZoneGroupState>"""
+)
 
 
 @pytest.yield_fixture
@@ -375,13 +379,16 @@ class TestSoco:
                 <SCPDURL>/xml/GroupRenderingControl1.xml</SCPDURL>
               </service>
                 </serviceList>
-                <X_Rhapsody-Extension xmlns="http://www.real.com/rhapsody/xmlns/upnp-1-0">
-                  <deviceID>urn:rhapsody-real-com:device-id-1-0:sonos_1:RINCON_000E5884455C01400</deviceID>
+                <X_Rhapsody-Extension """
+        """xmlns="http://www.real.com/rhapsody/xmlns/upnp-1-0">
+                  <deviceID>urn:rhapsody-real-com:device-id-1-0:"""
+        """sonos_1:RINCON_000E5884455C01400</deviceID>
                     <deviceCapabilities>
                       <interactionPattern type="real-rhapsody-upnp-1-0"/>
                     </deviceCapabilities>
                 </X_Rhapsody-Extension>
-                <qq:X_QPlay_SoftwareCapability xmlns:qq="http://www.tencent.com">QPlay:2</qq:X_QPlay_SoftwareCapability>
+                <qq:X_QPlay_SoftwareCapability xmlns:qq="http://www.tencent.com">"""
+        """QPlay:2</qq:X_QPlay_SoftwareCapability>
                 <iconList>
                   <icon>
                     <mimetype>image/png</mimetype>
@@ -494,7 +501,7 @@ class TestSoco:
 
     @mock.patch("soco.core.requests")
     @pytest.mark.parametrize("should", [{}, {"info": "yes"}])
-    def test_soco_get_speaker_info_speaker_set_no_refresh(self, mocr, moco_zgs, should):
+    def test_soco_get_speaker_info_speaker_set_refresh(self, mocr, moco_zgs, should):
         """Internal speaker_info not set/set; Refresh True.
 
         => should update
@@ -561,7 +568,7 @@ class TestAVTransport:
             [("InstanceID", 0), ("NewPlayMode", "NORMAL")]
         )
 
-    def test_soco_cross_fade(self, moco):
+    def test_soco_cross_fade2(self, moco):
         moco.avTransport.GetCrossfadeMode.return_value = {"CrossfadeMode": "1"}
         assert moco.cross_fade
         moco.avTransport.GetCrossfadeMode.return_value = {"CrossfadeMode": "0"}
@@ -618,8 +625,11 @@ class TestAVTransport:
                 "x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3",
             ),
             (
-                "aac://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false",
-                "x-rincon-mp3radio://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false",
+                "aac://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams="
+                "playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false",
+                "x-rincon-mp3radio://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?"
+                "amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:"
+                "false",
             ),
         ],
     )
@@ -631,13 +641,19 @@ class TestAVTransport:
         moco.avTransport.reset_mock()
 
     def test_soco_play_uri_calls_play(self, moco):
-        uri = "http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3"
+        uri = (
+            "http://archive.org/download/tend2005-07-16.flac16/"
+            "tend2005-07-16t10wonderboy_64kb.mp3"
+        )
         moco.play_uri(uri)
 
         moco.avTransport.Play.assert_called_with([("InstanceID", 0), ("Speed", 1)])
 
     def test_soco_play_uri_with_title(self, moco):
-        uri = "http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3"
+        uri = (
+            "http://archive.org/download/tend2005-07-16.flac16/"
+            "tend2005-07-16t10wonderboy_64kb.mp3"
+        )
         moco.play_uri(uri, title="<Fast & Loose>")
 
         moco.avTransport.SetAVTransportURI.assert_called_with(
@@ -646,7 +662,15 @@ class TestAVTransport:
                 ("CurrentURI", uri),
                 (
                     "CurrentURIMetaData",
-                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="R:0/0/0" parentID="R:0/0" restricted="true"><dc:title>&lt;Fast &amp; Loose&gt;</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>',
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                    'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                    'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                    'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                    '<item id="R:0/0/0" parentID="R:0/0" restricted="true">'
+                    "<dc:title>&lt;Fast &amp; Loose&gt;</dc:title>"
+                    "<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>"
+                    '<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:'
+                    'metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>',
                 ),
             ]
         )
@@ -709,7 +733,20 @@ class TestAVTransport:
 
     def test_soco_get_queue(self, moco):
         moco.contentDirectory.Browse.return_value = {
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="Q:0/1" parentID="Q:0" restricted="true"><res protocolInfo="fake.com-fake-direct:*:audio/mp3:*" duration="0:02:32">radea:Tra.12345678.mp3</res><upnp:albumArtURI>/getaa?r=1&amp;u=radea%3aTra.12345678.mp3</upnp:albumArtURI><dc:title>Item 1 Title</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:creator>Item 1 Creator</dc:creator><upnp:album>Item 1 Album</upnp:album></item></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                '<item id="Q:0/1" parentID="Q:0" restricted="true">'
+                '<res protocolInfo="fake.com-fake-direct:*:audio/mp3:*" '
+                'duration="0:02:32">radea:Tra.12345678.mp3</res>'
+                "<upnp:albumArtURI>/getaa?r=1&amp;u=radea%3aTra.12345678.mp3"
+                "</upnp:albumArtURI><dc:title>Item 1 Title</dc:title>"
+                "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
+                "<dc:creator>Item 1 Creator</dc:creator>"
+                "<upnp:album>Item 1 Album</upnp:album></item></DIDL-Lite>"
+            ),
             "NumberReturned": "1",
             "TotalMatches": "10",
             "UpdateID": "1",
@@ -732,7 +769,18 @@ class TestAVTransport:
     def test_soco_queue_size(self, moco):
         moco.contentDirectory.Browse.return_value = {
             "NumberReturned": "1",
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><container id="Q:0" parentID="Q:" restricted="true" childCount="384"><dc:title>Queue Instance 0</dc:title><upnp:class>object.container.playlistContainer</upnp:class><res protocolInfo="x-rincon-queue:*:*:*">x-rincon-queue:RINCON_00012345678901400#0</res></container></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                '<container id="Q:0" parentID="Q:" restricted="true" childCount="384">'
+                "<dc:title>Queue Instance 0</dc:title><upnp:class>"
+                "object.container.playlistContainer</upnp:class>"
+                '<res protocolInfo="x-rincon-queue:*:*:*">'
+                "x-rincon-queue:RINCON_00012345678901400#0</res>"
+                "</container></DIDL-Lite>"
+            ),
             "TotalMatches": "1",
             "UpdateID": "1",
         }
@@ -905,7 +953,12 @@ class TestAVTransport:
 
         moco.contentDirectory.Browse.return_value = {
             "NumberReturned": "0",
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>'
+            ),
             "TotalMatches": "0",
             "UpdateID": update_id,
         }
@@ -986,7 +1039,7 @@ class TestAVTransport:
             "CurrentSleepTimerGeneration": "0",
         }
         result = moco.get_sleep_timer()
-        assert result == None
+        assert result is None
 
 
 class TestContentDirectory:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,16 +5,12 @@ import mock
 import pytest
 
 from soco import SoCo
-from soco.data_structures import (
-    DidlMusicTrack, to_didl_string
-)
-from soco.exceptions import (
-    SoCoSlaveException, SoCoUPnPException
-)
+from soco.data_structures import DidlMusicTrack, to_didl_string
+from soco.exceptions import SoCoSlaveException, SoCoUPnPException
 from soco.groups import ZoneGroup
 from soco.xml import XML
 
-IP_ADDR = '192.168.1.101'
+IP_ADDR = "192.168.1.101"
 
 
 @pytest.yield_fixture()
@@ -25,14 +21,19 @@ def moco():
     access
     """
     services = (
-        'AVTransport', 'RenderingControl', 'DeviceProperties',
-        'ContentDirectory', 'ZoneGroupTopology', 'GroupRenderingControl')
-    patchers = [mock.patch('soco.core.{}'.format(service))
-                for service in services]
+        "AVTransport",
+        "RenderingControl",
+        "DeviceProperties",
+        "ContentDirectory",
+        "ZoneGroupTopology",
+        "GroupRenderingControl",
+    )
+    patchers = [mock.patch("soco.core.{}".format(service)) for service in services]
     for patch in patchers:
         patch.start()
-    with mock.patch("soco.SoCo.is_coordinator",
-                    new_callable=mock.PropertyMock) as is_coord:
+    with mock.patch(
+        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
+    ) as is_coord:
         is_coord = True
         yield SoCo(IP_ADDR)
     for patch in reversed(patchers):
@@ -47,10 +48,14 @@ def moco_only_on_master():
     access
     """
     services = (
-        'AVTransport', 'RenderingControl', 'DeviceProperties',
-        'ContentDirectory', 'ZoneGroupTopology', 'GroupRenderingControl')
-    patchers = [mock.patch('soco.core.{}'.format(service))
-                for service in services]
+        "AVTransport",
+        "RenderingControl",
+        "DeviceProperties",
+        "ContentDirectory",
+        "ZoneGroupTopology",
+        "GroupRenderingControl",
+    )
+    patchers = [mock.patch("soco.core.{}".format(service)) for service in services]
     for patch in patchers:
         patch.start()
     yield SoCo(IP_ADDR)
@@ -174,17 +179,17 @@ ZGS = """<ZoneGroupState>
       <VanishedDevices></VanishedDevices>
     </ZoneGroupState>"""
 
+
 @pytest.yield_fixture
 def moco_zgs(moco):
     """A mock soco with zone group state."""
-    moco.zoneGroupTopology.GetZoneGroupState.return_value = {
-        'ZoneGroupState': ZGS
-    }
+    moco.zoneGroupTopology.GetZoneGroupState.return_value = {"ZoneGroupState": ZGS}
     yield moco
 
 
 class TestSoco:
-    device_description = """<?xml version="1.0" encoding="utf-8" ?>
+    device_description = (
+        """<?xml version="1.0" encoding="utf-8" ?>
         <root xmlns="urn:schemas-upnp-org:device-1-0">
           <specVersion>
             <major>1</major>
@@ -192,7 +197,9 @@ class TestSoco:
           </specVersion>
           <device>
             <deviceType>urn:schemas-upnp-org:device:ZonePlayer:1</deviceType>
-            <friendlyName>""" + IP_ADDR + """ - Sonos Play:5</friendlyName>
+            <friendlyName>"""
+        + IP_ADDR
+        + """ - Sonos Play:5</friendlyName>
             <manufacturer>Sonos, Inc.</manufacturer>
             <manufacturerURL>http://www.sonos.com</manufacturerURL>
             <modelNumber>S3</modelNumber>
@@ -389,8 +396,9 @@ class TestSoco:
           </device>
         </root>
     """
+    )
 
-    @pytest.mark.parametrize('bad_ip_addr', ['not_ip', '555.555.555.555'])
+    @pytest.mark.parametrize("bad_ip_addr", ["not_ip", "555.555.555.555"])
     def test_soco_bad_ip(self, bad_ip_addr):
         with pytest.raises(ValueError):
             speaker = SoCo(bad_ip_addr)
@@ -405,22 +413,27 @@ class TestSoco:
     def test_soco_repr(self, moco):
         assert repr(moco) == 'SoCo("{}")'.format(IP_ADDR)
 
-    @pytest.mark.parametrize('model_name', (
-        ('Play:5', False),
-        ('Sonos One', False),
-        ('PLAYBAR', True),
-        ('Sonos Beam', True),
-        ('Sonos Playbar', True),
-        ('Sonos Playbase', True)))
+    @pytest.mark.parametrize(
+        "model_name",
+        (
+            ("Play:5", False),
+            ("Sonos One", False),
+            ("PLAYBAR", True),
+            ("Sonos Beam", True),
+            ("Sonos Playbar", True),
+            ("Sonos Playbase", True),
+        ),
+    )
     def test_soco_is_soundbar(self, moco, model_name):
         moco._is_soundbar = None
-        moco.speaker_info['model_name'] = model_name[0]
+        moco.speaker_info["model_name"] = model_name[0]
         assert moco.is_soundbar == model_name[1]
 
     @mock.patch("soco.core.requests")
-    @pytest.mark.parametrize('refresh', [None, False, True])
+    @pytest.mark.parametrize("refresh", [None, False, True])
     def test_soco_get_speaker_info_speaker_not_set_refresh(
-            self, mocr, moco_zgs, refresh):
+        self, mocr, moco_zgs, refresh
+    ):
         """Internal speaker_info not set; Refresh all values (default, False,
         True)
 
@@ -439,34 +452,32 @@ class TestSoco:
         # restore original value
         moco_zgs.speaker_info = old
         mocr.get.assert_called_once_with(
-            'http://' + IP_ADDR + ':1400/xml/device_description.xml',
-            timeout=None,
+            "http://" + IP_ADDR + ":1400/xml/device_description.xml", timeout=None,
         )
         should = {
-            'zone_name': "Room",
-            'player_icon': "/img/icon-S3.png",
-            'uid': "RINCON_000XXX1400",
-            'serial_number': "00-11-22-33-44-55:E",
-            'software_version': "49.2-64250",
-            'hardware_version': "1.8.1.2-2",
-            'model_number': "S3",
-            'model_name': "Sonos Play:3",
-            'display_version': "10.1.2",
-            'mac_address': "00-11-22-33-44-55"
+            "zone_name": "Room",
+            "player_icon": "/img/icon-S3.png",
+            "uid": "RINCON_000XXX1400",
+            "serial_number": "00-11-22-33-44-55:E",
+            "software_version": "49.2-64250",
+            "hardware_version": "1.8.1.2-2",
+            "model_number": "S3",
+            "model_name": "Sonos Play:3",
+            "display_version": "10.1.2",
+            "mac_address": "00-11-22-33-44-55",
         }
         assert should == res
 
     @mock.patch("soco.core.requests")
-    @pytest.mark.parametrize('refresh', [None, False])
+    @pytest.mark.parametrize("refresh", [None, False])
     def test_soco_get_speaker_info_speaker_set_no_refresh(
-            self, mocr, moco_zgs, refresh):
+        self, mocr, moco_zgs, refresh
+    ):
         """Internal speaker_info set; No refresh (default, False)
 
         => should not update
         """
-        should = {
-            'info': "yes"
-        }
+        should = {"info": "yes"}
         # save old state
         old = moco_zgs.speaker_info
         moco_zgs.speaker_info = should
@@ -482,9 +493,8 @@ class TestSoco:
         assert not mocr.get.called
 
     @mock.patch("soco.core.requests")
-    @pytest.mark.parametrize('should', [{}, {'info': "yes"}])
-    def test_soco_get_speaker_info_speaker_set_no_refresh(
-            self, mocr, moco_zgs, should):
+    @pytest.mark.parametrize("should", [{}, {"info": "yes"}])
+    def test_soco_get_speaker_info_speaker_set_no_refresh(self, mocr, moco_zgs, should):
         """Internal speaker_info not set/set; Refresh True.
 
         => should update
@@ -499,37 +509,44 @@ class TestSoco:
         # restore original value
         moco_zgs.speaker_info = old
         mocr.get.assert_called_once_with(
-            'http://' + IP_ADDR + ':1400/xml/device_description.xml',
-            timeout=None,
+            "http://" + IP_ADDR + ":1400/xml/device_description.xml", timeout=None,
         )
         # get_speaker_info only updates internal speaker_info and does not
         # replace it
-        should.update({
-            'zone_name': "Room",
-            'player_icon': "/img/icon-S3.png",
-            'uid': "RINCON_000XXX1400",
-            'serial_number': "00-11-22-33-44-55:E",
-            'software_version': "29.5-91030",
-            'hardware_version': "1.8.1.2-2",
-            'model_number': "S3",
-            'model_name': "Sonos Play:3",
-            'display_version': "10.1.2",
-            'mac_address': "00-11-22-33-44-55"
-        })
+        should.update(
+            {
+                "zone_name": "Room",
+                "player_icon": "/img/icon-S3.png",
+                "uid": "RINCON_000XXX1400",
+                "serial_number": "00-11-22-33-44-55:E",
+                "software_version": "29.5-91030",
+                "hardware_version": "1.8.1.2-2",
+                "model_number": "S3",
+                "model_name": "Sonos Play:3",
+                "display_version": "10.1.2",
+                "mac_address": "00-11-22-33-44-55",
+            }
+        )
         assert should == res
 
 
 class TestAVTransport:
-
-    @pytest.mark.parametrize('playmode', [
-        "NORMAL", "SHUFFLE_NOREPEAT", "SHUFFLE", "REPEAT_ALL", "SHUFFLE_REPEAT_ONE", "REPEAT_ONE"
-    ])
+    @pytest.mark.parametrize(
+        "playmode",
+        [
+            "NORMAL",
+            "SHUFFLE_NOREPEAT",
+            "SHUFFLE",
+            "REPEAT_ALL",
+            "SHUFFLE_REPEAT_ONE",
+            "REPEAT_ONE",
+        ],
+    )
     def test_soco_play_mode_values(self, moco, playmode):
-        moco.avTransport.GetTransportSettings.return_value = {
-            'PlayMode': playmode}
+        moco.avTransport.GetTransportSettings.return_value = {"PlayMode": playmode}
         assert moco.play_mode == playmode
         moco.avTransport.GetTransportSettings.assert_called_once_with(
-            [('InstanceID', 0)]
+            [("InstanceID", 0)]
         )
         moco.avTransport.reset_mock()
 
@@ -541,181 +558,195 @@ class TestAVTransport:
     def test_soco_play_mode_lowercase(self, moco):
         moco.play_mode = "normal"
         moco.avTransport.SetPlayMode.assert_called_once_with(
-            [('InstanceID', 0), ('NewPlayMode', 'NORMAL')]
+            [("InstanceID", 0), ("NewPlayMode", "NORMAL")]
         )
 
     def test_soco_cross_fade(self, moco):
-        moco.avTransport.GetCrossfadeMode.return_value = {'CrossfadeMode': '1'}
+        moco.avTransport.GetCrossfadeMode.return_value = {"CrossfadeMode": "1"}
         assert moco.cross_fade
-        moco.avTransport.GetCrossfadeMode.return_value = {'CrossfadeMode': '0'}
+        moco.avTransport.GetCrossfadeMode.return_value = {"CrossfadeMode": "0"}
         assert not moco.cross_fade
-        moco.avTransport.GetCrossfadeMode.assert_called_with(
-            [('InstanceID', 0)]
-        )
+        moco.avTransport.GetCrossfadeMode.assert_called_with([("InstanceID", 0)])
         moco.cross_fade = True
         moco.avTransport.SetCrossfadeMode.assert_called_once_with(
-            [('InstanceID', 0), ('CrossfadeMode', '1')]
+            [("InstanceID", 0), ("CrossfadeMode", "1")]
         )
 
     def test_soco_play(self, moco):
         moco.play()
-        moco.avTransport.Play.assert_called_once_with(
-            [('InstanceID', 0), ('Speed', 1)]
-        )
+        moco.avTransport.Play.assert_called_once_with([("InstanceID", 0), ("Speed", 1)])
 
     # Test that uris are forced to Radio style display and controls when
     # force_radio is True prefix is replaced with "x-rincon-mp3radion://"
     # first set of test with no forcing, second set with force_radio=True
 
     # No forcing
-    @pytest.mark.parametrize("uri_in, uri_passed", [
-        ('x-file-cifs://server/MyNiceRing.mp3',
-         'x-file-cifs://server/MyNiceRing.mp3'),
-        ('http://archive.org/download/TenD2005-07-16t_64kb.mp3',
-         'http://archive.org/download/TenD2005-07-16t_64kb.mp3'),
-        ('x-sonosapi-radio:station%3a%3aps.147077612?sid=203&flags=76&sn=2',
-         'x-sonosapi-radio:station%3a%3aps.147077612?sid=203&flags=76&sn=2'),
-    ])
+    @pytest.mark.parametrize(
+        "uri_in, uri_passed",
+        [
+            (
+                "x-file-cifs://server/MyNiceRing.mp3",
+                "x-file-cifs://server/MyNiceRing.mp3",
+            ),
+            (
+                "http://archive.org/download/TenD2005-07-16t_64kb.mp3",
+                "http://archive.org/download/TenD2005-07-16t_64kb.mp3",
+            ),
+            (
+                "x-sonosapi-radio:station%3a%3aps.147077612?sid=203&flags=76&sn=2",
+                "x-sonosapi-radio:station%3a%3aps.147077612?sid=203&flags=76&sn=2",
+            ),
+        ],
+    )
     def test_soco_play_uri(self, moco, uri_in, uri_passed):
         moco.play_uri(uri_in)
-        moco.avTransport.SetAVTransportURI.assert_called_once_with([
-            ('InstanceID', 0),
-            ('CurrentURI', uri_passed),
-            ('CurrentURIMetaData', '')
-        ])
+        moco.avTransport.SetAVTransportURI.assert_called_once_with(
+            [("InstanceID", 0), ("CurrentURI", uri_passed), ("CurrentURIMetaData", "")]
+        )
         moco.avTransport.reset_mock()
 
     # with force_radio=True
-    @pytest.mark.parametrize("uri_in, uri_passed", [
-        ('http://archive.org/download/TenD2005-07-16t_64kb.mp3',
-         'x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3'),
-        ('https://archive.org/download/TenD2005-07-16t_64kb.mp3',
-         'x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3'),
-        ('aac://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false',
-         'x-rincon-mp3radio://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false')
-    ])
+    @pytest.mark.parametrize(
+        "uri_in, uri_passed",
+        [
+            (
+                "http://archive.org/download/TenD2005-07-16t_64kb.mp3",
+                "x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3",
+            ),
+            (
+                "https://archive.org/download/TenD2005-07-16t_64kb.mp3",
+                "x-rincon-mp3radio://archive.org/download/TenD2005-07-16t_64kb.mp3",
+            ),
+            (
+                "aac://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false",
+                "x-rincon-mp3radio://icy-e-bz-04-cr.sharp-stream.com/magic1054.aac?amsparams=playerid:BMUK_tunein;skey:1483570441&awparams=loggedin:false",
+            ),
+        ],
+    )
     def test_soco_play_uri_force_radio(self, moco, uri_in, uri_passed):
         moco.play_uri(uri_in, force_radio=True)
-        moco.avTransport.SetAVTransportURI.assert_called_once_with([
-            ('InstanceID', 0),
-            ('CurrentURI', uri_passed),
-            ('CurrentURIMetaData', '')
-        ])
+        moco.avTransport.SetAVTransportURI.assert_called_once_with(
+            [("InstanceID", 0), ("CurrentURI", uri_passed), ("CurrentURIMetaData", "")]
+        )
         moco.avTransport.reset_mock()
 
     def test_soco_play_uri_calls_play(self, moco):
-        uri = 'http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3'
+        uri = "http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3"
         moco.play_uri(uri)
 
-        moco.avTransport.Play.assert_called_with(
-            [('InstanceID', 0), ('Speed', 1)]
-        )
+        moco.avTransport.Play.assert_called_with([("InstanceID", 0), ("Speed", 1)])
 
     def test_soco_play_uri_with_title(self, moco):
-        uri = 'http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3'
-        moco.play_uri(uri, title='<Fast & Loose>')
+        uri = "http://archive.org/download/tend2005-07-16.flac16/tend2005-07-16t10wonderboy_64kb.mp3"
+        moco.play_uri(uri, title="<Fast & Loose>")
 
-        moco.avTransport.SetAVTransportURI.assert_called_with([
-            ('InstanceID', 0),
-            ('CurrentURI', uri),
-            ('CurrentURIMetaData', '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="R:0/0/0" parentID="R:0/0" restricted="true"><dc:title>&lt;Fast &amp; Loose&gt;</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>')
-        ])
+        moco.avTransport.SetAVTransportURI.assert_called_with(
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", uri),
+                (
+                    "CurrentURIMetaData",
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="R:0/0/0" parentID="R:0/0" restricted="true"><dc:title>&lt;Fast &amp; Loose&gt;</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>',
+                ),
+            ]
+        )
 
     def test_soco_pause(self, moco):
         moco.pause()
         moco.avTransport.Pause.assert_called_once_with(
-            [('InstanceID', 0), ('Speed', 1)]
+            [("InstanceID", 0), ("Speed", 1)]
         )
 
     def test_soco_stop(self, moco):
         moco.stop()
-        moco.avTransport.Stop.assert_called_once_with(
-            [('InstanceID', 0), ('Speed', 1)]
-        )
+        moco.avTransport.Stop.assert_called_once_with([("InstanceID", 0), ("Speed", 1)])
 
     def test_soco_next(self, moco):
         moco.next()
-        moco.avTransport.Next.assert_called_once_with(
-            [('InstanceID', 0), ('Speed', 1)]
-        )
+        moco.avTransport.Next.assert_called_once_with([("InstanceID", 0), ("Speed", 1)])
 
     def test_soco_previous(self, moco):
         moco.previous()
         moco.avTransport.Previous.assert_called_once_with(
-            [('InstanceID', 0), ('Speed', 1)]
+            [("InstanceID", 0), ("Speed", 1)]
         )
 
-    @pytest.mark.parametrize('bad_timestamp', [
-        'NOT_VALID',
-        '12:34:56:78',
-        '99',
-        '12:3:4'
-    ])
+    @pytest.mark.parametrize(
+        "bad_timestamp", ["NOT_VALID", "12:34:56:78", "99", "12:3:4"]
+    )
     def test_soco_seek_invalid(self, moco, bad_timestamp):
         with pytest.raises(ValueError):
             moco.seek(bad_timestamp)
         assert not moco.avTransport.Seek.called
 
-    @pytest.mark.parametrize('timestamp', [
-        # '12:34', # Should this be valid?
-        '1:23:45',
-        '10:23:45',
-        '12:78:78'  # Should this really be valid?
-    ])
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            # '12:34', # Should this be valid?
+            "1:23:45",
+            "10:23:45",
+            "12:78:78",  # Should this really be valid?
+        ],
+    )
     def test_soco_seek_valid(self, moco, timestamp):
         moco.seek(timestamp)
         moco.avTransport.Seek.assert_called_once_with(
-            [('InstanceID', 0), ('Unit', 'REL_TIME'),
-                ('Target', timestamp)])
+            [("InstanceID", 0), ("Unit", "REL_TIME"), ("Target", timestamp)]
+        )
         moco.avTransport.reset_mock()
 
     def test_soco_current_transport_info(self, moco):
         moco.avTransport.GetTransportInfo.return_value = {
-            'CurrentTransportState': 'PLAYING',
-            'CurrentTransportStatus': 'OK',
-            'CurrentSpeed': '1'}
+            "CurrentTransportState": "PLAYING",
+            "CurrentTransportStatus": "OK",
+            "CurrentSpeed": "1",
+        }
         playstate = moco.get_current_transport_info()
-        moco.avTransport.GetTransportInfo.assert_called_once_with(
-            [('InstanceID', 0)]
-        )
-        assert playstate['current_transport_state'] == 'PLAYING'
-        assert playstate['current_transport_status'] == 'OK'
-        assert playstate['current_transport_speed'] == '1'
+        moco.avTransport.GetTransportInfo.assert_called_once_with([("InstanceID", 0)])
+        assert playstate["current_transport_state"] == "PLAYING"
+        assert playstate["current_transport_status"] == "OK"
+        assert playstate["current_transport_speed"] == "1"
 
     def test_soco_get_queue(self, moco):
         moco.contentDirectory.Browse.return_value = {
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="Q:0/1" parentID="Q:0" restricted="true"><res protocolInfo="fake.com-fake-direct:*:audio/mp3:*" duration="0:02:32">radea:Tra.12345678.mp3</res><upnp:albumArtURI>/getaa?r=1&amp;u=radea%3aTra.12345678.mp3</upnp:albumArtURI><dc:title>Item 1 Title</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:creator>Item 1 Creator</dc:creator><upnp:album>Item 1 Album</upnp:album></item></DIDL-Lite>',
-            'NumberReturned': '1',
-            'TotalMatches': '10',
-            'UpdateID': '1'}
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="Q:0/1" parentID="Q:0" restricted="true"><res protocolInfo="fake.com-fake-direct:*:audio/mp3:*" duration="0:02:32">radea:Tra.12345678.mp3</res><upnp:albumArtURI>/getaa?r=1&amp;u=radea%3aTra.12345678.mp3</upnp:albumArtURI><dc:title>Item 1 Title</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:creator>Item 1 Creator</dc:creator><upnp:album>Item 1 Album</upnp:album></item></DIDL-Lite>',
+            "NumberReturned": "1",
+            "TotalMatches": "10",
+            "UpdateID": "1",
+        }
         queue = moco.get_queue(start=8, max_items=32)
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'Q:0'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 8),
-            ('RequestedCount', 32),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "Q:0"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 8),
+                ("RequestedCount", 32),
+                ("SortCriteria", ""),
+            ]
+        )
         assert queue is not None
         assert len(queue) == 1
         moco.contentDirectory.reset_mock()
 
     def test_soco_queue_size(self, moco):
         moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '1',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><container id="Q:0" parentID="Q:" restricted="true" childCount="384"><dc:title>Queue Instance 0</dc:title><upnp:class>object.container.playlistContainer</upnp:class><res protocolInfo="x-rincon-queue:*:*:*">x-rincon-queue:RINCON_00012345678901400#0</res></container></DIDL-Lite>',
-            'TotalMatches': '1',
-            'UpdateID': '1'}
+            "NumberReturned": "1",
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><container id="Q:0" parentID="Q:" restricted="true" childCount="384"><dc:title>Queue Instance 0</dc:title><upnp:class>object.container.playlistContainer</upnp:class><res protocolInfo="x-rincon-queue:*:*:*">x-rincon-queue:RINCON_00012345678901400#0</res></container></DIDL-Lite>',
+            "TotalMatches": "1",
+            "UpdateID": "1",
+        }
         queue_size = moco.queue_size
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'Q:0'),
-            ('BrowseFlag', 'BrowseMetadata'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 1),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "Q:0"),
+                ("BrowseFlag", "BrowseMetadata"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 1),
+                ("SortCriteria", ""),
+            ]
+        )
         assert queue_size == 384
         moco.contentDirectory.reset_mock()
 
@@ -724,23 +755,28 @@ class TestAVTransport:
         moco2.uid = "RINCON_000XXX1400"
         moco_zgs.join(moco2)
         moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
-            [('InstanceID', 0),
-             ('CurrentURI', 'x-rincon:RINCON_000XXX1400'),
-             ('CurrentURIMetaData', '')]
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon:RINCON_000XXX1400"),
+                ("CurrentURIMetaData", ""),
+            ]
         )
 
     def test_unjoin(self, moco_zgs):
         moco_zgs.unjoin()
-        moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup\
-            .assert_called_once_with([('InstanceID', 0)])
+        moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup.assert_called_once_with(
+            [("InstanceID", 0)]
+        )
 
     def test_switch_to_line_in(self, moco_zgs):
         moco_zgs.avTransport.reset_mock()
         moco_zgs.switch_to_line_in()
         moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
-            [('InstanceID', 0),
-                ('CurrentURI', 'x-rincon-stream:RINCON_000XXX1400'),
-                ('CurrentURIMetaData', '')]
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon-stream:RINCON_000XXX1400"),
+                ("CurrentURIMetaData", ""),
+            ]
         )
 
         moco_zgs.avTransport.reset_mock()
@@ -748,34 +784,37 @@ class TestAVTransport:
         moco2.uid = "RINCON_000YYY1400"
         moco_zgs.switch_to_line_in(moco2)
         moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
-            [('InstanceID', 0),
-             ('CurrentURI', 'x-rincon-stream:RINCON_000YYY1400'),
-             ('CurrentURIMetaData', '')]
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon-stream:RINCON_000YYY1400"),
+                ("CurrentURIMetaData", ""),
+            ]
         )
 
     def test_switch_to_tv(self, moco_zgs):
         moco_zgs.avTransport.reset_mock()
         moco_zgs.switch_to_tv()
         moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
-            [('InstanceID', 0),
-                ('CurrentURI', 'x-sonos-htastream:RINCON_000XXX1400:spdif'),
-                ('CurrentURIMetaData', '')]
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-sonos-htastream:RINCON_000XXX1400:spdif"),
+                ("CurrentURIMetaData", ""),
+            ]
         )
 
     def test_is_playing_tv(self, moco):
         moco.avTransport.reset_mock()
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'x-sonos-htastream:RINCON_00012345678901234:spdif'
+            "TrackURI": "x-sonos-htastream:RINCON_00012345678901234:spdif"
         }
         playing_tv = moco.is_playing_tv
         assert playing_tv
         moco.avTransport.GetPositionInfo.assert_called_once_with(
-            [('InstanceID', 0),
-             ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
 
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'not-tv',
+            "TrackURI": "not-tv",
         }
         playing_tv = moco.is_playing_tv
         assert not playing_tv
@@ -783,17 +822,16 @@ class TestAVTransport:
     def test_is_playing_radio(self, moco):
         moco.avTransport.reset_mock()
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'x-rincon-mp3radio://example.com:80/myradio'
+            "TrackURI": "x-rincon-mp3radio://example.com:80/myradio"
         }
         playing_tv = moco.is_playing_radio
         assert playing_tv
         moco.avTransport.GetPositionInfo.assert_called_once_with(
-            [('InstanceID', 0),
-             ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
 
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'not-radio',
+            "TrackURI": "not-radio",
         }
         playing_tv = moco.is_playing_radio
         assert not playing_tv
@@ -801,17 +839,16 @@ class TestAVTransport:
     def test_is_playing_line_in(self, moco):
         moco.avTransport.reset_mock()
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'x-rincon-stream:blah-blah'
+            "TrackURI": "x-rincon-stream:blah-blah"
         }
         playing_tv = moco.is_playing_line_in
         assert playing_tv
         moco.avTransport.GetPositionInfo.assert_called_once_with(
-            [('InstanceID', 0),
-             ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
 
         moco.avTransport.GetPositionInfo.return_value = {
-            'TrackURI': 'not-line-in',
+            "TrackURI": "not-line-in",
         }
         playing_tv = moco.is_playing_line_in
         assert not playing_tv
@@ -820,18 +857,19 @@ class TestAVTransport:
         playlist_name = "cool music"
         playlist_id = 1
         moco.avTransport.CreateSavedQueue.return_value = {
-            'AssignedObjectID': 'SQ:{}'.format(playlist_id)
+            "AssignedObjectID": "SQ:{}".format(playlist_id)
         }
         playlist = moco.create_sonos_playlist(playlist_name)
         moco.avTransport.CreateSavedQueue.assert_called_once_with(
-            [('InstanceID', 0),
-             ('Title', playlist_name),
-             ('EnqueuedURI', ''),
-             ('EnqueuedURIMetaData', '')]
+            [
+                ("InstanceID", 0),
+                ("Title", playlist_name),
+                ("EnqueuedURI", ""),
+                ("EnqueuedURIMetaData", ""),
+            ]
         )
         assert playlist.title == playlist_name
-        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(
-            playlist_id)
+        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(playlist_id)
         assert playlist.resources[0].uri == expected_uri
         assert playlist.parent_id == "SQ:"
 
@@ -839,17 +877,14 @@ class TestAVTransport:
         playlist_name = "saved queue"
         playlist_id = 1
         moco.avTransport.SaveQueue.return_value = {
-            'AssignedObjectID': 'SQ:{}'.format(playlist_id)
+            "AssignedObjectID": "SQ:{}".format(playlist_id)
         }
         playlist = moco.create_sonos_playlist_from_queue(playlist_name)
         moco.avTransport.SaveQueue.assert_called_once_with(
-            [('InstanceID', 0),
-             ('Title', playlist_name),
-             ('ObjectID', '')]
+            [("InstanceID", 0), ("Title", playlist_name), ("ObjectID", "")]
         )
         assert playlist.title == playlist_name
-        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(
-            playlist_id)
+        expected_uri = "file:///jffs/settings/savedqueues.rsq#{}".format(playlist_id)
         assert playlist.resources[0].uri == expected_uri
         assert playlist.parent_id == "SQ:"
 
@@ -860,49 +895,50 @@ class TestAVTransport:
         playlist.item_id = 7
 
         ressource = mock.Mock()
-        ressource.uri = 'fake_uri'
+        ressource.uri = "fake_uri"
         track = mock.Mock()
         track.resources = [ressource]
-        track.uri = 'fake_uri'
-        track.to_element.return_value = XML.Element('a')
+        track.uri = "fake_uri"
+        track.to_element.return_value = XML.Element("a")
 
         update_id = 100
 
         moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '0',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
-            'TotalMatches': '0',
-            'UpdateID': update_id
+            "NumberReturned": "0",
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
+            "TotalMatches": "0",
+            "UpdateID": update_id,
         }
 
         moco.add_item_to_sonos_playlist(track, playlist)
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', playlist.item_id),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 1),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", playlist.item_id),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 1),
+                ("SortCriteria", ""),
+            ]
+        )
         moco.avTransport.AddURIToSavedQueue.assert_called_once_with(
-            [('InstanceID', 0),
-             ('UpdateID', update_id),
-             ('ObjectID', playlist.item_id),
-             ('EnqueuedURI', track.uri),
-             ('EnqueuedURIMetaData', to_didl_string(track)),
-             ('AddAtIndex', 4294967295)]
+            [
+                ("InstanceID", 0),
+                ("UpdateID", update_id),
+                ("ObjectID", playlist.item_id),
+                ("EnqueuedURI", track.uri),
+                ("EnqueuedURIMetaData", to_didl_string(track)),
+                ("AddAtIndex", 4294967295),
+            ]
         )
 
     def test_soco_cross_fade(self, moco):
-        moco.avTransport.GetCrossfadeMode.return_value = {
-            'CrossfadeMode': '1'}
+        moco.avTransport.GetCrossfadeMode.return_value = {"CrossfadeMode": "1"}
         assert moco.cross_fade
-        moco.avTransport.GetCrossfadeMode.assert_called_once_with(
-            [('InstanceID', 0)]
-        )
+        moco.avTransport.GetCrossfadeMode.assert_called_once_with([("InstanceID", 0)])
         moco.cross_fade = False
         moco.avTransport.SetCrossfadeMode.assert_called_once_with(
-            [('InstanceID', 0), ('CrossfadeMode', '0')]
+            [("InstanceID", 0), ("CrossfadeMode", "0")]
         )
 
     def test_set_sleep_timer(self, moco):
@@ -911,8 +947,7 @@ class TestAVTransport:
         result = moco.set_sleep_timer(None)
         assert result is None
         moco.avTransport.ConfigureSleepTimer.assert_called_once_with(
-            [('InstanceID', 0),
-             ('NewSleepTimerDuration', '')]
+            [("InstanceID", 0), ("NewSleepTimerDuration", "")]
         )
 
         moco.avTransport.reset_mock()
@@ -920,8 +955,7 @@ class TestAVTransport:
         result = moco.set_sleep_timer(7200)
         assert result is None
         moco.avTransport.ConfigureSleepTimer.assert_called_once_with(
-            [('InstanceID', 0),
-             ('NewSleepTimerDuration', '2:00:00')]
+            [("InstanceID", 0), ("NewSleepTimerDuration", "2:00:00")]
         )
 
         moco.avTransport.reset_mock()
@@ -929,11 +963,10 @@ class TestAVTransport:
         result = moco.set_sleep_timer(0)
         assert result is None
         moco.avTransport.ConfigureSleepTimer.assert_called_once_with(
-            [('InstanceID', 0),
-             ('NewSleepTimerDuration', '0:00:00')]
+            [("InstanceID", 0), ("NewSleepTimerDuration", "0:00:00")]
         )
 
-    @pytest.mark.parametrize('bad_sleep_time', ['BadTime', '00:43:23', '4200s',''])
+    @pytest.mark.parametrize("bad_sleep_time", ["BadTime", "00:43:23", "4200s", ""])
     def test_set_sleep_timer_bad_sleep_time(self, moco, bad_sleep_time):
         with pytest.raises(ValueError):
             result = moco.set_sleep_timer(bad_sleep_time)
@@ -941,186 +974,177 @@ class TestAVTransport:
     def test_get_sleep_timer(self, moco):
         moco.avTransport.reset_mock()
         moco.avTransport.GetRemainingSleepTimerDuration.return_value = {
-            'RemainingSleepTimerDuration': '02:00:00',
-            'CurrentSleepTimerGeneration': '3',
+            "RemainingSleepTimerDuration": "02:00:00",
+            "CurrentSleepTimerGeneration": "3",
         }
         result = moco.get_sleep_timer()
         assert result == 7200
 
         moco.avTransport.reset_mock()
         moco.avTransport.GetRemainingSleepTimerDuration.return_value = {
-            'RemainingSleepTimerDuration': '',
-            'CurrentSleepTimerGeneration': '0',
+            "RemainingSleepTimerDuration": "",
+            "CurrentSleepTimerGeneration": "0",
         }
         result = moco.get_sleep_timer()
         assert result == None
 
 
 class TestContentDirectory:
-
     def test_remove_sonos_playlist_success(self, moco):
         moco.contentDirectory.reset_mock()
         moco.contentDirectory.return_value = True
-        result = moco.remove_sonos_playlist('SQ:10')
+        result = moco.remove_sonos_playlist("SQ:10")
         moco.contentDirectory.DestroyObject.assert_called_once_with(
-            [('ObjectID', 'SQ:10')]
+            [("ObjectID", "SQ:10")]
         )
         assert result
 
 
 class TestRenderingControl:
-
     def test_soco_mute(self, moco):
-        moco.renderingControl.GetMute.return_value = {'CurrentMute': '1'}
+        moco.renderingControl.GetMute.return_value = {"CurrentMute": "1"}
         assert moco.mute
         moco.renderingControl.reset_mock()
-        moco.renderingControl.GetMute.return_value = {'CurrentMute': '0'}
+        moco.renderingControl.GetMute.return_value = {"CurrentMute": "0"}
         assert not moco.mute
         moco.renderingControl.GetMute.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
         moco.mute = False
         moco.renderingControl.SetMute.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'),
-                ('DesiredMute', '0')]
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredMute", "0")]
         )
         moco.renderingControl.reset_mock()
         moco.mute = True
         moco.renderingControl.SetMute.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'),
-                ('DesiredMute', '1')]
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredMute", "1")]
         )
 
-    @pytest.mark.parametrize('volume', [1, 4, 10, 100])
+    @pytest.mark.parametrize("volume", [1, 4, 10, 100])
     def test_soco_volume(self, moco, volume):
-        moco.renderingControl.GetVolume.return_value = {
-            'CurrentVolume': volume}
+        moco.renderingControl.GetVolume.return_value = {"CurrentVolume": volume}
         assert moco.volume == volume
         moco.renderingControl.GetVolume.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
         moco.renderingControl.reset_mock()
 
-    @pytest.mark.parametrize('vol_set, vol_called', [
-        (-120, 0),
-        (-10, 0),
-        (0, 0),
-        (5, 5),
-        (99, 99),
-        (100, 100),
-        (110, 100),
-        (300, 100)
-    ])
+    @pytest.mark.parametrize(
+        "vol_set, vol_called",
+        [
+            (-120, 0),
+            (-10, 0),
+            (0, 0),
+            (5, 5),
+            (99, 99),
+            (100, 100),
+            (110, 100),
+            (300, 100),
+        ],
+    )
     def soco_volume_set(self, moco, vol_set, vol_called):
         moco.volume = vol_set
         moco.renderingControl.SetVolume.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'),
-                ('DesiredVolume', vol_called)]
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredVolume", vol_called)]
         )
 
     def test_soco_ramp_to_volume(self, moco):
-        moco.renderingControl.RampToVolume.return_value = {'RampTime': '12'}
+        moco.renderingControl.RampToVolume.return_value = {"RampTime": "12"}
         ramp_time = moco.ramp_to_volume(15)
         moco.renderingControl.RampToVolume.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'),
-             ('RampType', 'SLEEP_TIMER_RAMP_TYPE'), ('DesiredVolume', 15),
-             ('ResetVolumeAfter', False), ('ProgramURI', '')]
+            [
+                ("InstanceID", 0),
+                ("Channel", "Master"),
+                ("RampType", "SLEEP_TIMER_RAMP_TYPE"),
+                ("DesiredVolume", 15),
+                ("ResetVolumeAfter", False),
+                ("ProgramURI", ""),
+            ]
         )
         assert ramp_time == 12
 
     def test_set_relative_volume(self, moco):
-        moco.renderingControl.SetRelativeVolume.return_value = {'NewVolume': '75'}
+        moco.renderingControl.SetRelativeVolume.return_value = {"NewVolume": "75"}
         new_volume = moco.set_relative_volume(25)
         moco.renderingControl.SetRelativeVolume.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'), ('Adjustment', 25)]
+            [("InstanceID", 0), ("Channel", "Master"), ("Adjustment", 25)]
         )
         assert new_volume == 75
 
     def test_soco_treble(self, moco):
-        moco.renderingControl.GetTreble.return_value = {'CurrentTreble': '15'}
+        moco.renderingControl.GetTreble.return_value = {"CurrentTreble": "15"}
         assert moco.treble == 15
         moco.renderingControl.GetTreble.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
-        moco.treble = '10'
+        moco.treble = "10"
         moco.renderingControl.SetTreble.assert_called_once_with(
-            [('InstanceID', 0),
-             ('DesiredTreble', 10)]
+            [("InstanceID", 0), ("DesiredTreble", 10)]
         )
 
     def test_soco_loudness(self, moco):
-        moco.renderingControl.GetLoudness.return_value = {
-            'CurrentLoudness': '1'}
+        moco.renderingControl.GetLoudness.return_value = {"CurrentLoudness": "1"}
         assert moco.loudness
         moco.renderingControl.GetLoudness.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master')]
+            [("InstanceID", 0), ("Channel", "Master")]
         )
         moco.loudness = False
         moco.renderingControl.SetLoudness.assert_called_once_with(
-            [('InstanceID', 0), ('Channel', 'Master'),
-             ('DesiredLoudness', '0')]
+            [("InstanceID", 0), ("Channel", "Master"), ("DesiredLoudness", "0")]
         )
 
     def test_soco_balance(self, moco):
         # GetVolume is called twice, once for each of the left
         # and right channels
-        moco.renderingControl.GetVolume.return_value = {
-            'CurrentVolume': '100'}
+        moco.renderingControl.GetVolume.return_value = {"CurrentVolume": "100"}
         assert moco.balance == (100, 100)
         moco.renderingControl.GetVolume.assert_any_call(
-            [('InstanceID', 0),
-             ('Channel', 'LF')]
+            [("InstanceID", 0), ("Channel", "LF")]
         )
         moco.renderingControl.GetVolume.assert_any_call(
-            [('InstanceID', 0),
-             ('Channel', 'RF'),]
+            [("InstanceID", 0), ("Channel", "RF"),]
         )
         # SetVolume is called twice, once for each of the left
         # and right channels
         moco.balance = (0, 100)
         moco.renderingControl.SetVolume.assert_any_call(
-            [('InstanceID', 0),
-             ('Channel', 'LF'),
-             ('DesiredVolume', 0)]
+            [("InstanceID", 0), ("Channel", "LF"), ("DesiredVolume", 0)]
         )
         moco.renderingControl.SetVolume.assert_any_call(
-            [('InstanceID', 0),
-             ('Channel', 'RF'),
-             ('DesiredVolume', 100)]
+            [("InstanceID", 0), ("Channel", "RF"), ("DesiredVolume", 100)]
         )
 
 
 class TestDeviceProperties:
-
     def test_soco_status_light(self, moco):
-        moco.deviceProperties.GetLEDState.return_value = {
-            'CurrentLEDState': 'On'}
+        moco.deviceProperties.GetLEDState.return_value = {"CurrentLEDState": "On"}
         assert moco.status_light
-        moco.deviceProperties.GetLEDState.return_value = {
-            'CurrentLEDState': 'Off'}
+        moco.deviceProperties.GetLEDState.return_value = {"CurrentLEDState": "Off"}
         assert not moco.status_light
         moco.deviceProperties.GetLEDState.assert_called_with()
         moco.status_light = False
         moco.deviceProperties.SetLEDState.assert_called_once_with(
-            [('DesiredLEDState', 'Off')])
+            [("DesiredLEDState", "Off")]
+        )
         moco.status_light = True
         moco.deviceProperties.SetLEDState.assert_called_with(
-            [('DesiredLEDState', 'On')]
+            [("DesiredLEDState", "On")]
         )
 
     def test_soco_set_player_name(self, moco):
-        moco.player_name = 'μИⅠℂ☺ΔЄ💋'
+        moco.player_name = "μИⅠℂ☺ΔЄ💋"
         moco.deviceProperties.SetZoneAttributes.assert_called_once_with(
-            [('DesiredZoneName', 'μИⅠℂ☺ΔЄ💋'),
-                ('DesiredIcon', ''),
-                ('DesiredConfiguration', '')]
+            [
+                ("DesiredZoneName", "μИⅠℂ☺ΔЄ💋"),
+                ("DesiredIcon", ""),
+                ("DesiredConfiguration", ""),
+            ]
         )
 
 
 class TestZoneGroupTopology:
-
     def test_soco_uid(self, moco_zgs):
-        assert moco_zgs.uid == 'RINCON_000XXX1400'
+        assert moco_zgs.uid == "RINCON_000XXX1400"
 
     def test_soco_is_visible(self, moco_zgs):
         assert moco_zgs.is_visible
@@ -1171,7 +1195,7 @@ class TestZoneGroupTopology:
         # g.members is parsed from the XML.
         for speaker in g.members:
             speaker.zoneGroupTopology.GetZoneGroupState.return_value = {
-                'ZoneGroupState': ZGS
+                "ZoneGroupState": ZGS
             }
         assert g.label == "Kitchen, Living Room"
 
@@ -1181,62 +1205,62 @@ class TestZoneGroupTopology:
         # g.members is parsed from the XML.
         for speaker in g.members:
             speaker.zoneGroupTopology.GetZoneGroupState.return_value = {
-                'ZoneGroupState': ZGS
+                "ZoneGroupState": ZGS
             }
         assert g.short_label == "Kitchen + 1"
 
     def test_group_volume(self, moco_zgs):
         g = moco_zgs.group
         c = moco_zgs.group.coordinator
-        c.groupRenderingControl.GetGroupVolume.return_value = {
-            'CurrentVolume': 50
-        }
+        c.groupRenderingControl.GetGroupVolume.return_value = {"CurrentVolume": 50}
         assert g.volume == 50
         c.groupRenderingControl.GetGroupVolume.assert_called_once_with(
-            [('InstanceID', 0)]
+            [("InstanceID", 0)]
         )
         g.volume = 75
         c.groupRenderingControl.SetGroupVolume.assert_called_once_with(
-            [('InstanceID', 0), ('DesiredVolume', 75)]
+            [("InstanceID", 0), ("DesiredVolume", 75)]
         )
 
     def test_group_mute(self, moco_zgs):
         g = moco_zgs.group
         c = moco_zgs.group.coordinator
-        c.groupRenderingControl.GetGroupMute.return_value = {
-            'CurrentMute': '0'
-        }
+        c.groupRenderingControl.GetGroupMute.return_value = {"CurrentMute": "0"}
         assert g.mute is False
         c.groupRenderingControl.GetGroupMute.assert_called_once_with(
-            [('InstanceID', 0)]
+            [("InstanceID", 0)]
         )
         g.mute = True
         c.groupRenderingControl.SetGroupMute.assert_called_once_with(
-            [('InstanceID', 0), ('DesiredMute', '1')]
+            [("InstanceID", 0), ("DesiredMute", "1")]
         )
 
     def test_set_relative_group_volume(self, moco_zgs):
         g = moco_zgs.group
         c = moco_zgs.group.coordinator
         c.groupRenderingControl.SetRelativeGroupVolume.return_value = {
-            'NewVolume': '75'
+            "NewVolume": "75"
         }
         new_volume = g.set_relative_volume(25)
         c.groupRenderingControl.SetRelativeGroupVolume.assert_called_once_with(
-            [('InstanceID', 0), ('Adjustment', 25)]
+            [("InstanceID", 0), ("Adjustment", 25)]
         )
         assert new_volume == 75
 
 
 def test_only_on_master_true(moco_only_on_master):
-    with mock.patch('soco.SoCo.is_coordinator', new_callable=mock.PropertyMock) as is_coord:
+    with mock.patch(
+        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
+    ) as is_coord:
         is_coord.return_value = True
         moco_only_on_master.play()
         is_coord.assert_called_once_with()
 
 
 def test_not_on_master_false(moco_only_on_master):
-    with mock.patch('soco.SoCo.is_coordinator', new_callable=mock.PropertyMock) as is_coord:
+    with mock.patch(
+        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
+    ) as is_coord:
         is_coord.return_value = False
         with pytest.raises(SoCoSlaveException):
             moco_only_on_master.play()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -10,27 +10,29 @@ from soco import discover
 from soco import config
 from soco.discovery import any_soco, by_name
 
-IP_ADDR = '192.168.1.101'
+IP_ADDR = "192.168.1.101"
 TIMEOUT = 5
+
 
 class TestDiscover:
     def test_discover(self, monkeypatch):
         # Create a fake socket, whose data is always a certain string
-        monkeypatch.setattr('socket.socket', Mock())
+        monkeypatch.setattr("socket.socket", Mock())
         sock = socket.socket.return_value
         sock.recvfrom.return_value = (
-            b'SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)', [IP_ADDR]
+            b"SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)",
+            [IP_ADDR],
         )  # (data, # address)
         # Each time gethostbyname is called, it gets a different value
-        monkeypatch.setattr('socket.gethostbyname',
-            Mock(side_effect=['192.168.1.15', '192.168.1.16']))
-        # Stop getfqdn from working, to avoud network access
-        monkeypatch.setattr('socket.getfqdn', Mock())
-        # prevent creation of soco instances
-        monkeypatch.setattr('soco.config.SOCO_CLASS', Mock())
-        # Fake return value for select
         monkeypatch.setattr(
-            'select.select', Mock(return_value = ([sock], 1, 1)))
+            "socket.gethostbyname", Mock(side_effect=["192.168.1.15", "192.168.1.16"])
+        )
+        # Stop getfqdn from working, to avoud network access
+        monkeypatch.setattr("socket.getfqdn", Mock())
+        # prevent creation of soco instances
+        monkeypatch.setattr("soco.config.SOCO_CLASS", Mock())
+        # Fake return value for select
+        monkeypatch.setattr("select.select", Mock(return_value=([sock], 1, 1)))
 
         # set timeout
         TIMEOUT = 2
@@ -39,20 +41,17 @@ class TestDiscover:
         # 192.168.1.15 and 3 to 192.168.1.15)
         assert sock.sendto.call_count == 9
         # select called with the relevant timeout
-        select.select.assert_called_with(
-            [sock, sock, sock], [], [], min(TIMEOUT, 0.1))
+        select.select.assert_called_with([sock, sock, sock], [], [], min(TIMEOUT, 0.1))
         # SoCo should be created with the IP address received
         config.SOCO_CLASS.assert_called_with(IP_ADDR)
 
         # Now test include_visible parameter. include_invisible=True should
         # result in calling SoCo.all_zones etc
         # Reset gethostbyname, to always return the same value
-        monkeypatch.setattr('socket.gethostbyname',
-            Mock(return_value='192.168.1.15'))
-        config.SOCO_CLASS.return_value = Mock(
-            all_zones='ALL', visible_zones='VISIBLE')
-        assert discover(include_invisible=True) == 'ALL'
-        assert discover(include_invisible=False) == 'VISIBLE'
+        monkeypatch.setattr("socket.gethostbyname", Mock(return_value="192.168.1.15"))
+        config.SOCO_CLASS.return_value = Mock(all_zones="ALL", visible_zones="VISIBLE")
+        assert discover(include_invisible=True) == "ALL"
+        assert discover(include_invisible=False) == "VISIBLE"
 
         # if select does not return within timeout SoCo should not be called
         # at all

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5,9 +5,7 @@ from __future__ import unicode_literals
 
 import pytest
 
-from soco.events_base import (
-    Event, parse_event_xml
-)
+from soco.events_base import Event, parse_event_xml
 
 
 DUMMY_EVENT = """
@@ -70,14 +68,14 @@ DUMMY_EVENT = """
 
 def test_event_object():
     # Basic initialisation
-    dummy_event = Event('123', '456', 'dummy', 123456.7, {'zone': 'kitchen'})
-    assert dummy_event.sid == '123'
-    assert dummy_event.seq == '456'
+    dummy_event = Event("123", "456", "dummy", 123456.7, {"zone": "kitchen"})
+    assert dummy_event.sid == "123"
+    assert dummy_event.seq == "456"
     assert dummy_event.timestamp == 123456.7
-    assert dummy_event.service == 'dummy'
-    assert dummy_event.variables == {'zone': 'kitchen'}
+    assert dummy_event.service == "dummy"
+    assert dummy_event.variables == {"zone": "kitchen"}
     # attribute access
-    assert dummy_event.zone == 'kitchen'
+    assert dummy_event.zone == "kitchen"
     # Should not access non-existent attributes
     with pytest.raises(AttributeError):
         var = dummy_event.non_existent
@@ -90,6 +88,6 @@ def test_event_object():
 
 def test_event_parsing():
     event_dict = parse_event_xml(DUMMY_EVENT)
-    assert event_dict['zone_group_state']
-    assert event_dict['alarm_run_sequence'] == 'RINCON_000EXXXXXX0:56:0'
-    assert event_dict['zone_group_id'] == "RINCON_000XXXX01400:57"
+    assert event_dict["zone_group_state"]
+    assert event_dict["alarm_run_sequence"] == "RINCON_000EXXXXXX0:56:0"
+    assert event_dict["zone_group_id"] == "RINCON_000XXXX01400:57"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,7 +39,7 @@ from soco.exceptions import SoCoUPnPException
 pytestmark = pytest.mark.integration
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.yield_fixture(scope="session")
 def soco(request):
     """Set up and tear down the soco fixture used by all tests."""
     # Get the ip address from the command line, and create the soco object
@@ -50,16 +50,22 @@ def soco(request):
     soco_instance = soco_module.SoCo(ip)
     # Check the device is playing and has items in the queue
     if len(soco_instance.get_queue()) == 0:
-        pytest.fail('Integration tests on the SoCo class must be run '
-                    'with at least 1 item in the playlist.')
+        pytest.fail(
+            "Integration tests on the SoCo class must be run "
+            "with at least 1 item in the playlist."
+        )
 
     transport_info = soco_instance.get_current_transport_info()
-    if transport_info['current_transport_state'] != 'PLAYING':
-        pytest.fail('Integration tests on the SoCo class must be run '
-                    'with the Sonos unit playing.')
+    if transport_info["current_transport_state"] != "PLAYING":
+        pytest.fail(
+            "Integration tests on the SoCo class must be run "
+            "with the Sonos unit playing."
+        )
     # Save the device's state
-    state = {'queue': soco_instance.get_queue(0, 1000),
-             'current_track_info': soco_instance.get_current_track_info()}
+    state = {
+        "queue": soco_instance.get_queue(0, 1000),
+        "current_track_info": soco_instance.get_current_track_info(),
+    }
 
     # Yield the device to the test function
     yield soco_instance
@@ -67,11 +73,12 @@ def soco(request):
     # Tear down. Restore state
     soco_instance.stop()
     soco_instance.clear_queue()
-    for track in state['queue']:
+    for track in state["queue"]:
         soco_instance.add_to_queue(track)
     soco_instance.play_from_queue(
-        int(state['current_track_info']['playlist_position']) - 1)
-    soco_instance.seek(state['current_track_info']['position'])
+        int(state["current_track_info"]["playlist_position"]) - 1
+    )
+    soco_instance.seek(state["current_track_info"]["position"])
     soco_instance.play()
 
 
@@ -208,8 +215,9 @@ class TestMute(object):
     def test(self, soco):
         """Test if the mute method works."""
         old = soco.mute
-        assert old is False, ('The unit should not be muted when running '
-                              'the unit tests.')
+        assert old is False, (
+            "The unit should not be muted when running " "the unit tests."
+        )
         soco.mute = True
         wait()
         new = soco.mute
@@ -224,9 +232,13 @@ class TestGetCurrentTransportInfo(object):
 
     # The values in this list must be kept up to date with the values in
     # the test doc string
-    transport_info_keys = sorted(['current_transport_status',
-                                  'current_transport_state',
-                                  'current_transport_speed'])
+    transport_info_keys = sorted(
+        [
+            "current_transport_status",
+            "current_transport_state",
+            "current_transport_speed",
+        ]
+    )
 
     def test(self, soco):
         """ Test if the return value is a dictionary that contains the keys:
@@ -248,45 +260,45 @@ class TestTransport(object):
         """Test if the pause and play methods work."""
         soco.pause()
         wait(1)
-        on_pause = soco.get_current_transport_info()['current_transport_state']
-        assert on_pause == 'PAUSED_PLAYBACK'
+        on_pause = soco.get_current_transport_info()["current_transport_state"]
+        assert on_pause == "PAUSED_PLAYBACK"
         soco.play()
         wait(1)
-        on_play = soco.get_current_transport_info()['current_transport_state']
-        assert on_play == 'PLAYING'
+        on_play = soco.get_current_transport_info()["current_transport_state"]
+        assert on_play == "PLAYING"
 
     def test_stop(self, soco):
         """Test if the stop method works."""
         soco.stop()
         wait(1)
-        new = soco.get_current_transport_info()['current_transport_state']
-        assert new == 'STOPPED'
+        new = soco.get_current_transport_info()["current_transport_state"]
+        assert new == "STOPPED"
         soco.play()
         wait(1)
-        on_play = soco.get_current_transport_info()['current_transport_state']
-        assert on_play == 'PLAYING'
+        on_play = soco.get_current_transport_info()["current_transport_state"]
+        assert on_play == "PLAYING"
 
     def test_seek_valid(self, soco):
         """Test if the seek method works with valid input."""
-        original_position = soco.get_current_track_info()['position']
+        original_position = soco.get_current_track_info()["position"]
         # Format 1
-        soco.seek('0:00:00')
+        soco.seek("0:00:00")
         wait()
-        position = soco.get_current_track_info()['position']
-        assert position in ['0:00:00', '0:00:01']
+        position = soco.get_current_track_info()["position"]
+        assert position in ["0:00:00", "0:00:01"]
         # Reset and format 2
         soco.seek(original_position)
-        soco.seek('00:00:00')
+        soco.seek("00:00:00")
         wait()
-        position = soco.get_current_track_info()['position']
-        assert position in ['0:00:00', '0:00:01']
+        position = soco.get_current_track_info()["position"]
+        assert position in ["0:00:00", "0:00:01"]
         # Clean up
         soco.seek(original_position)
         wait()
 
     def test_seek_invald(self, soco):
         """Test if the seek method properly fails with invalid input."""
-        for string in ['invalid_time_string', '5:12', '6', 'aa:aa:aa']:
+        for string in ["invalid_time_string", "5:12", "6", "aa:aa:aa"]:
             with pytest.raises(ValueError):
                 soco.seek(string)
 
@@ -294,9 +306,19 @@ class TestTransport(object):
 class TestGetCurrentTrackInfo(object):
     """Integration test for the get_current_track_info method."""
 
-    info_keys = sorted(['album', 'artist', 'title', 'uri', 'metadata',
-                        'playlist_position', 'duration', 'album_art',
-                        'position'])
+    info_keys = sorted(
+        [
+            "album",
+            "artist",
+            "title",
+            "uri",
+            "metadata",
+            "playlist_position",
+            "duration",
+            "album_art",
+            "position",
+        ]
+    )
 
     def test_get(self, soco):
         """ Test is the return value is a dictinary and contains the following
@@ -313,9 +335,17 @@ class TestGetSpeakerInfo(object):
 
     # The values in this list must be kept up to date with the values in
     # the test doc string
-    info_keys = sorted(['zone_name', 'zone_icon', 'uid',
-                        'serial_number', 'software_version',
-                        'hardware_version', 'mac_address'])
+    info_keys = sorted(
+        [
+            "zone_name",
+            "zone_icon",
+            "uid",
+            "serial_number",
+            "software_version",
+            "hardware_version",
+            "mac_address",
+        ]
+    )
 
     def test(self, soco):
         """ Test if the return value is a dictionary that contains the keys:
@@ -328,6 +358,7 @@ class TestGetSpeakerInfo(object):
         for _, value in speaker_info.items():
             assert value is not None
 
+
 # TODO: test GetSpeakersIp
 
 
@@ -336,8 +367,9 @@ class TestGetQueue(object):
 
     # The values in this list must be kept up to date with the values in
     # the test doc string
-    queue_element_keys = sorted(['album', 'creator', 'resources',
-                                 'album_art_uri', 'title'])
+    queue_element_keys = sorted(
+        ["album", "creator", "resources", "album_art_uri", "title"]
+    )
 
     def test_get(self, soco):
         """ Test is return value is a list of DidlMusicTracks and if each of
@@ -379,8 +411,8 @@ class TestRemoveFromQueue(object):
         wait()
         new_queue = soco.get_queue()
         assert old_queue != new_queue, (
-            'No difference between '
-            'queues before and after removing the last item')
+            "No difference between " "queues before and after removing the last item"
+        )
         assert len(new_queue) == len(old_queue) - 1
 
 
@@ -388,16 +420,15 @@ class TestSonosPlaylist(object):
     """Integration tests for Sonos Playlist Management."""
 
     existing_playlists = None
-    playlist_name = 'zSocoTestPlayList42'
+    playlist_name = "zSocoTestPlayList42"
 
     @pytest.yield_fixture(autouse=True)
     def restore_sonos_playlists(self, soco):
         """A fixture which cleans up after each sonos playlist test."""
         if self.existing_playlists is None:
             self.existing_playlists = soco.get_sonos_playlists()
-            if self.playlist_name in [x.title
-                                      for x in self.existing_playlists]:
-                msg = '%s is an existing playlist.' % self.playlist_name
+            if self.playlist_name in [x.title for x in self.existing_playlists]:
+                msg = "%s is an existing playlist." % self.playlist_name
                 pytest.fail(msg)
 
         yield
@@ -451,12 +482,11 @@ class TestSonosPlaylist(object):
         """Test attempting to remove a Sonos playlist using a bad id."""
         # junky bad
         with pytest.raises(SoCoUPnPException):
-            soco.remove_sonos_playlist('SQ:-7')
+            soco.remove_sonos_playlist("SQ:-7")
         # realistic non-existing
-        hpl_i = max([int(x.item_id.split(':')[1])
-                     for x in soco.get_sonos_playlists()])
+        hpl_i = max([int(x.item_id.split(":")[1]) for x in soco.get_sonos_playlists()])
         with pytest.raises(SoCoUPnPException):
-            soco.remove_sonos_playlist('SQ:{}'.format(hpl_i + 1))
+            soco.remove_sonos_playlist("SQ:{}".format(hpl_i + 1))
 
 
 class TestTimer(object):
@@ -476,13 +506,18 @@ class TestTimer(object):
         """Test setting the timer"""
         assert soco.set_sleep_timer(7200) is None
         result = soco.get_sleep_timer()
-        if not any(result == s for s in [ 7200, 7199, 7198 ]):
-            pytest.fail("Set timer to 7200, but sonos reports back time as %s" % result['RemainingSleepTimerDuration'])
+        if not any(result == s for s in [7200, 7199, 7198]):
+            pytest.fail(
+                "Set timer to 7200, but sonos reports back time as %s"
+                % result["RemainingSleepTimerDuration"]
+            )
+
 
 class TestReorderSonosPlaylist(object):
     """Integration tests for Sonos Playlist Management."""
+
     existing_playlists = None
-    playlist_name = 'zSocoTestPlayList42'
+    playlist_name = "zSocoTestPlayList42"
     test_playlist = None
     queue_length = None
 
@@ -492,27 +527,23 @@ class TestReorderSonosPlaylist(object):
         if self.existing_playlists is None:
             self.existing_playlists = soco.get_sonos_playlists()
         if self.playlist_name in [x.title for x in self.existing_playlists]:
-            msg = '%s is an existing playlist.' % self.playlist_name
+            msg = "%s is an existing playlist." % self.playlist_name
             pytest.fail(msg)
 
         queue_list = soco.get_queue()
         if len(queue_list) < 2:
-            msg = 'You must have 3 or more items in your queue for testing.'
+            msg = "You must have 3 or more items in your queue for testing."
             pytest.fail(msg)
         playlist = soco.create_sonos_playlist_from_queue(self.playlist_name)
         self.__class__.queue_length = soco.queue_size
         self.__class__.test_playlist = playlist
         yield
 
-        soco.contentDirectory.DestroyObject(
-            [('ObjectID', self.test_playlist.item_id)]
-        )
+        soco.contentDirectory.DestroyObject([("ObjectID", self.test_playlist.item_id)])
 
     def _reset_spl_contents(self, soco):
         """Ensure test playlist matches queue for each test."""
-        soco.contentDirectory.DestroyObject(
-            [('ObjectID', self.test_playlist.item_id)]
-        )
+        soco.contentDirectory.DestroyObject([("ObjectID", self.test_playlist.item_id)])
         playlist = soco.create_sonos_playlist_from_queue(self.playlist_name)
         self.__class__.test_playlist = playlist
         return playlist, self.__class__.queue_length
@@ -520,15 +551,17 @@ class TestReorderSonosPlaylist(object):
     def test_reverse_track_order(self, soco):
         """Test reversing the tracks in the Sonos playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        tracks = ','.join([str(x) for x in reversed(range(num_tracks))])
-        new_pos = ','.join([str(x) for x in range(num_tracks)])
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        tracks = ",".join([str(x) for x in reversed(range(num_tracks))])
+        new_pos = ",".join([str(x) for x in range(num_tracks)])
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == 0
-        assert response['length'] == num_tracks
-        assert response['update_id'] != 0
+        assert response["change"] == 0
+        assert response["length"] == num_tracks
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         for s_item, q_item in zip(spl, reversed(soco.get_queue())):
             assert s_item.resources[0].uri == q_item.resources[0].uri
@@ -537,16 +570,22 @@ class TestReorderSonosPlaylist(object):
         """Test a use case in doc string. Swapping the positions of the first
             two tracks in the Sonos playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        tracks = [0, ]
-        new_pos = [1, ]
+        tracks = [
+            0,
+        ]
+        new_pos = [
+            1,
+        ]
 
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == 0
-        assert response['length'] == num_tracks
-        assert response['update_id'] != 0
+        assert response["change"] == 0
+        assert response["length"] == num_tracks
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[1].resources[0].uri
@@ -560,16 +599,22 @@ class TestReorderSonosPlaylist(object):
     def test_remove_first_track(self, soco):
         """Test removing first track from Sonos Playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        tracks = [0, ]
-        new_pos = [None, ]
+        tracks = [
+            0,
+        ]
+        new_pos = [
+            None,
+        ]
 
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks - 1
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks - 1
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         # FIXME remove the list on queue() call, when the deprecated
         # __getitem__ on ListOfMusicInfoItems is removed
@@ -580,15 +625,17 @@ class TestReorderSonosPlaylist(object):
     def test_remove_first_track_full(self, soco):
         """Test removing first track from Sonos Playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        tracks = [0] + list(range(num_tracks - 1))        # [0, 0, 1, ..., n-1]
-        new_pos = [None, ] + list(range(num_tracks - 1))  # [None, 0, ..., n-1]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        tracks = [0] + list(range(num_tracks - 1))  # [0, 0, 1, ..., n-1]
+        new_pos = [None,] + list(range(num_tracks - 1))  # [None, 0, ..., n-1]
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks - 1
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks - 1
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         # FIXME remove the list on queue() call, when the deprecated
         # __getitem__ on ListOfMusicInfoItems is removed
@@ -600,14 +647,18 @@ class TestReorderSonosPlaylist(object):
         """Test removing last track from Sonos Playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         tracks = range(num_tracks)
-        new_pos = list(range(num_tracks - 1)) + [None, ]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        new_pos = list(range(num_tracks - 1)) + [
+            None,
+        ]
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks - 1
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks - 1
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         # FIXME remove the list on queue() call, when the deprecated
         # __getitem__ on ListOfMusicInfoItems is removed
@@ -621,33 +672,36 @@ class TestReorderSonosPlaylist(object):
         ndx = int(num_tracks / 2)
         tracks = [ndx]
         new_pos = [None]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks - 1
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks - 1
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         del que[ndx]
         for s_item, q_item in zip(spl, que):
             assert s_item.resources[0].uri == q_item.resources[0].uri
 
-    def test_remove_some_tracks(self, soco):    # pylint: disable=R0914
+    def test_remove_some_tracks(self, soco):  # pylint: disable=R0914
         """Test removing some tracks from Sonos Playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         # get rid of the even numbered tracks
-        tracks = sorted([x for x in range(num_tracks) if not x & 1],
-                        reverse=True)
+        tracks = sorted([x for x in range(num_tracks) if not x & 1], reverse=True)
         new_pos = [None for _ in tracks]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1 * len(new_pos)
-        assert response['length'] == num_tracks + response['change']
-        assert response['update_id'] != 0
+        assert response["change"] == -1 * len(new_pos)
+        assert response["length"] == num_tracks + response["change"]
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         for ndx in tracks:
@@ -661,14 +715,16 @@ class TestReorderSonosPlaylist(object):
         # get rid of the even numbered tracks
         tracks = sorted(range(num_tracks), reverse=True)
         new_pos = [None for _ in tracks]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1 * num_tracks
-        assert response['length'] == num_tracks + response['change']
-        assert response['length'] == 0
-        assert response['update_id'] != 0
+        assert response["change"] == -1 * num_tracks
+        assert response["length"] == num_tracks + response["change"]
+        assert response["length"] == 0
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         assert len(spl) == 0
 
@@ -677,13 +733,15 @@ class TestReorderSonosPlaylist(object):
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         tracks = [1, 2]
         new_pos = [0, None]
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks + response['change']
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks + response["change"]
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[1].resources[0].uri
@@ -693,14 +751,12 @@ class TestReorderSonosPlaylist(object):
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         tracks = sorted(range(num_tracks), reverse=True)
         new_pos = [None for _ in tracks]
-        args = {'sonos_playlist': test_playlist,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {"sonos_playlist": test_playlist, "tracks": tracks, "new_pos": new_pos}
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1 * num_tracks
-        assert response['length'] == num_tracks + response['change']
-        assert response['length'] == 0
-        assert response['update_id'] != 0
+        assert response["change"] == -1 * num_tracks
+        assert response["length"] == num_tracks + response["change"]
+        assert response["length"] == 0
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         assert len(spl) == 0
 
@@ -708,31 +764,27 @@ class TestReorderSonosPlaylist(object):
         """Remove all in one op by using strings."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         # we know what we are doing
-        tracks = ','.join([str(x) for x in range(num_tracks)])
-        new_pos = ''
-        args = {'sonos_playlist': test_playlist,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        tracks = ",".join([str(x) for x in range(num_tracks)])
+        new_pos = ""
+        args = {"sonos_playlist": test_playlist, "tracks": tracks, "new_pos": new_pos}
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1 * num_tracks
-        assert response['length'] == num_tracks + response['change']
-        assert response['length'] == 0
-        assert response['update_id'] != 0
+        assert response["change"] == -1 * num_tracks
+        assert response["length"] == num_tracks + response["change"]
+        assert response["length"] == 0
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         assert len(spl) == 0
 
     def test_remove_and_reorder_string(self, soco):
         """test remove then reorder using string arguments."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        tracks = '0,2'      # trackA, trackB, trackC, ...
-        new_pos = ',0'      # trackC, trackB, ...
-        args = {'sonos_playlist': test_playlist,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        tracks = "0,2"  # trackA, trackB, trackC, ...
+        new_pos = ",0"  # trackC, trackB, ...
+        args = {"sonos_playlist": test_playlist, "tracks": tracks, "new_pos": new_pos}
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks + response['change']
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks + response["change"]
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[2].resources[0].uri
@@ -743,13 +795,15 @@ class TestReorderSonosPlaylist(object):
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         tracks = "0"
         new_pos = "1"
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == 0
-        assert response['length'] == num_tracks
-        assert response['update_id'] != 0
+        assert response["change"] == 0
+        assert response["length"] == num_tracks
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[1].resources[0].uri
@@ -765,13 +819,15 @@ class TestReorderSonosPlaylist(object):
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         tracks = 1
         new_pos = 0
-        args = {'sonos_playlist': test_playlist.item_id,
-                'tracks': tracks,
-                'new_pos': new_pos}
+        args = {
+            "sonos_playlist": test_playlist.item_id,
+            "tracks": tracks,
+            "new_pos": new_pos,
+        }
         response = soco.reorder_sonos_playlist(**args)
-        assert response['change'] == 0
-        assert response['length'] == num_tracks
-        assert response['update_id'] != 0
+        assert response["change"] == 0
+        assert response["length"] == num_tracks
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[1].resources[0].uri
@@ -786,10 +842,10 @@ class TestReorderSonosPlaylist(object):
         """Test the clear_sonos_playlist helper function."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
         response = soco.clear_sonos_playlist(test_playlist)
-        assert response['change'] == -1 * num_tracks
-        assert response['length'] == num_tracks + response['change']
-        assert response['length'] == 0
-        assert response['update_id'] != 0
+        assert response["change"] == -1 * num_tracks
+        assert response["length"] == num_tracks + response["change"]
+        assert response["length"] == 0
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         assert len(spl) == 0
 
@@ -797,24 +853,21 @@ class TestReorderSonosPlaylist(object):
         """Test clearing an already empty Sonos playlist."""
         test_playlist, _ = self._reset_spl_contents(soco)
         response = soco.clear_sonos_playlist(test_playlist)
-        assert response['length'] == 0
-        update_id = response['update_id']
-        new_response = soco.clear_sonos_playlist(test_playlist,
-                                                 update_id=update_id)
-        assert new_response['change'] == 0
-        assert new_response['length'] == 0
-        assert new_response['update_id'] == update_id
+        assert response["length"] == 0
+        update_id = response["update_id"]
+        new_response = soco.clear_sonos_playlist(test_playlist, update_id=update_id)
+        assert new_response["change"] == 0
+        assert new_response["length"] == 0
+        assert new_response["update_id"] == update_id
 
     def test_move_in_sonos_playlist(self, soco):
         """Test method move_in_sonos_playlist."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        args = {'sonos_playlist': test_playlist.item_id,
-                'track': 0,
-                'new_pos': 1}
+        args = {"sonos_playlist": test_playlist.item_id, "track": 0, "new_pos": 1}
         response = soco.move_in_sonos_playlist(**args)
-        assert response['change'] == 0
-        assert response['length'] == num_tracks
-        assert response['update_id'] != 0
+        assert response["change"] == 0
+        assert response["length"] == num_tracks
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         que = soco.get_queue()
         assert spl[0].resources[0].uri == que[1].resources[0].uri
@@ -828,12 +881,11 @@ class TestReorderSonosPlaylist(object):
     def test_remove_from_sonos_playlist(self, soco):
         """Test remove_from_sonos_playlist method."""
         test_playlist, num_tracks = self._reset_spl_contents(soco)
-        args = {'sonos_playlist': test_playlist.item_id,
-                'track': 0}
+        args = {"sonos_playlist": test_playlist.item_id, "track": 0}
         response = soco.remove_from_sonos_playlist(**args)
-        assert response['change'] == -1
-        assert response['length'] == num_tracks - 1
-        assert response['update_id'] != 0
+        assert response["change"] == -1
+        assert response["length"] == num_tracks - 1
+        assert response["update_id"] != 0
         spl = soco.music_library.browse(ml_item=test_playlist)
         # FIXME remove the list on queue() call, when the deprecated
         # __getitem__ on ListOfMusicInfoItems is removed
@@ -844,16 +896,15 @@ class TestReorderSonosPlaylist(object):
     def test_get_sonos_playlist_by_attr(self, soco):
         """Test test_get_sonos_playlist_by_attr."""
         test_playlist, _ = self._reset_spl_contents(soco)
-        by_name = soco.get_sonos_playlist_by_attr('title', self.playlist_name)
+        by_name = soco.get_sonos_playlist_by_attr("title", self.playlist_name)
         assert test_playlist.item_id == by_name.item_id
-        by_id = soco.get_sonos_playlist_by_attr('item_id',
-                                                test_playlist.item_id)
+        by_id = soco.get_sonos_playlist_by_attr("item_id", test_playlist.item_id)
         assert test_playlist.item_id == by_id.item_id
         with pytest.raises(AttributeError):
-            soco.get_sonos_playlist_by_attr('fred', 'wilma')
+            soco.get_sonos_playlist_by_attr("fred", "wilma")
 
         with pytest.raises(ValueError):
-            soco.get_sonos_playlist_by_attr('item_id', 'wilma')
+            soco.get_sonos_playlist_by_attr("item_id", "wilma")
 
 
 class TestMusicLibrary(object):
@@ -861,8 +912,15 @@ class TestMusicLibrary(object):
 
     search_types = list(MusicLibrary.SEARCH_TRANSLATION.keys())
     specific_search_methods = (
-        "artists", "album_artists", "albums", "genres", "composers", "tracks",
-        "playlists", "sonos_favorites", "favorite_radio_stations",
+        "artists",
+        "album_artists",
+        "albums",
+        "genres",
+        "composers",
+        "tracks",
+        "playlists",
+        "sonos_favorites",
+        "favorite_radio_stations",
         "favorite_radio_shows",
     )
 

--- a/tests/test_ms_data_structures.py
+++ b/tests/test_ms_data_structures.py
@@ -11,8 +11,14 @@ import pytest
 
 from soco.exceptions import DIDLMetadataError
 from soco.ms_data_structures import (
-    MSAlbum, MSAlbumList, MSArtist, MSArtistTracklist,
-    MSCollection, MSFavorites, MSPlaylist, MSTrack
+    MSAlbum,
+    MSAlbumList,
+    MSArtist,
+    MSArtistTracklist,
+    MSCollection,
+    MSFavorites,
+    MSPlaylist,
+    MSTrack,
 )
 from soco.xml import XML
 
@@ -32,7 +38,7 @@ DIDL_TEMPLATE = """
 </item>
 </DIDL-Lite>
 """
-DIDL_TEMPLATE = DIDL_TEMPLATE.replace('\n', '')
+DIDL_TEMPLATE = DIDL_TEMPLATE.replace("\n", "")
 
 MS_TRACK_SEARCH_XML = """
 <ns0:mediaMetadata xmlns:ns0="http://www.sonos.com/Services/1.1">
@@ -60,33 +66,33 @@ _Image.jpg</ns0:albumArtURI>
 </ns0:trackMetadata>
 </ns0:mediaMetadata>
 """
-MS_TRACK_SEARCH_XML = MS_TRACK_SEARCH_XML.replace('\n', '')
+MS_TRACK_SEARCH_XML = MS_TRACK_SEARCH_XML.replace("\n", "")
 MS_TRACK_SEARCH_DICT = {
-    'can_add_to_favorites': True,
-    'composer': 'M\xd8',
-    'album_id': 'albumid_24125922',
-    'can_skip': True,
-    'uri': 'x-sonos-http:trackid_24125935.mp4?sid=20&flags=32',
-    'item_id': 'trackid_24125935',
-    'item_type': 'track',
-    'extended_id': '00030020trackid_24125935',
-    'duration': 231,
-    'can_play': True,
-    'composer_id': 'artistid_4816276',
-    'description': 'SA_RINCON5127_4542255535',
-    'album': 'Nyt\xe5rsfesten 2014',
-    'title': 'Pilgrim',
-    'artist': 'M\xd8',
-    'album_artist_id': 'artistid_4816276',
-    'album_art_uri': 'http://varnish01.music.aspiro.com/sca/imscale?'
-                     'h=90&w=90&img=/content/sg19/vd00/music/prod/sonyddex'
-                     '/1386109801/A10301A00030834072_20131203071914171/'
-                     'resources/A10301A00030834072_T-10764_Image.jpg',
-    'album_artist': 'M\xd8',
-    'parent_id': '00020064tracksearch:pilgrim',
-    'service_id': 20,
-    'artist_id': 'artistid_4816276',
-    'mime_type': 'audio/aac'
+    "can_add_to_favorites": True,
+    "composer": "M\xd8",
+    "album_id": "albumid_24125922",
+    "can_skip": True,
+    "uri": "x-sonos-http:trackid_24125935.mp4?sid=20&flags=32",
+    "item_id": "trackid_24125935",
+    "item_type": "track",
+    "extended_id": "00030020trackid_24125935",
+    "duration": 231,
+    "can_play": True,
+    "composer_id": "artistid_4816276",
+    "description": "SA_RINCON5127_4542255535",
+    "album": "Nyt\xe5rsfesten 2014",
+    "title": "Pilgrim",
+    "artist": "M\xd8",
+    "album_artist_id": "artistid_4816276",
+    "album_art_uri": "http://varnish01.music.aspiro.com/sca/imscale?"
+    "h=90&w=90&img=/content/sg19/vd00/music/prod/sonyddex"
+    "/1386109801/A10301A00030834072_20131203071914171/"
+    "resources/A10301A00030834072_T-10764_Image.jpg",
+    "album_artist": "M\xd8",
+    "parent_id": "00020064tracksearch:pilgrim",
+    "service_id": 20,
+    "artist_id": "artistid_4816276",
+    "mime_type": "audio/aac",
 }
 MS_ALBUM_SEARCH_XML = """
 <ns0:mediaCollection readOnly="true"
@@ -103,23 +109,23 @@ MS_ALBUM_SEARCH_XML = """
 </ns0:albumArtURI>
 </ns0:mediaCollection>
 """
-MS_ALBUM_SEARCH_XML = MS_ALBUM_SEARCH_XML.replace('\n', '')
+MS_ALBUM_SEARCH_XML = MS_ALBUM_SEARCH_XML.replace("\n", "")
 MS_ALBUM_SEARCH_DICT = {
-    'can_add_to_favorites': True,
-    'description': 'SA_RINCON5127_4542255535',
-    'artist': 'tv\xb72',
-    'title': 'Greatest De Unge \xc5r',
-    'album_art_uri': 'http://varnish01.music.aspiro.com/sca/imscale?h=90&w=90'
-                     '&img=/content/music8/prod/sonybmg/content/'
-                     '00000000000002304180/000/000/000/000/056/501/97/'
-                     '00000000000005650197-1000x1000_72dpi_RGB_100Q.jpg',
-    'uri': 'x-rincon-cpcontainer:0004002calbumid_5738780',
-    'parent_id': '00020064albumsearch:de unge',
-    'item_type': 'album',
-    'extended_id': '0004002calbumid_5738780',
-    'item_id': 'albumid_5738780',
-    'service_id': 20,
-    'can_play': True
+    "can_add_to_favorites": True,
+    "description": "SA_RINCON5127_4542255535",
+    "artist": "tv\xb72",
+    "title": "Greatest De Unge \xc5r",
+    "album_art_uri": "http://varnish01.music.aspiro.com/sca/imscale?h=90&w=90"
+    "&img=/content/music8/prod/sonybmg/content/"
+    "00000000000002304180/000/000/000/000/056/501/97/"
+    "00000000000005650197-1000x1000_72dpi_RGB_100Q.jpg",
+    "uri": "x-rincon-cpcontainer:0004002calbumid_5738780",
+    "parent_id": "00020064albumsearch:de unge",
+    "item_type": "album",
+    "extended_id": "0004002calbumid_5738780",
+    "item_id": "albumid_5738780",
+    "service_id": 20,
+    "can_play": True,
 }
 MS_ARTIST_SEARCH_XML = """
 <ns0:mediaCollection readOnly="true"
@@ -133,19 +139,19 @@ MS_ARTIST_SEARCH_XML = """
 artistid=4761386</ns0:albumArtURI>
 </ns0:mediaCollection>
 """
-MS_ARTIST_SEARCH_XML = MS_ARTIST_SEARCH_XML.replace('\n', '')
+MS_ARTIST_SEARCH_XML = MS_ARTIST_SEARCH_XML.replace("\n", "")
 MS_ARTIST_SEARCH_DICT = {
-    'can_add_to_favorites': True,
-    'description': 'SA_RINCON5127_4542255535',
-    'artist': 'Fritjof S\xe5heim',
-    'title': 'Fritjof S\xe5heim',
-    'album_art_uri': 'http://varnish01.music.aspiro.com/im/im?h=42&w=64'
-                     '&artistid=4761386',
-    'parent_id': '00020064artistsearch:Fritjof',
-    'item_type': 'artist',
-    'extended_id': '10050024artistid_4761386',
-    'item_id': 'artistid_4761386',
-    'service_id': 20
+    "can_add_to_favorites": True,
+    "description": "SA_RINCON5127_4542255535",
+    "artist": "Fritjof S\xe5heim",
+    "title": "Fritjof S\xe5heim",
+    "album_art_uri": "http://varnish01.music.aspiro.com/im/im?h=42&w=64"
+    "&artistid=4761386",
+    "parent_id": "00020064artistsearch:Fritjof",
+    "item_type": "artist",
+    "extended_id": "10050024artistid_4761386",
+    "item_id": "artistid_4761386",
+    "service_id": 20,
 }
 MS_PLAYLIST_SEARCH_XML = """
 <ns0:mediaCollection readOnly="true" xmlns:ns0="http://www.sonos.com/Services/1.1">
@@ -160,25 +166,25 @@ MS_PLAYLIST_SEARCH_XML = """
   <ns0:albumArtURI>http://varnish01.music.aspiro.com/im/im?h=160&amp;w=240&amp;rows=1&amp;cols=2&amp;artimg&amp;uuid=133fe1ff-1f16-4300-b440-fb80573f19ce</ns0:albumArtURI>
 </ns0:mediaCollection>
 """
-MS_PLAYLIST_SEARCH_XML = MS_PLAYLIST_SEARCH_XML.replace('\n', '')
+MS_PLAYLIST_SEARCH_XML = MS_PLAYLIST_SEARCH_XML.replace("\n", "")
 MS_PLAYLIST_SEARCH_DICT = {
-    'can_add_to_favorites': True,
-    'description': 'SA_RINCON5127_4542255535',
-    'artist': '39 sange',
-    'title': 'Kunstnerliste: Dans & L\xe6r',
-    'album_art_uri': 'http://varnish01.music.aspiro.com/im/im?h=160&w=240&'
-                     'rows=1&cols=2&artimg&uuid=133fe1ff-1f16-4300-b440-'
-                     'fb80573f19ce',
-    'uri': 'x-rincon-cpcontainer:000d006cplaylistid_133fe1ff-1f16-4300-b440'
-           '-fb80573f19ce',
-    'parent_id': '00020064playlistsearch:Dans &',
-    'item_type': 'albumList',
-    'extended_id': '000d006cplaylistid_133fe1ff-1f16-4300-b440-fb80573f19ce',
-    'item_id': 'playlistid_133fe1ff-1f16-4300-b440-fb80573f19ce',
-    'service_id': 20,
-    'artist_id': 'artistid_0',
-    'can_play': True,
-    'can_enumerate': True
+    "can_add_to_favorites": True,
+    "description": "SA_RINCON5127_4542255535",
+    "artist": "39 sange",
+    "title": "Kunstnerliste: Dans & L\xe6r",
+    "album_art_uri": "http://varnish01.music.aspiro.com/im/im?h=160&w=240&"
+    "rows=1&cols=2&artimg&uuid=133fe1ff-1f16-4300-b440-"
+    "fb80573f19ce",
+    "uri": "x-rincon-cpcontainer:000d006cplaylistid_133fe1ff-1f16-4300-b440"
+    "-fb80573f19ce",
+    "parent_id": "00020064playlistsearch:Dans &",
+    "item_type": "albumList",
+    "extended_id": "000d006cplaylistid_133fe1ff-1f16-4300-b440-fb80573f19ce",
+    "item_id": "playlistid_133fe1ff-1f16-4300-b440-fb80573f19ce",
+    "service_id": 20,
+    "artist_id": "artistid_0",
+    "can_play": True,
+    "can_enumerate": True,
 }
 
 
@@ -186,21 +192,21 @@ class FakeMusicService(object):
     """A fake music service."""
 
     def __init__(self, username):
-        self.description = 'SA_RINCON5127_{}'.format(username)
+        self.description = "SA_RINCON5127_{}".format(username)
         self.service_id = 20
 
     @staticmethod
     def id_to_extended_id(item_id, item_class):
         """ID to extended ID method."""
         id_prefix = {
-            MSTrack: '00030020',
-            MSAlbum: '0004002c',
-            MSArtist: '10050024',
-            MSAlbumList: '000d006c',
-            MSPlaylist: '0006006c',
-            MSArtistTracklist: '100f006c',
+            MSTrack: "00030020",
+            MSAlbum: "0004002c",
+            MSArtist: "10050024",
+            MSAlbumList: "000d006c",
+            MSPlaylist: "0006006c",
+            MSArtistTracklist: "100f006c",
             MSFavorites: None,  # This one is unknown
-            MSCollection: None  # This one is unknown
+            MSCollection: None,  # This one is unknown
         }
         out = id_prefix[item_class]
         if out:
@@ -210,18 +216,17 @@ class FakeMusicService(object):
     @staticmethod
     def form_uri(item_content, item_class):
         """Form the URI."""
-        mime_type_to_extension = {'audio/aac': 'mp4'}
+        mime_type_to_extension = {"audio/aac": "mp4"}
         uris = {
-            MSTrack: 'x-sonos-http:{item_id}.{extension}?sid={service_id}&'
-                     'flags=32',
-            MSAlbum: 'x-rincon-cpcontainer:{extended_id}',
-            MSAlbumList: 'x-rincon-cpcontainer:{extended_id}',
-            MSPlaylist: 'x-rincon-cpcontainer:{extended_id}',
-            MSArtistTracklist: 'x-rincon-cpcontainer:{extended_id}'
+            MSTrack: "x-sonos-http:{item_id}.{extension}?sid={service_id}&" "flags=32",
+            MSAlbum: "x-rincon-cpcontainer:{extended_id}",
+            MSAlbumList: "x-rincon-cpcontainer:{extended_id}",
+            MSPlaylist: "x-rincon-cpcontainer:{extended_id}",
+            MSArtistTracklist: "x-rincon-cpcontainer:{extended_id}",
         }
         extension = None
-        if 'mime_type' in item_content:
-            extension = mime_type_to_extension[item_content['mime_type']]
+        if "mime_type" in item_content:
+            extension = mime_type_to_extension[item_content["mime_type"]]
         out = uris.get(item_class)
         if out:
             # pylint: disable=star-args
@@ -229,7 +234,7 @@ class FakeMusicService(object):
         return out
 
 
-FAKE_MUSIC_SERVICE = FakeMusicService('4542255535')
+FAKE_MUSIC_SERVICE = FakeMusicService("4542255535")
 
 
 def getter_attributes_test(name, from_xml, from_dict, result):
@@ -240,7 +245,7 @@ def getter_attributes_test(name, from_xml, from_dict, result):
 
 def common_tests(class_, xml_, dict_, parent_id, helpers):
     """Common tests for the MS classes."""
-    xml_content = XML.fromstring(xml_.encode('utf8'))
+    xml_content = XML.fromstring(xml_.encode("utf8"))
 
     # MusicServiceItem.from_xml and MusicServiceItem.to_dict
     item_from_xml = class_.from_xml(xml_content, FAKE_MUSIC_SERVICE, parent_id)
@@ -261,36 +266,31 @@ def common_tests(class_, xml_, dict_, parent_id, helpers):
             except NameError:
                 is_str = isinstance(value, str)
             if is_str:
-                dict_encoded[key] = escape(value).\
-                    encode('ascii', 'xmlcharrefreplace').decode('ascii')
+                dict_encoded[key] = (
+                    escape(value).encode("ascii", "xmlcharrefreplace").decode("ascii")
+                )
 
             else:
                 dict_encoded[key] = value
-        didl = DIDL_TEMPLATE.format(item_class=class_.item_class,
-                                    **dict_encoded)
+        didl = DIDL_TEMPLATE.format(item_class=class_.item_class, **dict_encoded)
 
-        assert helpers.compare_xml(
-            item_from_xml.didl_metadata, XML.fromstring(didl)
-        )
-        assert helpers.compare_xml(
-            item_from_dict.didl_metadata, XML.fromstring(didl)
-        )
+        assert helpers.compare_xml(item_from_xml.didl_metadata, XML.fromstring(didl))
+        assert helpers.compare_xml(item_from_dict.didl_metadata, XML.fromstring(didl))
     else:
         with pytest.raises(DIDLMetadataError):
             # pylint: disable=pointless-statement
             item_from_xml.didl_metadata
 
     # Text attributes with mandatory content
-    for name in ['item_id', 'extended_id', 'title', 'service_id']:
-        getter_attributes_test(name, item_from_xml, item_from_dict,
-                               dict_[name])
+    for name in ["item_id", "extended_id", "title", "service_id"]:
+        getter_attributes_test(name, item_from_xml, item_from_dict, dict_[name])
     # Text attributes with voluntary content
-    for name in ['parent_id', 'album_art_uri']:
-        getter_attributes_test(name, item_from_xml, item_from_dict,
-                               dict_.get(name))
+    for name in ["parent_id", "album_art_uri"]:
+        getter_attributes_test(name, item_from_xml, item_from_dict, dict_.get(name))
     # Boolean attribute
-    getter_attributes_test('can_play', item_from_xml, item_from_dict,
-                           bool(dict_.get('can_play')))
+    getter_attributes_test(
+        "can_play", item_from_xml, item_from_dict, bool(dict_.get("can_play"))
+    )
     return item_from_xml, item_from_dict
 
 
@@ -300,13 +300,15 @@ def test_ms_track_search(helpers):
         MSTrack,
         MS_TRACK_SEARCH_XML,
         MS_TRACK_SEARCH_DICT,
-        '00020064tracksearch:pilgrim',
+        "00020064tracksearch:pilgrim",
         helpers,
     )
-    getter_attributes_test('artist', item_from_xml, item_from_dict,
-                           MS_TRACK_SEARCH_DICT.get('artist'))
-    getter_attributes_test('uri', item_from_xml, item_from_dict,
-                           MS_TRACK_SEARCH_DICT['uri'])
+    getter_attributes_test(
+        "artist", item_from_xml, item_from_dict, MS_TRACK_SEARCH_DICT.get("artist")
+    )
+    getter_attributes_test(
+        "uri", item_from_xml, item_from_dict, MS_TRACK_SEARCH_DICT["uri"]
+    )
 
 
 def test_ms_album_search(helpers):
@@ -315,13 +317,15 @@ def test_ms_album_search(helpers):
         MSAlbum,
         MS_ALBUM_SEARCH_XML,
         MS_ALBUM_SEARCH_DICT,
-        '00020064albumsearch:de unge',
+        "00020064albumsearch:de unge",
         helpers,
     )
-    getter_attributes_test('artist', item_from_xml, item_from_dict,
-                           MS_ALBUM_SEARCH_DICT.get('artist'))
-    getter_attributes_test('uri', item_from_xml, item_from_dict,
-                           MS_ALBUM_SEARCH_DICT['uri'])
+    getter_attributes_test(
+        "artist", item_from_xml, item_from_dict, MS_ALBUM_SEARCH_DICT.get("artist")
+    )
+    getter_attributes_test(
+        "uri", item_from_xml, item_from_dict, MS_ALBUM_SEARCH_DICT["uri"]
+    )
 
 
 def test_ms_artist_search(helpers):
@@ -330,7 +334,7 @@ def test_ms_artist_search(helpers):
         MSArtist,
         MS_ARTIST_SEARCH_XML,
         MS_ARTIST_SEARCH_DICT,
-        '00020064artistsearch:Fritjof',
+        "00020064artistsearch:Fritjof",
         helpers,
     )
 
@@ -341,8 +345,9 @@ def test_ms_playlist_search(helpers):
         MSAlbumList,
         MS_PLAYLIST_SEARCH_XML,
         MS_PLAYLIST_SEARCH_DICT,
-        '00020064playlistsearch:Dans &',
+        "00020064playlistsearch:Dans &",
         helpers,
     )
-    getter_attributes_test('uri', item_from_xml, item_from_dict,
-                           MS_PLAYLIST_SEARCH_DICT['uri'])
+    getter_attributes_test(
+        "uri", item_from_xml, item_from_dict, MS_PLAYLIST_SEARCH_DICT["uri"]
+    )

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -7,7 +7,7 @@ import pytest
 from soco import SoCo
 from soco.exceptions import SoCoUPnPException
 
-IP_ADDR = '192.168.1.101'
+IP_ADDR = "192.168.1.101"
 
 
 @pytest.yield_fixture()
@@ -18,14 +18,18 @@ def moco():
     access
     """
     services = (
-        'AVTransport', 'RenderingControl', 'DeviceProperties',
-        'ContentDirectory', 'ZoneGroupTopology')
-    patchers = [mock.patch('soco.core.{}'.format(service))
-                for service in services]
+        "AVTransport",
+        "RenderingControl",
+        "DeviceProperties",
+        "ContentDirectory",
+        "ZoneGroupTopology",
+    )
+    patchers = [mock.patch("soco.core.{}".format(service)) for service in services]
     for patch in patchers:
         patch.start()
-    with mock.patch("soco.SoCo.is_coordinator",
-                    new_callable=mock.PropertyMock) as is_coord:
+    with mock.patch(
+        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
+    ) as is_coord:
         is_coord = True
         yield SoCo(IP_ADDR)
     for patch in reversed(patchers):
@@ -33,26 +37,28 @@ def moco():
 
 
 class TestMusicLibrary:
-
     def test_search_track_no_result(self, moco):
         moco.contentDirectory.reset_mock()
         # Browse returns an exception if the artist can't be found
         # <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>701</errorCode></UPnPError></detail></s:Fault></s:Body></s:Envelope>
         moco.contentDirectory.Browse.side_effect = SoCoUPnPException(
-            "No such object", "701", "error XML")
+            "No such object", "701", "error XML"
+        )
 
         result = moco.music_library.search_track("artist")
 
         assert len(result) == 0
 
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/artist/'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "A:ALBUMARTIST/artist/"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 100000),
+                ("SortCriteria", ""),
+            ]
+        )
 
     def test_search_track_no_artist_album_track(self, moco):
         moco.contentDirectory.reset_mock()
@@ -60,62 +66,66 @@ class TestMusicLibrary:
         # track cannot be found
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '0',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
-            'TotalMatches': '0',
-            'UpdateID': '0'
+            "NumberReturned": "0",
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
+            "TotalMatches": "0",
+            "UpdateID": "0",
         }
 
         result = moco.music_library.search_track("artist", "album", "track")
 
         assert len(result) == 0
 
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/artist/album:track'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "A:ALBUMARTIST/artist/album:track"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 100000),
+                ("SortCriteria", ""),
+            ]
+        )
 
     def test_search_track_artist_albums(self, moco):
         moco.contentDirectory.reset_mock()
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '2',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/"><container id="A:ALBUMARTIST/The%20Artist/First%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>First Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/First%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container><container id="A:ALBUMARTIST/The%20Artist/Second%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>Second Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container></DIDL-Lite>',
-            'TotalMatches': '2',
-            'UpdateID': '0'
+            "NumberReturned": "2",
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/"><container id="A:ALBUMARTIST/The%20Artist/First%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>First Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/First%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container><container id="A:ALBUMARTIST/The%20Artist/Second%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>Second Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container></DIDL-Lite>',
+            "TotalMatches": "2",
+            "UpdateID": "0",
         }
         results = moco.music_library.search_track("The Artist")
 
         assert results.number_returned == 2
 
         album = results[0]
-        assert album.title == 'First Album'
-        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/First%20Album'
+        assert album.title == "First Album"
+        assert album.item_id == "A:ALBUMARTIST/The%20Artist/First%20Album"
         album = results[1]
-        assert album.title == 'Second Album'
-        assert album.item_id == 'A:ALBUMARTIST/The%20Artist/Second%20Album'
+        assert album.title == "Second Album"
+        assert album.item_id == "A:ALBUMARTIST/The%20Artist/Second%20Album"
 
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "A:ALBUMARTIST/The%20Artist/"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 100000),
+                ("SortCriteria", ""),
+            ]
+        )
 
     def test_search_track_artist_album_tracks(self, moco):
         moco.contentDirectory.reset_mock()
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
-            'NumberReturned': '3',
-            'Result': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 1</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>3</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a&amp;v=432</ns1:albumArtURI><dc:title>Track Title 2</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>4</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 3</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>5</ns1:originalTrackNumber></item></DIDL-Lite>',
-            'TotalMatches': '3',
-            'UpdateID': '0'
+            "NumberReturned": "3",
+            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 1</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>3</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a&amp;v=432</ns1:albumArtURI><dc:title>Track Title 2</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>4</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 3</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>5</ns1:originalTrackNumber></item></DIDL-Lite>',
+            "TotalMatches": "3",
+            "UpdateID": "0",
         }
 
         results = moco.music_library.search_track("The Artist", "The Album")
@@ -123,98 +133,113 @@ class TestMusicLibrary:
         assert len(results) == 3
 
         track = results[0]
-        assert track.title == 'Track Title 1'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3'
+        assert track.title == "Track Title 1"
+        assert (
+            track.item_id
+            == "S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3"
+        )
         track = results[1]
-        assert track.title == 'Track Title 2'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a'
+        assert track.title == "Track Title 2"
+        assert (
+            track.item_id
+            == "S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a"
+        )
         track = results[2]
-        assert track.title == 'Track Title 3'
-        assert track.item_id == 'S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3'
+        assert track.title == "Track Title 3"
+        assert (
+            track.item_id
+            == "S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3"
+        )
 
-        moco.contentDirectory.Browse.assert_called_once_with([
-            ('ObjectID', 'A:ALBUMARTIST/The%20Artist/The%20Album'),
-            ('BrowseFlag', 'BrowseDirectChildren'),
-            ('Filter', '*'),
-            ('StartingIndex', 0),
-            ('RequestedCount', 100000),
-            ('SortCriteria', '')
-        ])
+        moco.contentDirectory.Browse.assert_called_once_with(
+            [
+                ("ObjectID", "A:ALBUMARTIST/The%20Artist/The%20Album"),
+                ("BrowseFlag", "BrowseDirectChildren"),
+                ("Filter", "*"),
+                ("StartingIndex", 0),
+                ("RequestedCount", 100000),
+                ("SortCriteria", ""),
+            ]
+        )
 
     def test_soco_library_updating(self, moco):
-        moco.contentDirectory.GetShareIndexInProgress.return_value = {
-            'IsIndexing': '0'}
+        moco.contentDirectory.GetShareIndexInProgress.return_value = {"IsIndexing": "0"}
         assert not moco.music_library.library_updating
         moco.contentDirectory.reset_mock()
-        moco.contentDirectory.GetShareIndexInProgress.return_value = {
-            'IsIndexing': '1'}
+        moco.contentDirectory.GetShareIndexInProgress.return_value = {"IsIndexing": "1"}
         assert moco.music_library.library_updating
 
     def test_soco_start_library_update(self, moco):
         moco.contentDirectory.RefreshShareIndex.return_value = True
         assert moco.music_library.start_library_update()
-        moco.contentDirectory.RefreshShareIndex.assert_called_with([
-            ('AlbumArtistDisplayOption', ''),
-        ])
+        moco.contentDirectory.RefreshShareIndex.assert_called_with(
+            [("AlbumArtistDisplayOption", ""),]
+        )
 
     def test_soco_list_library_shares(self, moco):
         # Tests with 2, 1 and 0 library shares
         moco.contentDirectory.Browse.return_value = {
-            'TotalMatches': '2',
-            'NumberReturned': '2',
-            'UpdateID': '0',
-            'Result': ('<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
-                       'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
-                       'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
-                       'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
-                       '<container id="S://share_host/music_01/Music/Lossless" '
-                       'parentID="S:" restricted="true"><dc:title>//share_host/music_01/Music/Lossless'
-                       '</dc:title><upnp:class>object.container</upnp:class><res '
-                       'protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_XXXXXXXXXXXXX1400'
-                       '#S://share_host/music_01/Music/Lossless</res></container>'
-                       '<container id="S://share_host_2/music_01" parentID="S:" restricted="true">'
-                       '<dc:title>//share_host_2/music_01</dc:title><upnp:class>object.container'
-                       '</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist'
-                       ':RINCON_XXXXXXXXXXXXX1400#S://share_host_2/music_01</res></container></DIDL-Lite>')
+            "TotalMatches": "2",
+            "NumberReturned": "2",
+            "UpdateID": "0",
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                '<container id="S://share_host/music_01/Music/Lossless" '
+                'parentID="S:" restricted="true"><dc:title>//share_host/music_01/Music/Lossless'
+                "</dc:title><upnp:class>object.container</upnp:class><res "
+                'protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_XXXXXXXXXXXXX1400'
+                "#S://share_host/music_01/Music/Lossless</res></container>"
+                '<container id="S://share_host_2/music_01" parentID="S:" restricted="true">'
+                "<dc:title>//share_host_2/music_01</dc:title><upnp:class>object.container"
+                '</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist'
+                ":RINCON_XXXXXXXXXXXXX1400#S://share_host_2/music_01</res></container></DIDL-Lite>"
+            ),
         }
         results = moco.music_library.list_library_shares()
         assert len(results) == 2
-        assert '//share_host/music_01/Music/Lossless' in results
-        assert '//share_host_2/music_01' in results
+        assert "//share_host/music_01/Music/Lossless" in results
+        assert "//share_host_2/music_01" in results
 
         moco.contentDirectory.Browse.return_value = {
-            'TotalMatches': '1',
-            'NumberReturned': '1',
-            'UpdateID': '0',
-            'Result': ('<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
-                       'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
-                       'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
-                       'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
-                       '<container id="S://share_host/music_01/Music/Lossless" parentID="S:" restricted="true">'
-                       '<dc:title>//share_host/music_01/Music/Lossless</dc:title>'
-                       '<upnp:class>object.container</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">'
-                       'x-rincon-playlist:RINCON_XXXXXXXXXXXXXX400#'
-                       'S://share_host/music_01/Music/Lossless</res></container></DIDL-Lite>')
+            "TotalMatches": "1",
+            "NumberReturned": "1",
+            "UpdateID": "0",
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+                '<container id="S://share_host/music_01/Music/Lossless" parentID="S:" restricted="true">'
+                "<dc:title>//share_host/music_01/Music/Lossless</dc:title>"
+                '<upnp:class>object.container</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">'
+                "x-rincon-playlist:RINCON_XXXXXXXXXXXXXX400#"
+                "S://share_host/music_01/Music/Lossless</res></container></DIDL-Lite>"
+            ),
         }
         results = moco.music_library.list_library_shares()
         assert len(results) == 1
-        assert '//share_host/music_01/Music/Lossless' in results
+        assert "//share_host/music_01/Music/Lossless" in results
 
         moco.contentDirectory.Browse.return_value = {
-            'TotalMatches': '0',
-            'NumberReturned': '0',
-            'UpdateID': '0',
-            'Result': ('<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
-                       'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
-                       'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
-                       'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"/>')
+            "TotalMatches": "0",
+            "NumberReturned": "0",
+            "UpdateID": "0",
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"/>'
+            ),
         }
         results = moco.music_library.list_library_shares()
         assert len(results) == 0
 
     def test_soco_delete_library_share(self, moco):
-        share = '//host/share'
+        share = "//host/share"
         moco.music_library.delete_library_share(share)
-        moco.contentDirectory.DestroyObject.assert_called_once_with([
-            ('ObjectID', 'S:' + share)
-        ])
+        moco.contentDirectory.DestroyObject.assert_called_once_with(
+            [("ObjectID", "S:" + share)]
+        )

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -40,7 +40,20 @@ class TestMusicLibrary:
     def test_search_track_no_result(self, moco):
         moco.contentDirectory.reset_mock()
         # Browse returns an exception if the artist can't be found
-        # <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>701</errorCode></UPnPError></detail></s:Fault></s:Body></s:Envelope>
+        # <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+        #  s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        #   <s:Body>
+        #     <s:Fault>
+        #       <faultcode>s:Client</faultcode>
+        #       <faultstring>UPnPError</faultstring>
+        #       <detail>
+        #         <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+        #           <errorCode>701</errorCode>
+        #         </UPnPError>
+        #       </detail>
+        #     </s:Fault>
+        #   </s:Body>
+        # </s:Envelope>
         moco.contentDirectory.Browse.side_effect = SoCoUPnPException(
             "No such object", "701", "error XML"
         )
@@ -67,7 +80,12 @@ class TestMusicLibrary:
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
             "NumberReturned": "0",
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
+                'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
+                'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"></DIDL-Lite>'
+            ),
             "TotalMatches": "0",
             "UpdateID": "0",
         }
@@ -92,7 +110,34 @@ class TestMusicLibrary:
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
             "NumberReturned": "2",
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/"><container id="A:ALBUMARTIST/The%20Artist/First%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>First Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/First%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container><container id="A:ALBUMARTIST/The%20Artist/Second%20Album" parentID="A:ALBUMARTIST/The%20Artist" restricted="true"><dc:title>Second Album</dc:title><ns2:class>object.container.album.musicAlbum</ns2:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album</res><dc:creator>The Artist</dc:creator><ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI></container></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+                'xmlns:ns2="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+                '<container id="A:ALBUMARTIST/The%20Artist/First%20Album" '
+                'parentID="A:ALBUMARTIST/The%20Artist" restricted="true">'
+                "<dc:title>First Album</dc:title>"
+                "<ns2:class>object.container.album.musicAlbum</ns2:class>"
+                '<res protocolInfo="x-rincon-playlist:*:*:*">'
+                "x-rincon-playlist:RINCON_000123456789001400#A:ALBUMARTIST/"
+                "The%20Artist/First%20Album</res>"
+                "<dc:creator>The Artist</dc:creator>"
+                "<ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist"
+                "%2fFirst%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI>"
+                "</container>"
+                '<container id="A:ALBUMARTIST/The%20Artist/Second%20Album" '
+                'parentID="A:ALBUMARTIST/The%20Artist" restricted="true">'
+                "<dc:title>Second Album</dc:title>"
+                "<ns2:class>object.container.album.musicAlbum</ns2:class>"
+                '<res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:'
+                "RINCON_000123456789001400#A:ALBUMARTIST/The%20Artist/Second%20Album"
+                "</res>"
+                "<dc:creator>The Artist</dc:creator>"
+                "<ns2:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist"
+                "%2fSecond%2520Album%2ftrack2.mp3&amp;v=432</ns2:albumArtURI>"
+                "</container>"
+                "</DIDL-Lite>"
+            ),
             "TotalMatches": "2",
             "UpdateID": "0",
         }
@@ -123,7 +168,55 @@ class TestMusicLibrary:
         moco.contentDirectory.Browse.side_effect = None
         moco.contentDirectory.Browse.return_value = {
             "NumberReturned": "3",
-            "Result": '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="S://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 1</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>3</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a&amp;v=432</ns1:albumArtURI><dc:title>Track Title 2</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>4</ns1:originalTrackNumber></item><item id="S://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3" parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true"><res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/The%20Artist/The%20Album/05%20-%20Track%20Title%203.mp3</res><ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3&amp;v=432</ns1:albumArtURI><dc:title>Track Title 3</dc:title><ns1:class>object.item.audioItem.musicTrack</ns1:class><dc:creator>The Artist</dc:creator><ns1:album>The Album</ns1:album><ns1:originalTrackNumber>5</ns1:originalTrackNumber></item></DIDL-Lite>',
+            "Result": (
+                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
+                'xmlns:ns0="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+                'xmlns:ns1="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+                '<item id="S://server/The%20Artist/The%20Album/'
+                '03%20-%20Track%20Title%201.mp3" '
+                'parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true">'
+                '<res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://server/'
+                "The%20Artist/The%20Album/03%20-%20Track%20Title%201.mp3</res>"
+                "<ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520Artist"
+                "%2fThe%2520Album%2f03%2520-%2520Track%2520Title%25201.mp3&amp;v=432"
+                "</ns1:albumArtURI>"
+                "<dc:title>Track Title 1</dc:title>"
+                "<ns1:class>object.item.audioItem.musicTrack</ns1:class>"
+                "<dc:creator>The Artist</dc:creator>"
+                "<ns1:album>The Album</ns1:album>"
+                "<ns1:originalTrackNumber>3</ns1:originalTrackNumber>"
+                "</item>"
+                '<item id="S://server/The%20Artist/The%20Album/'
+                '04%20-%20Track%20Title%202.m4a" '
+                'parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true">'
+                '<res protocolInfo="x-file-cifs:*:audio/mp4:*">x-file-cifs://server/'
+                "The%20Artist/The%20Album/04%20-%20Track%20Title%202.m4a</res>"
+                "<ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520"
+                "Artist%2fThe%2520Album%2f04%2520-%2520Track%2520Title%25202.m4a"
+                "&amp;v=432</ns1:albumArtURI>"
+                "<dc:title>Track Title 2</dc:title>"
+                "<ns1:class>object.item.audioItem.musicTrack</ns1:class>"
+                "<dc:creator>The Artist</dc:creator>"
+                "<ns1:album>The Album</ns1:album>"
+                "<ns1:originalTrackNumber>4</ns1:originalTrackNumber>"
+                "</item>"
+                '<item id="S://server/The%20Artist/The%20Album/'
+                '05%20-%20Track%20Title%203.mp3" '
+                'parentID="A:ALBUMARTIST/The%20Artist/The%20Album" restricted="true">'
+                '<res protocolInfo="x-file-cifs:*:audio/mpeg:*">'
+                "x-file-cifs://server/The%20Artist/The%20Album/"
+                "05%20-%20Track%20Title%203.mp3</res>"
+                "<ns1:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fserver%2fThe%2520"
+                "Artist%2fThe%2520Album%2f05%2520-%2520Track%2520Title%25203.mp3"
+                "&amp;v=432</ns1:albumArtURI>"
+                "<dc:title>Track Title 3</dc:title>"
+                "<ns1:class>object.item.audioItem.musicTrack</ns1:class>"
+                "<dc:creator>The Artist</dc:creator>"
+                "<ns1:album>The Album</ns1:album>"
+                "<ns1:originalTrackNumber>5</ns1:originalTrackNumber>"
+                "</item>"
+                "</DIDL-Lite>"
+            ),
             "TotalMatches": "3",
             "UpdateID": "0",
         }
@@ -188,14 +281,20 @@ class TestMusicLibrary:
                 'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
                 'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
                 '<container id="S://share_host/music_01/Music/Lossless" '
-                'parentID="S:" restricted="true"><dc:title>//share_host/music_01/Music/Lossless'
+                'parentID="S:" restricted="true"><dc:title>//share_host/music_01/Music/'
+                "Lossless"
                 "</dc:title><upnp:class>object.container</upnp:class><res "
-                'protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_XXXXXXXXXXXXX1400'
+                'protocolInfo="x-rincon-playlist:*:*:*">'
+                "x-rincon-playlist:RINCON_XXXXXXXXXXXXX1400"
                 "#S://share_host/music_01/Music/Lossless</res></container>"
-                '<container id="S://share_host_2/music_01" parentID="S:" restricted="true">'
-                "<dc:title>//share_host_2/music_01</dc:title><upnp:class>object.container"
-                '</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist'
-                ":RINCON_XXXXXXXXXXXXX1400#S://share_host_2/music_01</res></container></DIDL-Lite>"
+                '<container id="S://share_host_2/music_01" parentID="S:" '
+                'restricted="true">'
+                "<dc:title>//share_host_2/music_01</dc:title>"
+                "<upnp:class>object.container"
+                '</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">'
+                "x-rincon-playlist"
+                ":RINCON_XXXXXXXXXXXXX1400#S://share_host_2/music_01</res>"
+                "</container></DIDL-Lite>"
             ),
         }
         results = moco.music_library.list_library_shares()
@@ -212,9 +311,11 @@ class TestMusicLibrary:
                 'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
                 'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
                 'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
-                '<container id="S://share_host/music_01/Music/Lossless" parentID="S:" restricted="true">'
+                '<container id="S://share_host/music_01/Music/Lossless" parentID="S:" '
+                'restricted="true">'
                 "<dc:title>//share_host/music_01/Music/Lossless</dc:title>"
-                '<upnp:class>object.container</upnp:class><res protocolInfo="x-rincon-playlist:*:*:*">'
+                "<upnp:class>object.container</upnp:class>"
+                '<res protocolInfo="x-rincon-playlist:*:*:*">'
                 "x-rincon-playlist:RINCON_XXXXXXXXXXXXXX400#"
                 "S://share_host/music_01/Music/Lossless</res></container></DIDL-Lite>"
             ),

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -39,7 +39,8 @@ RESPONSES.append(
                                         (
                                             "albumArtURI",
                                             "http://resources.wimpmusic.com/images/"
-                                            "2238a5cd/ed4d/4ad0/848d/40356f11bda0/640x640.jpg",
+                                            "2238a5cd/ed4d/4ad0/848d/40356f11bda0/"
+                                            "640x640.jpg",
                                         ),
                                         ("canAddToFavorite", "true"),
                                     ]
@@ -57,7 +58,8 @@ RESPONSES.append(
                                         ("canSkip", "true"),
                                         (
                                             "albumArtURI",
-                                            "http://resources.wimpmusic.com/images/eefb1532/dfe9/"
+                                            "http://resources.wimpmusic.com/images/"
+                                            "eefb1532/dfe9/"
                                             "46bd/8775/c583844bc098/640x640.jpg",
                                         ),
                                         ("canAddToFavorite", "true"),
@@ -92,7 +94,8 @@ RESPONSES.append(
                                             [
                                                 (
                                                     "albumArtURI",
-                                                    "http://artwork.cdn.247e.com/covers/104655587/256x256",
+                                                    "http://artwork.cdn.247e.com/"
+                                                    "covers/104655587/256x256",
                                                 ),
                                                 (
                                                     "artistId",

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -12,73 +12,124 @@ from soco.data_structures import DidlResource
 
 # DATA
 RESPONSES = []
-RESPONSES.append(OrderedDict([('searchResult',
-    OrderedDict([('index', '0'),
-                 ('count', '2'),
-                 ('total', '17230'),
-                 ('mediaCollection',
-        [OrderedDict([('id', 'album/43820695'),
-                      ('itemType', 'album'),
-                      ('title', 'Black Mosque'),
-                      ('artist', 'Black Mosque'),
-                      ('artistId', 'artist/6689314'),
-                      ('canPlay', 'true'),
-                      ('canEnumerate', 'true'),
-                      ('canAddToFavorites', 'true'),
-                      ('canSkip', 'true'),
-                      ('albumArtURI', 'http://resources.wimpmusic.com/images/'
-                       '2238a5cd/ed4d/4ad0/848d/40356f11bda0/640x640.jpg'),
-                      ('canAddToFavorite', 'true')]),
-         OrderedDict([('id', 'album/50340580'),
-                      ('itemType', 'album'),
-                      ('title', 'Black Hippy 2'),
-                      ('artist', 'Black Hippy'),
-                      ('artistId', 'artist/3882538'),
-                      ('canPlay', 'true'),
-                      ('canEnumerate', 'true'),
-                      ('canAddToFavorites', 'true'),
-                      ('canSkip', 'true'),
-                      ('albumArtURI',
-                       'http://resources.wimpmusic.com/images/eefb1532/dfe9/'
-                       '46bd/8775/c583844bc098/640x640.jpg'),
-                      ('canAddToFavorite', 'true')])
-        ])
-    ]))
-]))
 RESPONSES.append(
-OrderedDict([('getMetadataResult',
-    OrderedDict([('mediaMetadata',
-        OrderedDict([('id', 'Track@catalog:/tracks/104655624'),
-                     ('title', 'Take Me Into Your Skin'),
-                     ('itemType', 'track'),
-                     ('mimeType', 'audio/aac'),
-                     ('trackMetadata',
-            OrderedDict([('albumArtURI', 'http://artwork.cdn.247e.com/covers/104655587/256x256'),
-                         ('artistId', 'Artist@catalog:/artists/219591'),
-                         ('artist', 'Trentemøller'),
-                         ('album', 'The Last Resort'),
-                         ('duration', '464'),
-                         ('canPlay', 'true'),
-                         ('canSkip', 'true'),
-                         ('canAddToFavorites', 'true'),
-                         ('trackNumber', '1')])
-                     )])),
-                 ('count', '1'),
-                 ('index', '0'),
-                 ('total', '13')])
-)])
+    OrderedDict(
+        [
+            (
+                "searchResult",
+                OrderedDict(
+                    [
+                        ("index", "0"),
+                        ("count", "2"),
+                        ("total", "17230"),
+                        (
+                            "mediaCollection",
+                            [
+                                OrderedDict(
+                                    [
+                                        ("id", "album/43820695"),
+                                        ("itemType", "album"),
+                                        ("title", "Black Mosque"),
+                                        ("artist", "Black Mosque"),
+                                        ("artistId", "artist/6689314"),
+                                        ("canPlay", "true"),
+                                        ("canEnumerate", "true"),
+                                        ("canAddToFavorites", "true"),
+                                        ("canSkip", "true"),
+                                        (
+                                            "albumArtURI",
+                                            "http://resources.wimpmusic.com/images/"
+                                            "2238a5cd/ed4d/4ad0/848d/40356f11bda0/640x640.jpg",
+                                        ),
+                                        ("canAddToFavorite", "true"),
+                                    ]
+                                ),
+                                OrderedDict(
+                                    [
+                                        ("id", "album/50340580"),
+                                        ("itemType", "album"),
+                                        ("title", "Black Hippy 2"),
+                                        ("artist", "Black Hippy"),
+                                        ("artistId", "artist/3882538"),
+                                        ("canPlay", "true"),
+                                        ("canEnumerate", "true"),
+                                        ("canAddToFavorites", "true"),
+                                        ("canSkip", "true"),
+                                        (
+                                            "albumArtURI",
+                                            "http://resources.wimpmusic.com/images/eefb1532/dfe9/"
+                                            "46bd/8775/c583844bc098/640x640.jpg",
+                                        ),
+                                        ("canAddToFavorite", "true"),
+                                    ]
+                                ),
+                            ],
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+)
+RESPONSES.append(
+    OrderedDict(
+        [
+            (
+                "getMetadataResult",
+                OrderedDict(
+                    [
+                        (
+                            "mediaMetadata",
+                            OrderedDict(
+                                [
+                                    ("id", "Track@catalog:/tracks/104655624"),
+                                    ("title", "Take Me Into Your Skin"),
+                                    ("itemType", "track"),
+                                    ("mimeType", "audio/aac"),
+                                    (
+                                        "trackMetadata",
+                                        OrderedDict(
+                                            [
+                                                (
+                                                    "albumArtURI",
+                                                    "http://artwork.cdn.247e.com/covers/104655587/256x256",
+                                                ),
+                                                (
+                                                    "artistId",
+                                                    "Artist@catalog:/artists/219591",
+                                                ),
+                                                ("artist", "Trentemøller"),
+                                                ("album", "The Last Resort"),
+                                                ("duration", "464"),
+                                                ("canPlay", "true"),
+                                                ("canSkip", "true"),
+                                                ("canAddToFavorites", "true"),
+                                                ("trackNumber", "1"),
+                                            ]
+                                        ),
+                                    ),
+                                ]
+                            ),
+                        ),
+                        ("count", "1"),
+                        ("index", "0"),
+                        ("total", "13"),
+                    ]
+                ),
+            )
+        ]
+    )
 )
 PARSE_RESULTS = (
     {
-        'number_of_results': 2,
-        'type': 'searchResult',
-        'class_key': 'MediaCollectionAlbum',
-        
+        "number_of_results": 2,
+        "type": "searchResult",
+        "class_key": "MediaCollectionAlbum",
     },
     {
-        'number_of_results': 1,
-        'type': 'getMetadataResult',
-        'class_key': 'MediaMetadataTrack',
+        "number_of_results": 1,
+        "type": "getMetadataResult",
+        "class_key": "MediaMetadataTrack",
     },
 )
 
@@ -86,40 +137,39 @@ PARSE_RESULTS = (
 def test_get_class():
     """Test the get_class function"""
     # Test core functionality for base class MediaMetadata
-    cls = data_structures.get_class('MediaMetadataTrack')
-    assert cls.__name__ == 'MSTrack'
+    cls = data_structures.get_class("MediaMetadataTrack")
+    assert cls.__name__ == "MSTrack"
     assert issubclass(cls, data_structures.MediaMetadata)
 
     # Test core functionality for base class Mediacolection
-    cls = data_structures.get_class('MediaCollectionArtist')
-    assert cls.__name__ == 'MSArtist'
+    cls = data_structures.get_class("MediaCollectionArtist")
+    assert cls.__name__ == "MSArtist"
     assert issubclass(cls, data_structures.MediaCollection)
 
     # Test the caching function
-    cls2 = data_structures.get_class('MediaCollectionArtist')
+    cls2 = data_structures.get_class("MediaCollectionArtist")
     assert cls is cls2
 
     # Asking for bad class should raise KeyError
     with pytest.raises(KeyError):
-        cls = data_structures.get_class('Nonsense')
+        cls = data_structures.get_class("Nonsense")
 
 
-@pytest.mark.parametrize("response, correct",
-                         zip(RESPONSES, PARSE_RESULTS))
+@pytest.mark.parametrize("response, correct", zip(RESPONSES, PARSE_RESULTS))
 def test_parse_response(response, correct):
     """Test the parse_response function"""
     music_service = Mock()
-    music_service.desc = 'DESC'
-    results = data_structures.parse_response(music_service, response, 'albums')
+    music_service.desc = "DESC"
+    results = data_structures.parse_response(music_service, response, "albums")
 
     # Check the search result metadata
-    response_data = response[correct['type']]
-    assert results.number_returned == response_data['count']
-    assert results.search_type == 'albums'
+    response_data = response[correct["type"]]
+    assert results.number_returned == response_data["count"]
+    assert results.search_type == "albums"
 
     # Check the result
-    assert len(results) == correct['number_of_results']
-    klass = data_structures.get_class(correct['class_key'])
+    assert len(results) == correct["number_of_results"]
+    klass = data_structures.get_class(correct["class_key"])
     for result in results:
         assert isinstance(result, klass)
         assert result.music_service is music_service
@@ -128,30 +178,30 @@ def test_parse_response(response, correct):
 def test_parse_response_bad_type():
     """Test parse reponse bad code"""
     with pytest.raises(ValueError) as exp:
-        data_structures.parse_response(None, {}, 'albums')
+        data_structures.parse_response(None, {}, "albums")
     print(exp)
 
 
 def test_form_uri():
     """Test the form uri function"""
     music_service = Mock()
-    music_service.sonos_uri_from_id.return_value = '99'
+    music_service.sonos_uri_from_id.return_value = "99"
 
     # Test non track uri
-    non_track_uri = data_structures.form_uri('dummy_id', None, False)
-    assert non_track_uri == 'x-rincon-cpcontainer:dummy_id'
+    non_track_uri = data_structures.form_uri("dummy_id", None, False)
+    assert non_track_uri == "x-rincon-cpcontainer:dummy_id"
 
     # Test track uri
-    track_uri = data_structures.form_uri('dummy_id', music_service, True)
-    music_service.sonos_uri_from_id.assert_called_once_with('dummy_id')
+    track_uri = data_structures.form_uri("dummy_id", music_service, True)
+    music_service.sonos_uri_from_id.assert_called_once_with("dummy_id")
 
 
 def test_bool_str():
     """Test the bool_str function"""
-    assert data_structures.bool_str('true') is True
-    assert data_structures.bool_str('false') is False
+    assert data_structures.bool_str("true") is True
+    assert data_structures.bool_str("false") is False
     with pytest.raises(ValueError):
-        data_structures.bool_str('dummy')
+        data_structures.bool_str("dummy")
 
 
 class TestMetadataDictBase(object):
@@ -163,12 +213,12 @@ class TestMetadataDictBase(object):
 
         """
         metadata_dict = {
-            'superTitle': 'Dummy Title',
+            "superTitle": "Dummy Title",
         }
         metadata = data_structures.MetadataDictBase(metadata_dict)
         # Assert only metadata element, name conversion and value
         assert len(metadata.metadata) == 1
-        assert metadata.super_title == 'Dummy Title'
+        assert metadata.super_title == "Dummy Title"
 
     def test_conversion(self):
         """Test the type conversion of fields in metadata"""
@@ -178,27 +228,27 @@ class TestMetadataDictBase(object):
         # MetadataDictBase is meant to ve overwritten, to supply
         # valid_fields and conversion functions
         class MyClass(data_structures.MetadataDictBase):
-            _types = {'trackDuration': conversion_mock}
+            _types = {"trackDuration": conversion_mock}
 
         metadata_dict = {
-            'title': 'Dummy Title',
-            'trackDuration': '47',
+            "title": "Dummy Title",
+            "trackDuration": "47",
         }
         metadata = MyClass(metadata_dict)
         # Check that the duration has been properly type converted
-        conversion_mock.assert_called_once_with('47')
+        conversion_mock.assert_called_once_with("47")
         assert metadata.track_duration == 47
         # And that title has been left unchanged
-        assert metadata.title == 'Dummy Title'
+        assert metadata.title == "Dummy Title"
 
     def test_get_attr(self):
         """Test the __getattr__ method"""
         metadata_dict = {
-            'superTitle': 'Dummy Title',
+            "superTitle": "Dummy Title",
         }
         metadata = data_structures.MetadataDictBase(metadata_dict)
         # Test normal lookup
-        assert metadata.super_title == 'Dummy Title'
+        assert metadata.super_title == "Dummy Title"
         # Test raise attribute error when the key is not in metadata
         with pytest.raises(AttributeError):
             metadata.nonexistent_key
@@ -207,65 +257,73 @@ class TestMetadataDictBase(object):
 class TestMusicServiceItem(object):
     """Test the MusicServiceItem class"""
 
-    @patch('soco.music_services.data_structures.MetadataDictBase.__init__')
+    @patch("soco.music_services.data_structures.MetadataDictBase.__init__")
     def test_init(self, metadata_dict_base_init):
         """Test the __init__ method"""
         kwargs = {
-            'item_id': 'some_item_id', 'desc': 'the_desc',
-            'resources': 'the ressources', 'uri': 'https://the_uri',
-            'metadata_dict': {'some': 'dict'}, 'music_service': 'the music service',
-
-            }
+            "item_id": "some_item_id",
+            "desc": "the_desc",
+            "resources": "the ressources",
+            "uri": "https://the_uri",
+            "metadata_dict": {"some": "dict"},
+            "music_service": "the music service",
+        }
 
         music_service_item = data_structures.MusicServiceItem(**kwargs)
         # Test call to super class init
-        metadata_dict_base_init.assert_called_once_with({'some': 'dict'})
+        metadata_dict_base_init.assert_called_once_with({"some": "dict"})
         # Test that all but the metadata_dict arg have been set as
         # attributes with the same names as the arguments
-        kwargs.pop('metadata_dict')
+        kwargs.pop("metadata_dict")
         for arg_name, arg_value in kwargs.items():
             assert getattr(music_service_item, arg_name) == arg_value
 
-    @patch('soco.music_services.data_structures.MusicServiceItem.__init__')
-    @patch('soco.music_services.data_structures.form_uri')
-    @patch('soco.music_services.data_structures.DidlResource')
+    @patch("soco.music_services.data_structures.MusicServiceItem.__init__")
+    @patch("soco.music_services.data_structures.form_uri")
+    @patch("soco.music_services.data_structures.DidlResource")
     def test_from_music_service(self, didl_resource, form_uri, music_service_init):
         """Test th from music service class method"""
         # Setup mock music service with mocked desc property
         ms = Mock()
-        desc = PropertyMock(return_value='fake_desc')
+        desc = PropertyMock(return_value="fake_desc")
         type(ms).desc = desc
 
         # Setup content dict
-        id_ = 'fakeid1234'
-        item_id = '0fffffff' + id_
-        content_dict = {'id': id_, 'title': 'fake title'}
+        id_ = "fakeid1234"
+        item_id = "0fffffff" + id_
+        content_dict = {"id": id_, "title": "fake title"}
 
         # Setup return values of mocks
         didl_resource.return_value = Mock()
-        form_uri.return_value = 'x-rincon-whatever:' + id_
+        form_uri.return_value = "x-rincon-whatever:" + id_
         music_service_init.return_value = None
 
         # Call the class method and assert init called
         data_structures.MusicServiceItem.from_music_service(ms, content_dict)
         music_service_init.assert_called_once_with(
-            item_id, 'fake_desc', [didl_resource.return_value],
-            form_uri.return_value, content_dict, music_service=ms
+            item_id,
+            "fake_desc",
+            [didl_resource.return_value],
+            form_uri.return_value,
+            content_dict,
+            music_service=ms,
         )
         form_uri.assert_called_once_with(item_id, ms, False)
 
     def test_str_(self):
         """Test the __str__ method"""
-        content_dict = {'title': 'fake title'}
-        item = data_structures.MusicServiceItem('fake_id', 'desc', 'ressources', 'uri', content_dict)
+        content_dict = {"title": "fake title"}
+        item = data_structures.MusicServiceItem(
+            "fake_id", "desc", "ressources", "uri", content_dict
+        )
         assert item.__str__() == '<MusicServiceItem title="fake title">'
 
-    @patch('soco.music_services.data_structures.DidlItem.to_element')
+    @patch("soco.music_services.data_structures.DidlItem.to_element")
     def test_to_element(self, didl_item_to_element):
         """Test the to_element method"""
         didl_item_to_element.return_value = object()
-        content_dict = {'title': 'fake title'}
-        item = data_structures.MusicServiceItem('fake_id', 'desc', 'ressources', 'uri', content_dict)
+        content_dict = {"title": "fake title"}
+        item = data_structures.MusicServiceItem(
+            "fake_id", "desc", "ressources", "uri", content_dict
+        )
         assert item.to_element() == didl_item_to_element.return_value
-        
-        

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -54,7 +54,8 @@ ACCOUNT_DATA = """<?xml version="1.0" ?>
 # available_services = device.musicServices.ListAvailableServices()
 # descriptor_list_xml = available_services['AvailableServiceDescriptorList']
 # The list has been edited to include services represented in ACCOUNT_DATA
-SERVICES_DESCRIPTOR_LIST = """<?xml version="1.0"?>
+SERVICES_DESCRIPTOR_LIST = (
+    """<?xml version="1.0"?>
 <Services
     SchemaVersion="1">
     <Service
@@ -168,12 +169,15 @@ SERVICES_DESCRIPTOR_LIST = """<?xml version="1.0"?>
             Auth="DeviceLink"
             PollInterval="30"/>
         <Presentation>
-            <Strings Version="11" Uri="http://soundcloud-static.ws.sonos.com/strings.xml"/>
-            <PresentationMap Version="11" Uri="http://soundcloud-static.ws.sonos.com/pmap.xml"/>
+            <Strings Version="11" Uri="http://"""
+    """soundcloud-static.ws.sonos.com/strings.xml"/>
+            <PresentationMap Version="11" Uri="http://"""
+    """soundcloud-static.ws.sonos.com/pmap.xml"/>
         </Presentation>
     </Service>
 </Services>
 """
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -10,7 +10,9 @@ import soco.soap
 from soco.exceptions import MusicServiceException
 from soco.music_services.accounts import Account
 from soco.music_services.music_service import (
-    MusicService, MusicServiceSoapClient, desc_from_uri
+    MusicService,
+    MusicServiceSoapClient,
+    desc_from_uri,
 )
 
 
@@ -179,30 +181,29 @@ def patch_music_services(monkeypatch):
     """Patch MusicService, Account and SoapMessage to avoid network requests
     and use dummy data."""
     monkeypatch.setattr(
-        MusicService, '_get_music_services_data_xml',
-        mock.Mock(return_value=SERVICES_DESCRIPTOR_LIST))
+        MusicService,
+        "_get_music_services_data_xml",
+        mock.Mock(return_value=SERVICES_DESCRIPTOR_LIST),
+    )
+    monkeypatch.setattr(soco.soap, "SoapMessage", mock.Mock())
     monkeypatch.setattr(
-        soco.soap, 'SoapMessage',
-        mock.Mock())
-    monkeypatch.setattr(
-        soco.music_services.music_service, 'MusicServiceSoapClient',
-        mock.Mock()
+        soco.music_services.music_service, "MusicServiceSoapClient", mock.Mock()
     )
     monkeypatch.setattr(
-        Account, '_get_account_xml',
-        mock.Mock(return_value=ACCOUNT_DATA))
+        Account, "_get_account_xml", mock.Mock(return_value=ACCOUNT_DATA)
+    )
 
 
 def test_initialise_account():
     assert len(Account._all_accounts) == 0
     accounts = Account.get_accounts()
     assert len(accounts) == 4  # TuneIn account is added automatically
-    assert accounts['0'].service_type == '65031'  # TuneIn
-    assert accounts['1'].username == '12345678'
-    assert accounts['1'].service_type == '2311'
-    assert accounts['1'].deleted is False
-    assert accounts['1'].nickname == 'mysonos'
-    assert accounts.get('4') is None
+    assert accounts["0"].service_type == "65031"  # TuneIn
+    assert accounts["1"].username == "12345678"
+    assert accounts["1"].service_type == "2311"
+    assert accounts["1"].deleted is False
+    assert accounts["1"].nickname == "mysonos"
+    assert accounts.get("4") is None
 
 
 def test_get_all_accounts():
@@ -211,7 +212,7 @@ def test_get_all_accounts():
 
 
 def test_get_accounts_for_service():
-    a = Account.get_accounts_for_service('2311')
+    a = Account.get_accounts_for_service("2311")
     assert len(a) == 1
     assert a[0].username == "12345678"
 
@@ -220,22 +221,24 @@ def test_initialise_services():
     assert MusicService._music_services_data is None
     data = MusicService._get_music_services_data()
     assert len(data) == 6
-    deezer = data['519']
-    assert deezer['Name'] == "Deezer"
-    assert deezer['Capabilities'] == '563'
-    assert deezer['Auth'] == 'UserId'
-    assert deezer['Version'] == '1.1'
-    assert deezer['ContainerType'] == 'MService'
-    assert deezer['Id'] == '2'
-    assert deezer['PresentationMapUri'] == \
-        'http://sonos-pmap.ws.sonos.com/deezer_pmap.4.xml'
-    assert deezer['ServiceType'] == '519'
+    deezer = data["519"]
+    assert deezer["Name"] == "Deezer"
+    assert deezer["Capabilities"] == "563"
+    assert deezer["Auth"] == "UserId"
+    assert deezer["Version"] == "1.1"
+    assert deezer["ContainerType"] == "MService"
+    assert deezer["Id"] == "2"
+    assert (
+        deezer["PresentationMapUri"]
+        == "http://sonos-pmap.ws.sonos.com/deezer_pmap.4.xml"
+    )
+    assert deezer["ServiceType"] == "519"
 
 
 def test_get_data_for_name():
-    s = MusicService.get_data_for_name('Spotify')
-    assert s['Name'] == "Spotify"
-    assert s['Capabilities'] == '2563'
+    s = MusicService.get_data_for_name("Spotify")
+    assert s["Name"] == "Spotify"
+    assert s["Capabilities"] == "2563"
 
 
 def test_get_names():
@@ -248,79 +251,83 @@ def test_get_names():
 def test_get_subscribed_names():
     names = MusicService.get_subscribed_services_names()
     assert len(names) == 4
-    assert set(names) == {'TuneIn', 'Spotify', 'Spreaker', 'radioPup'}
+    assert set(names) == {"TuneIn", "Spotify", "Spreaker", "radioPup"}
 
 
 def test_create_music_service():
-    ms = MusicService('Spotify')
-    assert ms.account.username == '12345678'
+    ms = MusicService("Spotify")
+    assert ms.account.username == "12345678"
     with pytest.raises(MusicServiceException) as excinfo:
-        unknown = MusicService('Unknown Music Service')
-    assert 'Unknown music service' in str(excinfo.value)
+        unknown = MusicService("Unknown Music Service")
+    assert "Unknown music service" in str(excinfo.value)
     with pytest.raises(MusicServiceException) as excinfo:
-        soundcloud = MusicService('SoundCloud')
-    assert 'No account found' in str(excinfo.value)
+        soundcloud = MusicService("SoundCloud")
+    assert "No account found" in str(excinfo.value)
 
 
 def test_tunein():
     """TuneIn is handles specially by MusicServices."""
-    tunein = MusicService('TuneIn')
+    tunein = MusicService("TuneIn")
     assert tunein
-    assert tunein.service_id == '254'
-    assert tunein.service_type == '65031'
-    assert tunein.account.serial_number == '0'
+    assert tunein.service_id == "254"
+    assert tunein.service_type == "65031"
+    assert tunein.account.serial_number == "0"
 
 
 def test_search():
-    spotify = MusicService('Spotify')
+    spotify = MusicService("Spotify")
     # Set up dummy search categories
     spotify._get_search_prefix_map = lambda: {
-        'stations': 'search:station',
-        'shows': 'search:show',
-        'hosts': 'search:host',
+        "stations": "search:station",
+        "shows": "search:show",
+        "hosts": "search:host",
     }
     categories = spotify.available_search_categories
     assert len(categories) == 3
-    assert set(categories) == {'stations', 'shows', 'hosts'}
+    assert set(categories) == {"stations", "shows", "hosts"}
     with pytest.raises(MusicServiceException) as excinfo:
-        spotify.search('badcategory')
+        spotify.search("badcategory")
     assert "support the 'badcategory' search category" in str(excinfo.value)
 
 
 def test_sonos_uri_from_id():
-    spotify = MusicService('Spotify')
-    track = 'spotify:track:2qs5ZcLByNTctJKbhAZ9JE'
-    assert spotify.sonos_uri_from_id(track) == \
-        'soco://spotify%3Atrack%3A2qs5ZcLByNTctJKbhAZ9JE?sid=9&sn=1'
+    spotify = MusicService("Spotify")
+    track = "spotify:track:2qs5ZcLByNTctJKbhAZ9JE"
+    assert (
+        spotify.sonos_uri_from_id(track)
+        == "soco://spotify%3Atrack%3A2qs5ZcLByNTctJKbhAZ9JE?sid=9&sn=1"
+    )
     # Check for escaping with a few difficult characters
-    track = 'spotify: track\2qc%ünicøde?'
-    assert spotify.sonos_uri_from_id(track) == \
-        'soco://spotify%3A%20track%02qc%25%C3%BCnic%C3%B8de%3F?sid=9&sn=1'
+    track = "spotify: track\2qc%ünicøde?"
+    assert (
+        spotify.sonos_uri_from_id(track)
+        == "soco://spotify%3A%20track%02qc%25%C3%BCnic%C3%B8de%3F?sid=9&sn=1"
+    )
     # and a different service
-    spreaker = MusicService('Spreaker')
-    track = 'spreaker12345678'
-    assert spreaker.sonos_uri_from_id(track) == \
-        'soco://spreaker12345678?sid=163&sn=3'
+    spreaker = MusicService("Spreaker")
+    track = "spreaker12345678"
+    assert spreaker.sonos_uri_from_id(track) == "soco://spreaker12345678?sid=163&sn=3"
 
 
 def test_desc():
-    spotify = MusicService('Spotify')
-    assert spotify.desc == 'SA_RINCON2311_12345678'
-    spreaker = MusicService('Spreaker')
-    assert spreaker.desc == 'SA_RINCON41735_'
+    spotify = MusicService("Spotify")
+    assert spotify.desc == "SA_RINCON2311_12345678"
+    spreaker = MusicService("Spreaker")
+    assert spreaker.desc == "SA_RINCON41735_"
 
 
 def test_desc_from_uri():
-    URI = 'x-sonos-http:track%3a3402413.mp3?sid=2&amp;flags=32&amp;sn=1'
-    assert desc_from_uri(URI) == 'SA_RINCON2311_12345678'
-    SID_ONLY = 'x-sonos-http:track%3a3402413.mp3?sid=9&amp;flags=32'
-    assert desc_from_uri(SID_ONLY) == 'SA_RINCON2311_12345678'
-    TUNEIN_URI = 'x-sonosapi-stream:s49815?sid=254&amp;flags=8224&amp;sn=0'
-    assert desc_from_uri(TUNEIN_URI) == 'SA_RINCON65031_'
-    UNKNOWN_AC_WITH_SID = \
-        'x-sonos-http:track%3a3402413.mp3?sid=9&amp;flags=32&amp;sn=400'
-    assert desc_from_uri(UNKNOWN_AC_WITH_SID) == 'SA_RINCON2311_12345678'
-    NO_DATA = 'x-sonos-http:track%3a3402413.mp3?flags=32'
-    assert desc_from_uri(NO_DATA) == 'RINCON_AssociatedZPUDN'
+    URI = "x-sonos-http:track%3a3402413.mp3?sid=2&amp;flags=32&amp;sn=1"
+    assert desc_from_uri(URI) == "SA_RINCON2311_12345678"
+    SID_ONLY = "x-sonos-http:track%3a3402413.mp3?sid=9&amp;flags=32"
+    assert desc_from_uri(SID_ONLY) == "SA_RINCON2311_12345678"
+    TUNEIN_URI = "x-sonosapi-stream:s49815?sid=254&amp;flags=8224&amp;sn=0"
+    assert desc_from_uri(TUNEIN_URI) == "SA_RINCON65031_"
+    UNKNOWN_AC_WITH_SID = (
+        "x-sonos-http:track%3a3402413.mp3?sid=9&amp;flags=32&amp;sn=400"
+    )
+    assert desc_from_uri(UNKNOWN_AC_WITH_SID) == "SA_RINCON2311_12345678"
+    NO_DATA = "x-sonos-http:track%3a3402413.mp3?flags=32"
+    assert desc_from_uri(NO_DATA) == "RINCON_AssociatedZPUDN"
     HTTP = "http://archive.org/download/TenD/TenD2005-07-16t10Wonderboy_64kb.mp3"
-    assert desc_from_uri(HTTP) == 'RINCON_AssociatedZPUDN'
+    assert desc_from_uri(HTTP) == "RINCON_AssociatedZPUDN"

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -23,28 +23,30 @@ def assert_xml_equal(left, right, explain=None):
     Raises
         AssertionError: if the Elements do not match
     """
+
     def _build_explanation(left, right, explain):
         if left.tag != right.tag:
-            explain.append('tag <%s> does not match tag <%s>' % (left.tag,
-                                                                 right.tag))
+            explain.append("tag <%s> does not match tag <%s>" % (left.tag, right.tag))
         for name, value in left.attrib.items():
             if right.get(name) != value:
                 explain.append(
-                    '%s attribute of element <%s> does not match: %s=%r, %s=%r' %
-                    (name, left.tag, name, value, name, right.get(name)))
+                    "%s attribute of element <%s> does not match: %s=%r, %s=%r"
+                    % (name, left.tag, name, value, name, right.get(name))
+                )
         for name in right.attrib:
             if name not in left.attrib:
                 explain.append(
-                    'right element <%s> has attribute %s but left does not' %
-                    (left.tag, name))
+                    "right element <%s> has attribute %s but left does not"
+                    % (left.tag, name)
+                )
         if left.text != right.text:
             explain.append(
-                'text for element <%s>: %r != %r' %
-                (left.tag, left.text, right.text))
+                "text for element <%s>: %r != %r" % (left.tag, left.text, right.text)
+            )
         if left.tail != right.tail:
             explain.append(
-                'tail for element <%s>: %r != %r' %
-                (left.tag, left.text, right.text))
+                "tail for element <%s>: %r != %r" % (left.tag, left.text, right.text)
+            )
         for i1, i2 in zip(left, right):
             _build_explanation(i1, i2, explain)
         return
@@ -53,10 +55,10 @@ def assert_xml_equal(left, right, explain=None):
     _build_explanation(left, right, explain)
     if explain != []:
         header = "Comparing XML elements %s and %s" % (left, right)
-        assert False, header + '\n'.join(explain)
+        assert False, header + "\n".join(explain)
 
 
-class TestResource():
+class TestResource:
     """Testing the Resource class."""
 
     def test_create_didl_resource_with_no_params(self):
@@ -64,57 +66,55 @@ class TestResource():
             res = data_structures.DidlResource()
 
     def test_create_didl_resource(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
-        assert res.uri == 'a%20uri'
-        assert res.protocol_info == 'a:protocol:info:xx'
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
+        assert res.uri == "a%20uri"
+        assert res.protocol_info == "a:protocol:info:xx"
 
     def test_create_didl_resource_to_from_element(self, helpers):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx',
-                                           bitrate=3)
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx", bitrate=3)
         elt = res.to_element()
         assert helpers.compare_xml(
             elt,
             XML.fromstring(
-                b'<res bitrate="3" '
-                b'protocolInfo="a:protocol:info:xx">a%20uri</res>'
-            )
+                b'<res bitrate="3" ' b'protocolInfo="a:protocol:info:xx">a%20uri</res>'
+            ),
         )
         assert data_structures.DidlResource.from_element(elt) == res
 
     def test_didl_resource_to_dict(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
         rez = res.to_dict()
-        assert rez['uri'] == 'a%20uri'
-        assert rez['protocol_info'] == 'a:protocol:info:xx'
+        assert rez["uri"] == "a%20uri"
+        assert rez["protocol_info"] == "a:protocol:info:xx"
         assert len(rez) == 12
 
     def test_didl_resource_to_dict_remove_nones(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
         rez = res.to_dict(remove_nones=True)
-        assert rez['uri'] == 'a%20uri'
-        assert rez['protocol_info'] == 'a:protocol:info:xx'
+        assert rez["uri"] == "a%20uri"
+        assert rez["protocol_info"] == "a:protocol:info:xx"
         assert len(rez) == 2
 
     def test_didl_resource_from_dict(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
         rez = data_structures.DidlResource.from_dict(res.to_dict())
         assert res == rez
 
     def test_didl_resource_from_dict_remove_nones(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
-        rez = data_structures.DidlResource.from_dict(
-            res.to_dict(remove_nones=True))
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
+        rez = data_structures.DidlResource.from_dict(res.to_dict(remove_nones=True))
         assert res == rez
 
     def test_didl_resource_eq(self):
-        res = data_structures.DidlResource('a%20uri', 'a:protocol:info:xx')
+        res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
         assert res != data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid')
+            title="a_title", parent_id="pid", item_id="iid"
+        )
         assert res is not None
         assert res == res
 
 
-class TestDidlObject():
+class TestDidlObject:
     """Testing the DidlObject base class."""
 
     didl_xml = """
@@ -137,21 +137,23 @@ class TestDidlObject():
     def test_create_didl_object_with_disallowed_params(self):
         with pytest.raises(ValueError) as excinfo:
             didl_object = data_structures.DidlObject(
-                title='a_title', parent_id='pid', item_id='iid', bad_args='other')
-        assert 'not allowed' in str(excinfo.value)
+                title="a_title", parent_id="pid", item_id="iid", bad_args="other"
+            )
+        assert "not allowed" in str(excinfo.value)
 
     def test_create_didl_object_with_good_params(self):
         didl_object = data_structures.DidlObject(
-            title='a_title',
-            parent_id='pid',
-            item_id='iid',
-            creator='a_creator',
-            desc="dummy")
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            desc="dummy",
+        )
         assert didl_object is not None
-        assert didl_object.title == 'a_title'
-        assert didl_object.parent_id == 'pid'
-        assert didl_object.item_id == 'iid'
-        assert didl_object.creator == 'a_creator'
+        assert didl_object.title == "a_title"
+        assert didl_object.parent_id == "pid"
+        assert didl_object.item_id == "iid"
+        assert didl_object.creator == "a_creator"
         assert didl_object.resources == []
         assert didl_object.desc == "dummy"
 
@@ -166,12 +168,12 @@ class TestDidlObject():
     def test_didl_object_from_element(self):
         elt = XML.fromstring(self.didl_xml)
         didl_object = data_structures.DidlObject.from_element(elt)
-        assert didl_object.title == 'the_title'
-        assert didl_object.parent_id == 'pid'
-        assert didl_object.item_id == 'iid'
-        assert didl_object.creator == 'a_creator'
-        assert didl_object.desc == 'DUMMY'
-        assert didl_object.item_class == 'object'
+        assert didl_object.title == "the_title"
+        assert didl_object.parent_id == "pid"
+        assert didl_object.item_id == "iid"
+        assert didl_object.creator == "a_creator"
+        assert didl_object.desc == "DUMMY"
+        assert didl_object.item_class == "object"
 
     def test_didl_object_from_element_unoff_subelement(self):
         """Test that for a DidlObject created from an element with an
@@ -179,11 +181,9 @@ class TestDidlObject():
         completely ignored
 
         """
-        elt = XML.fromstring(
-            self.didl_xml.replace('object', 'object.#SubClass')
-        )
+        elt = XML.fromstring(self.didl_xml.replace("object", "object.#SubClass"))
         didl_object = data_structures.DidlObject.from_element(elt)
-        assert didl_object.item_class == 'object'
+        assert didl_object.item_class == "object"
 
     def test_didl_object_from_wrong_class(self):
         # mismatched upnp class
@@ -200,163 +200,177 @@ class TestDidlObject():
                    RINCON_AssociatedZPUDN
                  </desc>
                </item>
-        """)
+        """
+        )
         with pytest.raises(DIDLMetadataError) as excinfo:
             didl_object = data_structures.DidlObject.from_element(bad_elt1)
-        assert ("UPnP class is incorrect. Expected 'object', got 'object.item'"
-                ) in str(excinfo.value)
+        assert ("UPnP class is incorrect. Expected 'object', got 'object.item'") in str(
+            excinfo.value
+        )
 
     def test_didl_object_from_dict(self):
         didl_object = data_structures.DidlObject(
-            title='a_title',
-            parent_id='pid',
-            item_id='iid',
-            creator='a_creator',
-            desc='dummy')
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            desc="dummy",
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'dummy'
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "dummy",
         }
         assert data_structures.DidlObject.from_dict(the_dict) == didl_object
         # adding in an attibute not in _translation should make no difference
-        the_dict['creator'] = 'another_creator'
+        the_dict["creator"] = "another_creator"
         assert data_structures.DidlObject.from_dict(the_dict) != didl_object
         # round trip
-        assert data_structures.DidlObject.from_dict(the_dict).to_dict() == \
-            the_dict
+        assert data_structures.DidlObject.from_dict(the_dict).to_dict() == the_dict
 
     def test_didl_object_from_dict_resources(self):
-        resources_list = [data_structures.DidlResource('a%20uri',
-                                                       'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 desc='dummy',
-                                                 resources=resources_list)
+        resources_list = [data_structures.DidlResource("a%20uri", "a:protocol:info:xx")]
+        didl_object = data_structures.DidlObject(
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            desc="dummy",
+            resources=resources_list,
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'dummy',
-            'resources': [resource.to_dict() for resource in resources_list]
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "dummy",
+            "resources": [resource.to_dict() for resource in resources_list],
         }
         assert data_structures.DidlObject.from_dict(the_dict) == didl_object
 
     def test_didl_object_from_dict_resources_remove_nones(self):
-        resources_list = [data_structures.DidlResource('a%20uri',
-                                                       'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 desc='dummy',
-                                                 resources=resources_list)
+        resources_list = [data_structures.DidlResource("a%20uri", "a:protocol:info:xx")]
+        didl_object = data_structures.DidlObject(
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            desc="dummy",
+            resources=resources_list,
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'dummy',
-            'resources': [resource.to_dict(remove_nones=True)
-                          for resource in resources_list]
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "dummy",
+            "resources": [
+                resource.to_dict(remove_nones=True) for resource in resources_list
+            ],
         }
         assert data_structures.DidlObject.from_dict(the_dict) == didl_object
 
     def test_didl_comparisons(self):
         didl_object_1 = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title="a_title", parent_id="pid", item_id="iid", creator="a_creator"
+        )
         didl_object_2 = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title="a_title", parent_id="pid", item_id="iid", creator="a_creator"
+        )
         # should be not the same, but equal!
         assert didl_object_1 is not didl_object_2
         assert didl_object_1 == didl_object_2
         didl_object_3 = data_structures.DidlObject(
-            title='a_title',
-            parent_id='pid',
-            item_id='iid',
-            creator='a__different_creator')
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a__different_creator",
+        )
         assert didl_object_3 != didl_object_1
 
     def test_didl_object_to_dict(self):
         didl_object = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title="a_title", parent_id="pid", item_id="iid", creator="a_creator"
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'RINCON_AssociatedZPUDN'
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "RINCON_AssociatedZPUDN",
         }
         assert didl_object.to_dict() == the_dict
         # adding in an attibute not in _translation should make no difference
-        didl_object.other = 'other'
+        didl_object.other = "other"
         assert didl_object.to_dict() == the_dict
         # but changing on the other should
-        didl_object.creator = 'another'
+        didl_object.creator = "another"
         assert didl_object.to_dict() != the_dict
 
     def test_didl_object_to_dict_resources(self):
-        resources_list = [data_structures.DidlResource('a%20uri',
-                                                       'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 resources=resources_list)
+        resources_list = [data_structures.DidlResource("a%20uri", "a:protocol:info:xx")]
+        didl_object = data_structures.DidlObject(
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            resources=resources_list,
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'RINCON_AssociatedZPUDN',
-            'resources': [resource.to_dict() for resource in resources_list]
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "RINCON_AssociatedZPUDN",
+            "resources": [resource.to_dict() for resource in resources_list],
         }
         assert didl_object.to_dict() == the_dict
 
     def test_didl_object_to_dict_resources_remove_nones(self):
-        resources_list = [data_structures.DidlResource('a%20uri',
-                                                       'a:protocol:info:xx')]
-        didl_object = data_structures.DidlObject(title='a_title',
-                                                 parent_id='pid',
-                                                 item_id='iid',
-                                                 creator='a_creator',
-                                                 resources=resources_list)
+        resources_list = [data_structures.DidlResource("a%20uri", "a:protocol:info:xx")]
+        didl_object = data_structures.DidlObject(
+            title="a_title",
+            parent_id="pid",
+            item_id="iid",
+            creator="a_creator",
+            resources=resources_list,
+        )
         the_dict = {
-            'title': 'a_title',
-            'parent_id': 'pid',
-            'item_id': 'iid',
-            'creator': 'a_creator',
-            'restricted': True,
-            'desc': 'RINCON_AssociatedZPUDN',
-            'resources': [resource.to_dict(remove_nones=True)
-                          for resource in resources_list]
+            "title": "a_title",
+            "parent_id": "pid",
+            "item_id": "iid",
+            "creator": "a_creator",
+            "restricted": True,
+            "desc": "RINCON_AssociatedZPUDN",
+            "resources": [
+                resource.to_dict(remove_nones=True) for resource in resources_list
+            ],
         }
         assert didl_object.to_dict(remove_nones=True) == the_dict
 
     def test_didl_object_to_element(self):
         didl_object = data_structures.DidlObject(
-            title='a_title', parent_id='pid', item_id='iid', creator='a_creator')
+            title="a_title", parent_id="pid", item_id="iid", creator="a_creator"
+        )
         # we seem to have to go through this to get ElementTree to deal
         # with namespaces properly!
         elt = XML.fromstring(XML.tostring(didl_object.to_element(True)))
         elt2 = XML.fromstring(
-            '<dummy xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" ' +
-            'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
-            'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">' +
-            '<item id="iid" parentID="pid" restricted="true">' +
-            '<dc:title>a_title</dc:title>' +
-            '<dc:creator>a_creator</dc:creator>' +
-            '<upnp:class>object</upnp:class><desc id="cdudn" ' +
-            'nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">' +
-            'RINCON_AssociatedZPUDN</desc></item></dummy>')[0]
+            '<dummy xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+            + 'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+            + 'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+            + '<item id="iid" parentID="pid" restricted="true">'
+            + "<dc:title>a_title</dc:title>"
+            + "<dc:creator>a_creator</dc:creator>"
+            + '<upnp:class>object</upnp:class><desc id="cdudn" '
+            + 'nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">'
+            + "RINCON_AssociatedZPUDN</desc></item></dummy>"
+        )[0]
         assert_xml_equal(elt2, elt)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,9 +9,7 @@ from __future__ import unicode_literals
 import pytest
 
 from soco.exceptions import SoCoUPnPException
-from soco.services import (
-    Service, Action, Argument, Vartype
-)
+from soco.services import Service, Action, Argument, Vartype
 
 try:
     from unittest import mock
@@ -22,69 +20,77 @@ except:
 # actual commands, but are valid XML/UPnP. They also contain unicode characters
 # to test unicode handling.
 
-DUMMY_ERROR = "".join([
-    '<?xml version="1.0"?>',
-    '<s:Envelope ',
-    'xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ',
-    's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
-        '<s:Body>',
-            '<s:Fault>',
-                '<faultcode>s:Client</faultcode>',
-                '<faultstring>UPnPError</faultstring>',
-                '<detail>',
-                    '<UPnPError xmlns="urn:schemas-upnp-org:control-1-0">',
-                        '<errorCode>607</errorCode>',
-                        '<errorDescription>Oops μИⅠℂ☺ΔЄ💋</errorDescription>',
-                    '</UPnPError>',
-                '</detail>',
-            '</s:Fault>',
-        '</s:Body>',
-    '</s:Envelope>'])  # noqa PEP8
+DUMMY_ERROR = "".join(
+    [
+        '<?xml version="1.0"?>',
+        "<s:Envelope ",
+        'xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ',
+        's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
+        "<s:Body>",
+        "<s:Fault>",
+        "<faultcode>s:Client</faultcode>",
+        "<faultstring>UPnPError</faultstring>",
+        "<detail>",
+        '<UPnPError xmlns="urn:schemas-upnp-org:control-1-0">',
+        "<errorCode>607</errorCode>",
+        "<errorDescription>Oops μИⅠℂ☺ΔЄ💋</errorDescription>",
+        "</UPnPError>",
+        "</detail>",
+        "</s:Fault>",
+        "</s:Body>",
+        "</s:Envelope>",
+    ]
+)  # noqa PEP8
 
-DUMMY_VALID_RESPONSE = "".join([
-    '<?xml version="1.0"?>',
-    '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
+DUMMY_VALID_RESPONSE = "".join(
+    [
+        '<?xml version="1.0"?>',
+        '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
         ' s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
-        '<s:Body>',
-            '<u:GetLEDStateResponse ',
-                'xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1">',
-                '<CurrentLEDState>On</CurrentLEDState>',
-                '<Unicode>μИⅠℂ☺ΔЄ💋</Unicode>',
-        '</u:GetLEDStateResponse>',
-        '</s:Body>',
-    '</s:Envelope>'])  # noqa PEP8
+        "<s:Body>",
+        "<u:GetLEDStateResponse ",
+        'xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1">',
+        "<CurrentLEDState>On</CurrentLEDState>",
+        "<Unicode>μИⅠℂ☺ΔЄ💋</Unicode>",
+        "</u:GetLEDStateResponse>",
+        "</s:Body>",
+        "</s:Envelope>",
+    ]
+)  # noqa PEP8
 
-DUMMY_VALID_ACTION = "".join([
-    '<?xml version="1.0"?>',
-    '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
+DUMMY_VALID_ACTION = "".join(
+    [
+        '<?xml version="1.0"?>',
+        '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
         ' s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
-        '<s:Body>',
-            '<u:SetAVTransportURI ',
-                'xmlns:u="urn:schemas-upnp-org:service:Service:1">',
-                '<InstanceID>0</InstanceID>',
-                '<CurrentURI>URI</CurrentURI>',
-                '<CurrentURIMetaData></CurrentURIMetaData>',
-                '<Unicode>μИⅠℂ☺ΔЄ💋</Unicode>'
-            '</u:SetAVTransportURI>',
-        '</s:Body>'
-    '</s:Envelope>'])  # noqa PEP8
+        "<s:Body>",
+        "<u:SetAVTransportURI ",
+        'xmlns:u="urn:schemas-upnp-org:service:Service:1">',
+        "<InstanceID>0</InstanceID>",
+        "<CurrentURI>URI</CurrentURI>",
+        "<CurrentURIMetaData></CurrentURIMetaData>",
+        "<Unicode>μИⅠℂ☺ΔЄ💋</Unicode>" "</u:SetAVTransportURI>",
+        "</s:Body>" "</s:Envelope>",
+    ]
+)  # noqa PEP8
 
-DUMMY_VARTYPE = Vartype('string', None, None, None)
+DUMMY_VARTYPE = Vartype("string", None, None, None)
 
 DUMMY_ACTIONS = [
     Action(
-        name='Test',
+        name="Test",
         in_args=[
-            Argument(name='Argument1', vartype=DUMMY_VARTYPE),
-            Argument(name='Argument2', vartype=DUMMY_VARTYPE)
+            Argument(name="Argument1", vartype=DUMMY_VARTYPE),
+            Argument(name="Argument2", vartype=DUMMY_VARTYPE),
         ],
-        out_args=[]
+        out_args=[],
     )
 ]
 
-DUMMY_ARGS = [('Argument1', 1), ('Argument2', 2)]
+DUMMY_ARGS = [("Argument1", 1), ("Argument2", 2)]
 
-DUMMY_ARGS_ALTERNATIVE = [('Argument1', 3), ('Argument2', 2)]
+DUMMY_ARGS_ALTERNATIVE = [("Argument1", 3), ("Argument2", 2)]
+
 
 @pytest.fixture()
 def service():
@@ -110,12 +116,13 @@ def test_init_defaults(service):
 def test_method_dispatcher_function_creation(service):
     """Testing __getattr__ functionality."""
     import inspect
+
     # There should be no testing method
-    assert 'testing' not in service.__dict__.keys()
+    assert "testing" not in service.__dict__.keys()
     # but we should be able to inspect it
     assert inspect.ismethod(service.testing)
     # and then, having examined it, the method should be cached on the instance
-    assert 'testing' in service.__dict__.keys()
+    assert "testing" in service.__dict__.keys()
     assert service.testing.__name__ == "testing"
     # check that send_command is actually called when we invoke a method
     service.send_command = lambda x, y: "Hello {}".format(x)
@@ -127,44 +134,49 @@ def test_method_dispatcher_arg_count(service):
     service.send_command = mock.Mock()
     # http://bugs.python.org/issue7688
     # __name__ must be a string in python 2
-    method = service.__getattr__(str('test'))
-    assert method('onearg')
-    service.send_command.assert_called_with('test', 'onearg')
+    method = service.__getattr__(str("test"))
+    assert method("onearg")
+    service.send_command.assert_called_with("test", "onearg")
     assert method()  # no args
-    service.send_command.assert_called_with('test')
-    assert method('one', cache_timeout=4)  # one arg + cache_timeout
-    service.send_command.assert_called_with('test', 'one', cache_timeout=4)
+    service.send_command.assert_called_with("test")
+    assert method("one", cache_timeout=4)  # one arg + cache_timeout
+    service.send_command.assert_called_with("test", "one", cache_timeout=4)
 
 
 def test_wrap(service):
     """wrapping args in XML properly."""
-    assert service.wrap_arguments([('first', 'one'), ('second', 2)]) == \
-        "<first>one</first><second>2</second>"
+    assert (
+        service.wrap_arguments([("first", "one"), ("second", 2)])
+        == "<first>one</first><second>2</second>"
+    )
     assert service.wrap_arguments() == ""
     # Unicode
-    assert service.wrap_arguments([('unicode', "μИⅠℂ☺ΔЄ💋")]) == \
-        "<unicode>μИⅠℂ☺ΔЄ💋</unicode>"
+    assert (
+        service.wrap_arguments([("unicode", "μИⅠℂ☺ΔЄ💋")])
+        == "<unicode>μИⅠℂ☺ΔЄ💋</unicode>"
+    )
     # XML escaping - do we also need &apos; ?
-    assert service.wrap_arguments([('weird', '&<"2')]) == \
-        "<weird>&amp;&lt;&quot;2</weird>"
+    assert (
+        service.wrap_arguments([("weird", '&<"2')]) == "<weird>&amp;&lt;&quot;2</weird>"
+    )
 
 
 def test_unwrap(service):
     """unwrapping args from XML."""
     assert service.unwrap_arguments(DUMMY_VALID_RESPONSE) == {
         "CurrentLEDState": "On",
-        "Unicode": "μИⅠℂ☺ΔЄ💋"}
+        "Unicode": "μИⅠℂ☺ΔЄ💋",
+    }
 
 
 def test_unwrap_invalid_char(service):
     """Test unwrapping args from XML with invalid char"""
-    responce_with_invalid_char = DUMMY_VALID_RESPONSE.replace(
-        'μИⅠℂ☺ΔЄ💋', 'AB'
-    )
+    responce_with_invalid_char = DUMMY_VALID_RESPONSE.replace("μИⅠℂ☺ΔЄ💋", "AB")
     # Note, the invalid ^D (code point 0x04) should be filtered out
     assert service.unwrap_arguments(responce_with_invalid_char) == {
         "CurrentLEDState": "On",
-        "Unicode": "AB"}
+        "Unicode": "AB",
+    }
 
 
 def test_compose(service):
@@ -174,40 +186,44 @@ def test_compose(service):
 
     # Detect unknown action
     with pytest.raises(AttributeError):
-        service.compose_args('Error', {})
+        service.compose_args("Error", {})
     # Detect missing / unknown arguments
     with pytest.raises(ValueError):
-        service.compose_args('Test', {'Argument1': 1})
+        service.compose_args("Test", {"Argument1": 1})
     with pytest.raises(ValueError):
-        service.compose_args('Test', dict(DUMMY_ARGS+[('Error', 3)]))
+        service.compose_args("Test", dict(DUMMY_ARGS + [("Error", 3)]))
 
     # Check correct output
-    assert service.compose_args('Test', dict(DUMMY_ARGS)) == DUMMY_ARGS
+    assert service.compose_args("Test", dict(DUMMY_ARGS)) == DUMMY_ARGS
 
     # Set Argument1 = 1 as default
     service.DEFAULT_ARGS = dict(DUMMY_ARGS[:1])
 
     # Check that arguments are completed with default values
-    assert service.compose_args('Test', dict(DUMMY_ARGS[1:])) == DUMMY_ARGS
+    assert service.compose_args("Test", dict(DUMMY_ARGS[1:])) == DUMMY_ARGS
     # Check that given arguments override the default values
-    assert service.compose_args('Test', dict(DUMMY_ARGS_ALTERNATIVE)) \
+    assert (
+        service.compose_args("Test", dict(DUMMY_ARGS_ALTERNATIVE))
         == DUMMY_ARGS_ALTERNATIVE
-
+    )
 
 
 def test_build_command(service):
     """Test creation of SOAP body and headers from a command."""
-    headers, body = service.build_command('SetAVTransportURI', [
-        ('InstanceID', 0),
-        ('CurrentURI', 'URI'),
-        ('CurrentURIMetaData', ''),
-        ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-    ])
+    headers, body = service.build_command(
+        "SetAVTransportURI",
+        [
+            ("InstanceID", 0),
+            ("CurrentURI", "URI"),
+            ("CurrentURIMetaData", ""),
+            ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+        ],
+    )
     assert body == DUMMY_VALID_ACTION
     assert headers == {
-        'Content-Type': 'text/xml; charset="utf-8"',
-        'SOAPACTION':
-        'urn:schemas-upnp-org:service:Service:1#SetAVTransportURI'}
+        "Content-Type": 'text/xml; charset="utf-8"',
+        "SOAPACTION": "urn:schemas-upnp-org:service:Service:1#SetAVTransportURI",
+    }
 
 
 def test_send_command(service):
@@ -217,46 +233,63 @@ def test_send_command(service):
     response.headers = {}
     response.status_code = 200
     response.text = DUMMY_VALID_RESPONSE
-    with mock.patch('requests.post', return_value=response) as fake_post:
-        result = service.send_command('SetAVTransportURI', [
-            ('InstanceID', 0),
-            ('CurrentURI', 'URI'),
-            ('CurrentURIMetaData', ''),
-            ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-        ], cache_timeout=2)
-        assert result == {'CurrentLEDState': 'On', 'Unicode': "μИⅠℂ☺ΔЄ💋"}
+    with mock.patch("requests.post", return_value=response) as fake_post:
+        result = service.send_command(
+            "SetAVTransportURI",
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "URI"),
+                ("CurrentURIMetaData", ""),
+                ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+            ],
+            cache_timeout=2,
+        )
+        assert result == {"CurrentLEDState": "On", "Unicode": "μИⅠℂ☺ΔЄ💋"}
         fake_post.assert_called_once_with(
-            'http://192.168.1.101:1400/Service/Control',
-            headers=mock.ANY, data=DUMMY_VALID_ACTION.encode('utf-8'))
+            "http://192.168.1.101:1400/Service/Control",
+            headers=mock.ANY,
+            data=DUMMY_VALID_ACTION.encode("utf-8"),
+        )
         # Now the cache should be primed, so try it again
         fake_post.reset_mock()
-        result = service.send_command('SetAVTransportURI', [
-            ('InstanceID', 0),
-            ('CurrentURI', 'URI'),
-            ('CurrentURIMetaData', ''),
-            ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-        ], cache_timeout=0)
+        result = service.send_command(
+            "SetAVTransportURI",
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "URI"),
+                ("CurrentURIMetaData", ""),
+                ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+            ],
+            cache_timeout=0,
+        )
         # The cache should be hit, so there should be no http request
         assert not fake_post.called
         # but this should not affefct a call with different params
         fake_post.reset_mock()
-        result = service.send_command('SetAVTransportURI', [
-            ('InstanceID', 1),
-            ('CurrentURI', 'URI2'),
-            ('CurrentURIMetaData', 'abcd'),
-            ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-        ])
+        result = service.send_command(
+            "SetAVTransportURI",
+            [
+                ("InstanceID", 1),
+                ("CurrentURI", "URI2"),
+                ("CurrentURIMetaData", "abcd"),
+                ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+            ],
+        )
         assert fake_post.called
         # calling again after the time interval will avoid the cache
         fake_post.reset_mock()
         import time
+
         time.sleep(2)
-        result = service.send_command('SetAVTransportURI', [
-            ('InstanceID', 0),
-            ('CurrentURI', 'URI'),
-            ('CurrentURIMetaData', ''),
-            ('Unicode', 'μИⅠℂ☺ΔЄ💋')
-        ])
+        result = service.send_command(
+            "SetAVTransportURI",
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "URI"),
+                ("CurrentURIMetaData", ""),
+                ("Unicode", "μИⅠℂ☺ΔЄ💋"),
+            ],
+        )
         assert fake_post.called
 
 
@@ -264,10 +297,13 @@ def test_handle_upnp_error(service):
     """Check errors are extracted properly."""
     with pytest.raises(SoCoUPnPException) as E:
         service.handle_upnp_error(DUMMY_ERROR)
-    assert "UPnP Error 607 received: Signature Failure from 192.168.1.101" \
+    assert (
+        "UPnP Error 607 received: Signature Failure from 192.168.1.101"
         == E.value.message
-    assert E.value.error_code == '607'
-    assert E.value.error_description == 'Signature Failure'
+    )
+    assert E.value.error_code == "607"
+    assert E.value.error_description == "Signature Failure"
     # TODO: Try this with a None Error Code
+
 
 # TODO: test iter_actions

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,7 +13,7 @@ from soco.services import Service, Action, Argument, Vartype
 
 try:
     from unittest import mock
-except:
+except ImportError:
     import mock  # TODO: add mock to requirements
 
 # Dummy known-good errors/responses etc.  These are not necessarily valid as

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -9,7 +9,6 @@ from soco.core import _SocoSingletonBase as Base
 
 
 class ASingleton(Base):
-
     def __init__(self, arg):
         pass
 
@@ -19,14 +18,14 @@ class AnotherSingleton(ASingleton):
 
 
 class ThirdSingleton(Base):
-    _class_group = 'somegroup'
+    _class_group = "somegroup"
 
     def __init__(self, arg):
         pass
 
 
 class FourthSingleton(ASingleton):
-    _class_group = 'somegroup'
+    _class_group = "somegroup"
     pass
 
 
@@ -35,14 +34,14 @@ def test_singleton():
 
     For a given arg, there is only one instance
     """
-    assert ASingleton('aa') is ASingleton('aa')
-    assert ASingleton('aa') is not ASingleton('bb')
+    assert ASingleton("aa") is ASingleton("aa")
+    assert ASingleton("aa") is not ASingleton("bb")
 
 
 def test_singleton_inherit():
     """Check that subclasses behave properly."""
-    assert ASingleton('aa') is not AnotherSingleton('aa')
-    assert AnotherSingleton('aa') is AnotherSingleton('aa')
+    assert ASingleton("aa") is not AnotherSingleton("aa")
+    assert AnotherSingleton("aa") is AnotherSingleton("aa")
 
 
 def test_class_group_singleton():
@@ -51,6 +50,6 @@ def test_class_group_singleton():
     For a given arg, instances of FourthGroup are Instances of
     ThirdGroup because they share a `_class_group` valur
     """
-    assert ThirdSingleton('aa') is FourthSingleton('aa')
-    assert ThirdSingleton('aa') is not FourthSingleton('bb')
-    assert ThirdSingleton('aa') is not ASingleton('aa')
+    assert ThirdSingleton("aa") is FourthSingleton("aa")
+    assert ThirdSingleton("aa") is not FourthSingleton("bb")
+    assert ThirdSingleton("aa") is not ASingleton("aa")

--- a/tests/test_soap.py
+++ b/tests/test_soap.py
@@ -14,25 +14,28 @@ except ImportError:
     import mock
 
 
-DUMMY_VALID_RESPONSE = "".join([
-    '<?xml version="1.0"?>',
-    '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
-    ' s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
-    '<s:Body>',
-    '<u:GetLEDStateResponse ',
-    'xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1">',
-    '<CurrentLEDState>On</CurrentLEDState>',
-    '<Unicode>data</Unicode>',
-    '</u:GetLEDStateResponse>',
-    '</s:Body>',
-    '</s:Envelope>'])  # noqa PEP8
+DUMMY_VALID_RESPONSE = "".join(
+    [
+        '<?xml version="1.0"?>',
+        '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"',
+        ' s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">',
+        "<s:Body>",
+        "<u:GetLEDStateResponse ",
+        'xmlns:u="urn:schemas-upnp-org:service:DeviceProperties:1">',
+        "<CurrentLEDState>On</CurrentLEDState>",
+        "<Unicode>data</Unicode>",
+        "</u:GetLEDStateResponse>",
+        "</s:Body>",
+        "</s:Envelope>",
+    ]
+)  # noqa PEP8
 
 
 def test_init():
     """Tests for initialisation of classes."""
-    s = SoapMessage('http://endpoint_url', 'a_method')
+    s = SoapMessage("http://endpoint_url", "a_method")
     assert s.endpoint == "http://endpoint_url"
-    assert s.method == 'a_method'
+    assert s.method == "a_method"
     assert s.parameters == []
     assert s.soap_action is None
     assert s.http_headers is None
@@ -43,95 +46,110 @@ def test_init():
 
 def test_prepare_headers():
     """Check http_headers are correctly prepared."""
-    s = SoapMessage('endpoint', 'method')
-    h = s.prepare_headers({'test1': 'one', 'test2': 'two'}, None)
-    assert h == {'Content-Type': 'text/xml; charset="utf-8"',
-                 'test2': 'two', 'test1': 'one'}
-    h = s.prepare_headers(http_headers={'test1': 'one', 'test2': 'two'},
-                          soap_action='soapaction')
-    assert h == {'Content-Type': 'text/xml; charset="utf-8"',
-                 'test2': 'two', 'test1': 'one',
-                 'SOAPACTION': '"soapaction"'}
+    s = SoapMessage("endpoint", "method")
+    h = s.prepare_headers({"test1": "one", "test2": "two"}, None)
+    assert h == {
+        "Content-Type": 'text/xml; charset="utf-8"',
+        "test2": "two",
+        "test1": "one",
+    }
+    h = s.prepare_headers(
+        http_headers={"test1": "one", "test2": "two"}, soap_action="soapaction"
+    )
+    assert h == {
+        "Content-Type": 'text/xml; charset="utf-8"',
+        "test2": "two",
+        "test1": "one",
+        "SOAPACTION": '"soapaction"',
+    }
 
 
 def test_prepare_soap_header():
     """Check that the SOAP header is correctly wrapped."""
-    s = SoapMessage('endpoint', 'method')
-    h = s.prepare_soap_header('<a><b></b></a>')
+    s = SoapMessage("endpoint", "method")
+    h = s.prepare_soap_header("<a><b></b></a>")
     assert h == "<s:Header><a><b></b></a></s:Header>"
-    s = SoapMessage('endpoint', 'method', http_headers={
-        'test1': 'one', 'test2': 'two'})
+    s = SoapMessage("endpoint", "method", http_headers={"test1": "one", "test2": "two"})
     h = s.prepare_soap_header(None)
-    assert h == ''
+    assert h == ""
 
 
 def test_prepare_soap_body():
     """Check that the SOAP body is correctly prepared."""
     # No params
-    s = SoapMessage('endpoint', 'method')
-    b = s.prepare_soap_body('a_method', [], None)
+    s = SoapMessage("endpoint", "method")
+    b = s.prepare_soap_body("a_method", [], None)
     assert b == "<a_method></a_method>"
     # One param
-    b = s.prepare_soap_body('a_method', [('one', '1')], None)
+    b = s.prepare_soap_body("a_method", [("one", "1")], None)
     assert b == "<a_method><one>1</one></a_method>"
     # Two params
-    b = s.prepare_soap_body('a_method', [
-        ('one', '1'), ('two', '2')
-    ], None)
+    b = s.prepare_soap_body("a_method", [("one", "1"), ("two", "2")], None)
     assert b == "<a_method><one>1</one><two>2</two></a_method>"
 
     # And with a namespace
 
-    b = s.prepare_soap_body('a_method', [('one', '1'),
-                                         ('two', '2')], "http://a_namespace")
-    assert b == "<a_method " \
-                'xmlns="http://a_namespace"><one>1</one><two>2</two' \
-                '></a_method>'
+    b = s.prepare_soap_body(
+        "a_method", [("one", "1"), ("two", "2")], "http://a_namespace"
+    )
+    assert (
+        b == "<a_method "
+        'xmlns="http://a_namespace"><one>1</one><two>2</two'
+        "></a_method>"
+    )
 
 
 def test_prepare():
     """Test preparation of whole SOAP message."""
     s = SoapMessage(
-        endpoint='endpoint',
-        method='getData',
-        parameters=[('one', '1')],
-        http_headers={'timeout': '3'},
-        soap_action='ACTION',
+        endpoint="endpoint",
+        method="getData",
+        parameters=[("one", "1")],
+        http_headers={"timeout": "3"},
+        soap_action="ACTION",
         soap_header="<a_header>data</a_header>",
-        namespace="http://namespace.com")
+        namespace="http://namespace.com",
+    )
     headers, data = s.prepare()
-    assert data == '<?xml version="1.0"?><s:Envelope ' \
-                   'xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" ' \
-                   's:encodingStyle="http://schemas.xmlsoap.org/soap' \
-                   '/encoding/"><s:Header><a_header>data</a_header></s' \
-                   ':Header><s:Body><getData ' \
-                   'xmlns="http://namespace.com"><one>1</one></getData></s' \
-                   ':Body></s:Envelope>'
+    assert (
+        data == '<?xml version="1.0"?><s:Envelope '
+        'xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" '
+        's:encodingStyle="http://schemas.xmlsoap.org/soap'
+        '/encoding/"><s:Header><a_header>data</a_header></s'
+        ":Header><s:Body><getData "
+        'xmlns="http://namespace.com"><one>1</one></getData></s'
+        ":Body></s:Envelope>"
+    )
 
 
 def test_call():
     """Calling a command should result in an http request."""
 
     s = SoapMessage(
-        endpoint='http://endpoint.example.com',
-        method='getData',
-        parameters=[('one', '1')],
-        http_headers={'user-agent': 'sonos'},
-        soap_action='ACTION',
+        endpoint="http://endpoint.example.com",
+        method="getData",
+        parameters=[("one", "1")],
+        http_headers={"user-agent": "sonos"},
+        soap_action="ACTION",
         soap_header="<a_header>data</a_header>",
         namespace="http://namespace.com",
-        other_arg=4)
+        other_arg=4,
+    )
 
     response = mock.MagicMock()
     response.headers = {}
     response.status_code = 200
     response.content = DUMMY_VALID_RESPONSE
-    with mock.patch('requests.post', return_value=response) as fake_post:
+    with mock.patch("requests.post", return_value=response) as fake_post:
         result = s.call()
         assert XML.tostring(result)
         fake_post.assert_called_once_with(
-            'http://endpoint.example.com',
-            headers={'SOAPACTION': '"ACTION"',
-                     'Content-Type': 'text/xml; charset="utf-8"', 'user-agent':
-                         'sonos'},
-            data=mock.ANY, other_arg=4)
+            "http://endpoint.example.com",
+            headers={
+                "SOAPACTION": '"ACTION"',
+                "Content-Type": 'text/xml; charset="utf-8"',
+                "user-agent": "sonos",
+            },
+            data=mock.ANY,
+            other_arg=4,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,28 +10,31 @@ from soco.utils import deprecated
 
 
 def test_deprecation(recwarn):
-
-    @deprecated('0.7')
+    @deprecated("0.7")
     def dummy(args):
         """My docs."""
         pass
 
-    @deprecated('0.8', 'better_function', '0.12')
+    @deprecated("0.8", "better_function", "0.12")
     def dummy2(args):
         """My docs."""
         pass
 
     assert dummy.__doc__ == "My docs.\n\n  .. deprecated:: 0.7\n"
-    assert dummy2.__doc__ == "My docs.\n\n  .. deprecated:: 0.8\n\n"\
-                             "     Will be removed in version 0.12.\n" \
-                             "     Use `better_function` instead."
+    assert (
+        dummy2.__doc__ == "My docs.\n\n  .. deprecated:: 0.8\n\n"
+        "     Will be removed in version 0.12.\n"
+        "     Use `better_function` instead."
+    )
     dummy(3)
     w = recwarn.pop()
-    assert str(w.message) == 'Call to deprecated function dummy.'
+    assert str(w.message) == "Call to deprecated function dummy."
     dummy2(4)
     w = recwarn.pop()
-    assert str(w.message) == "Call to deprecated function dummy2. Will be " \
-                             "removed in version 0.12. Use " \
-                             "better_function instead."
+    assert (
+        str(w.message) == "Call to deprecated function dummy2. Will be "
+        "removed in version 0.12. Use "
+        "better_function instead."
+    )
     assert w.filename
     assert w.lineno

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -9,10 +9,12 @@ from soco import xml
 
 def test_ns_tag():
     """Test the ns_tag function."""
-    namespaces = ['http://purl.org/dc/elements/1.1/',
-                  'urn:schemas-upnp-org:metadata-1-0/upnp/',
-                  'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/']
-    for ns_in, namespace in zip(['dc', 'upnp', ''], namespaces):
-        res = xml.ns_tag(ns_in, 'testtag')
-        correct = '{{{}}}{}'.format(namespace, 'testtag')
+    namespaces = [
+        "http://purl.org/dc/elements/1.1/",
+        "urn:schemas-upnp-org:metadata-1-0/upnp/",
+        "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
+    ]
+    for ns_in, namespace in zip(["dc", "upnp", ""], namespaces):
+        res = xml.ns_tag(ns_in, "testtag")
+        correct = "{{{}}}{}".format(namespace, "testtag")
         assert res == correct


### PR DESCRIPTION
Yeah. There is finally a PR to paint SoCo black.

black is "the uncomprimising code formatter" (https://github.com/psf/black) and its sole purpose is to format **all** code into a consistent style. black **is** uncompromising, in that it allows very little customization, but personally I find that I much prefer to have a codestyle tool that can't be modified, to debating which style is best. From my perspective, codestyle consistency is a hell of a lot more important that the itty bitty details of the style.

But perhaps the biggest advantage of black is that it almost removes code style discussions from reviews. I set it up so that there is a travisCI check that checks that the branch is black formatted. As those of that have gone through a review with me will know, I do care about style, but implementing it this way will remove the need to comment on codestyle to the point where I can just refer to the tool.

I painted both soco, the examples and the tests black. As an added advantage to this, black formatting the test code brought it within an hours of work to make it pass linting as well, which means that we now have linted test code as well :man_cartwheeling: 

Since this is code formatting, it touches just about all lines of code, which means that all other PRs will break, but I will help with that.

Let me know what you think.