### PR TITLE
Autogenerate vendor extended DIDL-Lite classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "pypy"  # Run slowest first so as not to hold up the build
   - "pypy3"
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -982,7 +982,7 @@ class DidlMusicAlbum(DidlAlbum):
     )
 
 
-class DidlMusicAlbumFavorite(DidlAlbum):
+class DidlMusicAlbumFavorite(DidlMusicAlbum):
 
     """Class that represents a Sonos favorite music library album.
 
@@ -997,7 +997,7 @@ class DidlMusicAlbumFavorite(DidlAlbum):
     tag = "item"
 
 
-class DidlMusicAlbumCompilation(DidlAlbum):
+class DidlMusicAlbumCompilation(DidlMusicAlbum):
 
     """Class that represents a Sonos favorite music library compilation.
 

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import logging
 
 from .xml import XML, ns_tag
-from .data_structures import _DIDL_CLASS_TO_CLASS
+from .data_structures import didl_class_to_soco_class
 from .exceptions import DIDLMetadataError
 from .compat import urlparse
 from .music_services.data_structures import get_class
@@ -36,16 +36,7 @@ def from_didl_string(string):
     for elt in root:
         if elt.tag.endswith("item") or elt.tag.endswith("container"):
             item_class = elt.findtext(ns_tag("upnp", "class"))
-
-            # In case this class has an # specified unofficial
-            # subclass, ignore it by stripping it from item_class
-            if ".#" in item_class:
-                item_class = item_class[: item_class.find(".#")]
-
-            try:
-                cls = _DIDL_CLASS_TO_CLASS[item_class]
-            except KeyError:
-                raise DIDLMetadataError("Unknown UPnP class: %s" % item_class)
+            cls = didl_class_to_soco_class(item_class)
             item = cls.from_element(elt)
             item = attempt_datastructure_upgrade(item)
             items.append(item)

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -187,3 +187,8 @@ def url_escape_path(path):
     """
     # Using 'safe' arg does not seem to work for python 2.6
     return quote_url(path.encode("utf-8")).replace("/", "%2F")
+
+
+def first_cap(string):
+    """Return upper cased first character"""
+    return string[0].upper() + string[1:]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,14 @@
 Add the --ip command line option, and skip all tests marked the with
 'integration' marker unless the option is included
 """
+from os import path
+import json
+import codecs
+
+
 import pytest
+
+THISDIR = path.dirname(path.abspath(__file__))
 
 
 def pytest_addoption(parser):
@@ -53,3 +60,32 @@ class Helpers(object):
 @pytest.fixture
 def helpers():
     return Helpers
+
+
+class DataLoader:
+    """A class that loads test data"""
+
+    def __init__(self, data_sub_dir):
+        self.data_dir = path.join(THISDIR, "data", data_sub_dir)
+
+    def load_xml(self, filename):
+        """Return XML string loaded from filename under ``self.data_sub_dir``"""
+        xml_string = ""
+        with codecs.open(path.join(self.data_dir, filename), encoding="utf-8") as file_:
+            for line in file_:
+                # Allow for indenting the XML source
+                xml_string += line.lstrip(" ")
+        return xml_string
+
+    def load_json(self, filename):
+        """Return parsed data from json file"""
+        with open(path.join(self.data_dir, filename)) as file_:
+            data = json.load(file_)
+        return data
+
+    def load_xml_and_json(self, filename_base):
+        """Return XML string and parsed data from ``filename_base``.xml and .json"""
+        return (
+            self.load_xml(filename_base + ".xml"),
+            self.load_json(filename_base + ".json"),
+        )

--- a/tests/data/data_structures_entry_integration/album.json
+++ b/tests/data/data_structures_entry_integration/album.json
@@ -1,0 +1,4 @@
+{
+    "title": "St. Anger",
+    "creator": "Metallica"
+}

