### PR TITLE
Lists 'sonos amp' as a soundbar in order to provide night mode and speech enhancement support for amp.

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -2122,7 +2122,7 @@ PLAY_MODES = (
     "REPEAT_ONE",
 )
 # soundbar product names
-SOUNDBARS = ("playbase", "playbar", "beam")
+SOUNDBARS = ("playbase", "playbar", "beam", "sonos amp")
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo


### PR DESCRIPTION
Night mode and speech enhancement is supported by Sonos amp, but the amp is not listed in the code, meaning it is not supported at present.