### PR TITLE
Fixes required to pass updated pylint checks

### DIFF
--- a/soco/cache.py
+++ b/soco/cache.py
@@ -2,7 +2,7 @@
 # pylint: disable=not-context-manager,useless-object-inheritance
 
 # NOTE: The pylint not-content-manager warning is disabled pending the fix of
-# a bug in pylint: https://github.com/PyCQA/pylint/issues/782
+# a bug in pylint https://github.com/PyCQA/pylint/issues/782
 
 # NOTE: useless-object-inheritance needed for Python 2.x compatability
 

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -203,7 +203,7 @@ class MetadataDictBase(object):
         for key in metadata_dict:
             # Check for invalid fields
             if key not in self._valid_fields:
-                message = '%s instantiated with invalid field "%s" and ' "value: %s"
+                message = '%s instantiated with invalid field "%s" and value: "%s"'
                 # Really wanted to raise exceptions here, but as it
                 # turns out I have already encountered invalid fields
                 # from music services.


### PR DESCRIPTION
 Pylint has been updated and is picking up a couple of new issues, hence all test builds will fail. This PR fixes the issues.