--- a/tests/data/data_structures_entry_integration/album.xml
+++ b/tests/data/data_structures_entry_integration/album.xml
@@ -1,0 +1,9 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:ALBUM/St.%20Anger" parentID="A:ALBUM" restricted="true">
+    <dc:title>St. Anger</dc:title>
+    <upnp:class>object.container.album.musicAlbum</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000E5884455C01400#A:ALBUM/St.%20Anger</res>
+    <dc:creator>Metallica</dc:creator>
+    <upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fmyweb%2fmusic%2fogg%2fMetallica%2520-%2520St.%2520Anger%2f01%2520-%2520Frantic.ogg&amp;v=15</upnp:albumArtURI>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/album_compilation.xml
+++ b/tests/data/data_structures_entry_integration/album_compilation.xml
@@ -1,0 +1,9 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:ALBUM/St.%20Anger" parentID="A:ALBUM" restricted="true">
+    <dc:title>St. Anger</dc:title>
+    <upnp:class>object.container.album.musicAlbum.compilation</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000E5884455C01400#A:ALBUM/St.%20Anger</res>
+    <dc:creator>Metallica</dc:creator>
+    <upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fmyweb%2fmusic%2fogg%2fMetallica%2520-%2520St.%2520Anger%2f01%2520-%2520Frantic.ogg&amp;v=15</upnp:albumArtURI>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/album_favorite.xml
+++ b/tests/data/data_structures_entry_integration/album_favorite.xml
@@ -1,0 +1,9 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:ALBUM/St.%20Anger" parentID="A:ALBUM" restricted="true">
+    <dc:title>St. Anger</dc:title>
+    <upnp:class>object.container.album.musicAlbum.sonos-favorite</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_000E5884455C01400#A:ALBUM/St.%20Anger</res>
+    <dc:creator>Metallica</dc:creator>
+    <upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fmyweb%2fmusic%2fogg%2fMetallica%2520-%2520St.%2520Anger%2f01%2520-%2520Frantic.ogg&amp;v=15</upnp:albumArtURI>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/album_list.xml
+++ b/tests/data/data_structures_entry_integration/album_list.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music" parentID="S:" restricted="true">
+    <dc:title>//myweb/music</dc:title>
+    <upnp:class>object.container.albumlist</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_B8E93781F3EA01400#S://myweb/music</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/artist.json
+++ b/tests/data/data_structures_entry_integration/artist.json
@@ -1,0 +1,1 @@
+{"title": "Anne Linnet"}

--- a/tests/data/data_structures_entry_integration/artist.xml
+++ b/tests/data/data_structures_entry_integration/artist.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:ARTIST/Anne%20Linnet" parentID="A:ARTIST" restricted="true">
+    <dc:title>Anne Linnet</dc:title>
+    <upnp:class>object.container.person.musicArtist</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_B8E93781F3EA01400#A:ARTIST/Anne%20Linnet</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/audio_broadcast.json
+++ b/tests/data/data_structures_entry_integration/audio_broadcast.json
@@ -1,0 +1,1 @@
+{"title": "DR P3 93.9 (Euro Hits)"}

--- a/tests/data/data_structures_entry_integration/audio_broadcast.xml
+++ b/tests/data/data_structures_entry_integration/audio_broadcast.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <item id="R:0/0/12" parentID="R:0/0" restricted="false">
+    <dc:title>DR P3 93.9 (Euro Hits)</dc:title>
+    <upnp:class>object.item.audioItem.audioBroadcast</upnp:class>
+    <res protocolInfo="x-rincon-mp3radio:*:*:*">x-sonosapi-stream:s24861?sid=254&amp;flags=32</res>
+  </item>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/composer.json
+++ b/tests/data/data_structures_entry_integration/composer.json
@@ -1,0 +1,1 @@
+{"title": "Alicia Keys/Warryn Smiley Campbell"}

--- a/tests/data/data_structures_entry_integration/composer.xml
+++ b/tests/data/data_structures_entry_integration/composer.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:COMPOSER/Alicia%20Keys%2fWarryn%20Smiley%20Campbell" parentID="A:COMPOSER" restricted="true">
+    <dc:title>Alicia Keys/Warryn Smiley Campbell</dc:title>
+    <upnp:class>object.container.person.composer</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_B8E93781F3EA01400#A:COMPOSER/Alicia%20Keys%2fWarryn%20Smiley%20Campbell</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/genre.json
+++ b/tests/data/data_structures_entry_integration/genre.json
@@ -1,0 +1,1 @@
+{"title": "Choral"}

--- a/tests/data/data_structures_entry_integration/genre.xml
+++ b/tests/data/data_structures_entry_integration/genre.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="A:GENRE/Choral" parentID="A:GENRE" restricted="true">
+    <dc:title>Choral</dc:title>
+    <upnp:class>object.container.genre.musicGenre</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_B8E93781F3EA01400#A:GENRE/Choral</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/playlist.json
+++ b/tests/data/data_structures_entry_integration/playlist.json
@@ -1,0 +1,1 @@
+{"title": "000-christina_aguilera-back_to_basics-2cd-2006.m3u"}

--- a/tests/data/data_structures_entry_integration/playlist.xml
+++ b/tests/data/data_structures_entry_integration/playlist.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u" parentID="A:PLAYLISTS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpegurl:*">x-file-cifs://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u</res>
+    <dc:title>000-christina_aguilera-back_to_basics-2cd-2006.m3u</dc:title>
+    <upnp:class>object.container.playlistContainer</upnp:class>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/playlist_favorite.xml
+++ b/tests/data/data_structures_entry_integration/playlist_favorite.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u" parentID="A:PLAYLISTS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpegurl:*">x-file-cifs://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u</res>
+    <dc:title>000-christina_aguilera-back_to_basics-2cd-2006.m3u</dc:title>
+    <upnp:class>object.container.playlistContainer.sonos-favorite</upnp:class>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/radio_show.json
+++ b/tests/data/data_structures_entry_integration/radio_show.json
@@ -1,0 +1,1 @@
+{"title": "Hitlisten på P7 MIX"}

--- a/tests/data/data_structures_entry_integration/radio_show.xml
+++ b/tests/data/data_structures_entry_integration/radio_show.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="R:0/1/29" parentID="R:0/1" restricted="false">
+    <dc:title>Hitlisten på P7 MIX</dc:title>
+    <upnp:class>object.container.radioShow</upnp:class>
+    <res protocolInfo="x-sonosapi-show:*:*:*">x-sonosapi-show:F00080000p571331%3afavorite</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/recent_show.xml
+++ b/tests/data/data_structures_entry_integration/recent_show.xml
@@ -1,0 +1,11 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <item id="S://myweb/music/mp3/Den%20Sorte%20Skole%20-_Lektion%231/densorteskole_lektion%231/mp3/17%20-%20Track%2017.mp3" parentID="A:TRACKS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://myweb/music/mp3/Den%20Sorte%20Skole%20-_Lektion%231/densorteskole_lektion%231/mp3/17%20-%20Track%2017.mp3</res>
+    <upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fmyweb%2fmusic%2fmp3%2fDen%2520Sorte%2520Skole%2520-_Lektion%25231%2fdensorteskole_lektion%25231%2fmp3%2f17%2520-%2520Track%252017.mp3&amp;v=15</upnp:albumArtURI>
+    <dc:title>17 - Track 17</dc:title>
+    <upnp:class>object.item.audioItem.musicTrack.recentShow</upnp:class>
+    <dc:creator>Den sorte skole</dc:creator>
+    <upnp:album>Lektion #1 (Mix tape)</upnp:album>
+    <r:episodeNumber>0</r:episodeNumber>
+  </item>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/same_artist.xml
+++ b/tests/data/data_structures_entry_integration/same_artist.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u" parentID="A:PLAYLISTS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpegurl:*">x-file-cifs://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u</res>
+    <dc:title>000-christina_aguilera-back_to_basics-2cd-2006.m3u</dc:title>
+    <upnp:class>object.container.playlistContainer.sameArtist</upnp:class>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/share.json
+++ b/tests/data/data_structures_entry_integration/share.json
@@ -1,0 +1,1 @@
+{"title": "//myweb/music"}

--- a/tests/data/data_structures_entry_integration/share.xml
+++ b/tests/data/data_structures_entry_integration/share.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music" parentID="S:" restricted="true">
+    <dc:title>//myweb/music</dc:title>
+    <upnp:class>object.container</upnp:class>
+    <res protocolInfo="x-rincon-playlist:*:*:*">x-rincon-playlist:RINCON_B8E93781F3EA01400#S://myweb/music</res>
+  </container>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/track.json
+++ b/tests/data/data_structures_entry_integration/track.json
@@ -1,0 +1,5 @@
+{
+    "title": "17 - Track 17",
+    "creator": "Den sorte skole",
+    "album": "Lektion #1 (Mix tape)"
+}

--- a/tests/data/data_structures_entry_integration/track.xml
+++ b/tests/data/data_structures_entry_integration/track.xml
@@ -1,0 +1,11 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <item id="S://myweb/music/mp3/Den%20Sorte%20Skole%20-_Lektion%231/densorteskole_lektion%231/mp3/17%20-%20Track%2017.mp3" parentID="A:TRACKS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpeg:*">x-file-cifs://myweb/music/mp3/Den%20Sorte%20Skole%20-_Lektion%231/densorteskole_lektion%231/mp3/17%20-%20Track%2017.mp3</res>
+    <upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2fmyweb%2fmusic%2fmp3%2fDen%2520Sorte%2520Skole%2520-_Lektion%25231%2fdensorteskole_lektion%25231%2fmp3%2f17%2520-%2520Track%252017.mp3&amp;v=15</upnp:albumArtURI>
+    <dc:title>17 - Track 17</dc:title>
+    <upnp:class>object.item.audioItem.musicTrack</upnp:class>
+    <dc:creator>Den sorte skole</dc:creator>
+    <upnp:album>Lektion #1 (Mix tape)</upnp:album>
+    <r:episodeNumber>0</r:episodeNumber>
+  </item>
+</DIDL-Lite>

--- a/tests/data/data_structures_entry_integration/tracklist.xml
+++ b/tests/data/data_structures_entry_integration/tracklist.xml
@@ -1,0 +1,7 @@
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+  <container id="S://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u" parentID="A:PLAYLISTS" restricted="true">
+    <res protocolInfo="x-file-cifs:*:audio/mpegurl:*">x-file-cifs://myweb/music/mp3/Christina%20Aguilera%20-%20Back%20To%20Basics%202CD%202006/000-christina_aguilera-back_to_basics-2cd-2006.m3u</res>
+    <dc:title>000-christina_aguilera-back_to_basics-2cd-2006.m3u</dc:title>
+    <upnp:class>object.container.playlistContainer.tracklist</upnp:class>
+  </container>
+</DIDL-Lite>

--- a/tests/official_and_extended_didl_classes.txt
+++ b/tests/official_and_extended_didl_classes.txt
@@ -1,0 +1,28 @@
+# In the overview below, the first columns indicates whether the class is (O)fficial of (E)xtended
+#
+#
+# O object                                                  -> <class 'soco.data_structures.DidlObject'>
+# O object.item                                             -> <class 'soco.data_structures.DidlItem'>
+# O object.item.audioItem                                   -> <class 'soco.data_structures.DidlAudioItem'>
+# O object.item.audioItem.musicTrack                        -> <class 'soco.data_structures.DidlMusicTrack'>
+# O object.item.audioItem.audioBook                         -> <class 'soco.data_structures.DidlAudioBook'>
+# O object.item.audioItem.audioBroadcast                    -> <class 'soco.data_structures.DidlAudioBroadcast'>
+# E object.item.audioItem.musicTrack.recentShow             -> <class 'soco.data_structures.DidlRecentShow'>
+# E object.item.audioItem.audioBroadcast.sonos-favorite     -> <class 'soco.data_structures.DidlAudioBroadcastFavorite'>
+# E object.itemobject.item.sonos-favorite                   -> <class 'soco.data_structures.DidlFavorite'>
+# O object.container                                        -> <class 'soco.data_structures.DidlContainer'>
+# O object.container.album                                  -> <class 'soco.data_structures.DidlAlbum'>
+# O object.container.album.musicAlbum                       -> <class 'soco.data_structures.DidlMusicAlbum'>
+# E object.container.album.musicAlbum.sonos-favorite        -> <class 'soco.data_structures.DidlMusicAlbumFavorite'>
+# E object.container.album.musicAlbum.compilation           -> <class 'soco.data_structures.DidlMusicAlbumCompilation'>
+# O object.container.person                                 -> <class 'soco.data_structures.DidlPerson'>
+# E object.container.person.composer                        -> <class 'soco.data_structures.DidlComposer'>
+# O object.container.person.musicArtist                     -> <class 'soco.data_structures.DidlMusicArtist'>
+# E object.container.albumlist                              -> <class 'soco.data_structures.DidlAlbumList'>
+# O object.container.playlistContainer                      -> <class 'soco.data_structures.DidlPlaylistContainer'>
+# E object.container.playlistContainer.sameArtist           -> <class 'soco.data_structures.DidlSameArtist'>
+# E object.container.playlistContainer.sonos-favorite       -> <class 'soco.data_structures.DidlPlaylistContainerFavorite'>
+# E object.container.playlistContainer.tracklist            -> <class 'soco.data_structures.DidlPlaylistContainerTracklist'>
+# O object.container.genre                                  -> <class 'soco.data_structures.DidlGenre'>
+# O object.container.genre.musicGenre                       -> <class 'soco.data_structures.DidlMusicGenre'>
+# E object.container.radioShow                              -> <class 'soco.data_structures.DidlRadioShow'>

--- a/tests/test_data_structures_entry_integration.py
+++ b/tests/test_data_structures_entry_integration.py
@@ -1,0 +1,129 @@
+"""Integration test data_structures_entry"""
+
+import pytest
+
+from soco.data_structures_entry import from_didl_string
+from soco.data_structures import (
+    DidlMusicTrack,
+    DidlMusicArtist,
+    DidlMusicGenre,
+    DidlContainer,
+    DidlPlaylistContainer,
+    DidlMusicAlbum,
+    DidlPerson,
+    DidlAudioBroadcast,
+)
+
+
+from conftest import DataLoader
+
+DATA_LOADER = DataLoader("data_structures_entry_integration")
+
+
+TEST_ITEMS_DATA = (
+    (DidlMusicTrack, *DATA_LOADER.load_xml_and_json("track")),
+    (DidlMusicAlbum, *DATA_LOADER.load_xml_and_json("album")),
+    (DidlMusicArtist, *DATA_LOADER.load_xml_and_json("artist")),
+    (DidlMusicGenre, *DATA_LOADER.load_xml_and_json("genre")),
+    (DidlContainer, *DATA_LOADER.load_xml_and_json("share")),
+    (DidlPlaylistContainer, *DATA_LOADER.load_xml_and_json("playlist")),
+    (DidlAudioBroadcast, *DATA_LOADER.load_xml_and_json("audio_broadcast")),
+)
+
+
+@pytest.mark.parametrize(
+    "klass,didl_xml_string,data",
+    TEST_ITEMS_DATA,
+    ids=[i[0].__name__ for i in TEST_ITEMS_DATA],
+)
+def test_items(klass, didl_xml_string, data):
+    """Test standard DIDL item loading"""
+    item = from_didl_string(didl_xml_string)[0]
+    assert item.__class__ is klass
+    for key, value in data.items():
+        assert getattr(item, key) == value
+
+
+# FIXME For the tests below that doesn't have a dedicated JSON data file, the
+# XML used is faked, created by just editing the didl_class in a copy of the
+# XML of the class it is derived from and therefore also compared to the same
+# data as the class it is derived from. It should be replaced with data
+# captured in the wild.
+KNOWN_VENDOR_EXTENDED_CLASSES = (
+    (
+        "DidlRecentShow",
+        DidlMusicTrack,
+        DATA_LOADER.load_xml("recent_show.xml"),
+        DATA_LOADER.load_json("track.json"),
+    ),
+    (
+        "DidlMusicAlbumFavorite",
+        DidlMusicAlbum,
+        DATA_LOADER.load_xml("album_favorite.xml"),
+        DATA_LOADER.load_json("album.json"),
+    ),
+    (
+        "DidlMusicAlbumCompilation",
+        DidlMusicAlbum,
+        DATA_LOADER.load_xml("album_compilation.xml"),
+        DATA_LOADER.load_json("album.json"),
+    ),
+    (
+        "DidlComposer",
+        DidlPerson,
+        DATA_LOADER.load_xml("composer.xml"),
+        DATA_LOADER.load_json("composer.json"),
+    ),
+    (
+        "DidlAlbumList",
+        DidlContainer,
+        DATA_LOADER.load_xml("album_list.xml"),
+        DATA_LOADER.load_json("share.json"),
+    ),
+    (
+        "DidlSameArtist",
+        DidlPlaylistContainer,
+        DATA_LOADER.load_xml("same_artist.xml"),
+        DATA_LOADER.load_json("playlist.json"),
+    ),
+    (
+        "DidlPlaylistContainerFavorite",
+        DidlPlaylistContainer,
+        DATA_LOADER.load_xml("playlist_favorite.xml"),
+        DATA_LOADER.load_json("playlist.json"),
+    ),
+    (
+        "DidlPlaylistContainerTracklist",
+        DidlPlaylistContainer,
+        DATA_LOADER.load_xml("tracklist.xml"),
+        DATA_LOADER.load_json("playlist.json"),
+    ),
+    (
+        "DidlRadioShow",
+        DidlContainer,
+        DATA_LOADER.load_xml("radio_show.xml"),
+        DATA_LOADER.load_json("radio_show.json"),
+    ),
+)
+
+# There doesn't exist any tests of this kind yet for:
+# "object.item.audioItem.audioBroadcast.sonos-favorite"
+# "DidlAudioBroadcastFavorite",
+#
+# "object.itemobject.item.sonos-favorite"
+# "DidlFavorite",
+
+
+@pytest.mark.parametrize(
+    "class_name,base_class,didl_xml_string,data",
+    KNOWN_VENDOR_EXTENDED_CLASSES,
+    ids=[i[0] for i in KNOWN_VENDOR_EXTENDED_CLASSES],
+)
+def test_vendor_extended_didl_class(class_name, base_class, didl_xml_string, data):
+    """Test that vendor extended DIDL classes have proper names and base class"""
+    item = from_didl_string(didl_xml_string)[0]
+
+    # Test inheritance
+    assert item.__class__.__name__ == class_name
+    assert base_class is item.__class__.__bases__[0]
+    assert base_class._translation == item._translation

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -374,3 +374,27 @@ class TestDidlObject:
             + "RINCON_AssociatedZPUDN</desc></item></dummy>"
         )[0]
         assert_xml_equal(elt2, elt)
+
+
+# There is an overview of all observed classes, whether they are in or
+# out of base DIDL in official_and_extended_didl_classes.txt
+
+
+def test_didl_object_inheritance():
+    """Test that DIDL object inheritance is as indicated by the didl class"""
+    class_dict = data_structures._DIDL_CLASS_TO_CLASS.copy()
+    class_dict["object"] = data_structures.DidlObject
+    for didl_class, soco_class in data_structures._DIDL_CLASS_TO_CLASS.items():
+        # Skip this one, because its DIDL class is expected to be an error
+        if didl_class == "object.itemobject.item.sonos-favorite":
+            continue
+        # object does not inherit
+        if didl_class == "object":
+            continue
+
+        # First make sure it is registered with the correct DIDL class
+        assert didl_class == soco_class.item_class
+
+        base_didl_class = ".".join(didl_class.split(".")[:-1])
+        base_class = data_structures._DIDL_CLASS_TO_CLASS[base_didl_class]
+        assert base_class == soco_class.__bases__[0]


### PR DESCRIPTION
Ok. So this has been brewing. We see quite a lot of vendor extended DIDL-Lite classes on a Sonos network. Every time a music service supplier created a new one, this would cause an error in SoCo. This PR adds the ability to autogenerate unknown extended classes.

I also managed to find a way to name the new classes that is mostly compatible with the way we have done so far, which actually means that the vendor extended classes:

DidlRecentShow
DidlComposer
DidlAlbumList
DidlSameArtist
DidlPlaylistContainerFavorite
DidlRadioShow

in data_structures.py are now redundant. I have however chosen not to delete them, to make sure not to cause a regression if a user imports one of these classes directly.

The autogenerated classes are simple extensions of their base class which means the only item that gets changes is the ``item_class``. If the new class add attributes or has a non-standard content tag, then it will still be necessary to create the class by hand. But in all other cases, this should now work and that also means that we will not add anymore vendor extended classes to data_structures.py unless it is necessary for one of the two reasons mentioned above.

Comments and reviews welcome.