### PR TITLE
Network Scan Discovery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 xmltodict
+ifaddr

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -415,17 +415,17 @@ def scan_network(
 
         while True:
             try:
-                ip = ip_set.pop()
+                ip_addr = ip_set.pop()
             except KeyError:
                 break
 
-            ip_address = str(ip)
+            ip_address = str(ip_addr)
             try:
                 check = _check_ip_and_port(ip_address, 1400, socket_timeout)
             except OSError:
                 # With large numbers of threads, we can exceed the file handle limit.
                 # Put the address back on the list and drop out of this thread.
-                ip_set.add(ip)
+                ip_set.add(ip_addr)
                 break
 
             if check:

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -445,7 +445,7 @@ def scan_network(
         )
         try:
             thread.start()
-        except RuntimeError:
+        except (RuntimeError, OSError):
             # We probably can't start any more threads
             # Cease thread creation and continue
             _LOG.info(

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -244,7 +244,7 @@ def by_name(name):
     return None
 
 
-def scan_network_for_devices(max_threads=256, timeout=1.0, include_invisible=False):
+def scan_network(max_threads=256, timeout=1.0, include_invisible=False):
     """Scan all attached networks for Sonos devices.
 
     Scans the IPv4 network attached to each interface to check for network devices
@@ -292,11 +292,11 @@ def scan_network_for_devices(max_threads=256, timeout=1.0, include_invisible=Fal
                             ipv4_net_list.append(_network)
         return ipv4_net_list
 
-    def check_ip_and_port(_ip_address, port, timeout):
+    def check_ip_and_port(ip_address, port, timeout):
         """Helper function to check if a port is open"""
         _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         _socket.settimeout(timeout)
-        return bool(_socket.connect_ex((_ip_address, port)))
+        return not bool(_socket.connect_ex((ip_address, port)))
 
     def sonos_scan_worker_thread(ip_list, socket_timeout, sonos_ip_addresses):
         """Helper function worker thread to take IP addresses off a list and
@@ -314,8 +314,8 @@ def scan_network_for_devices(max_threads=256, timeout=1.0, include_invisible=Fal
     # Generate the list of IPs to check
     ip_check_list = []
     for network in find_ipv4_networks():
-        for ip_addr in network:
-            ip_check_list.append(ip_addr)
+        for ip_address in network:
+            ip_check_list.append(ip_address)
     # Find IP addresses with open port 1400
     # Use threading to scan the IP range efficiently
     sonos_ip_addresses = []
@@ -332,7 +332,7 @@ def scan_network_for_devices(max_threads=256, timeout=1.0, include_invisible=Fal
     # Wait for all threads to finish
     for thread in thread_list:
         thread.join()
-    # Pick the first IP address to create a SoCo instance
+    # Pick the first IP address in the list to create a SoCo instance
     for ip_address in sonos_ip_addresses:
         try:
             zone = config.SOCO_CLASS(ip_address)

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -382,8 +382,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
     # Generate the set of IPs to check
     ip_set = set()
     for network in find_ipv4_networks(min_netmask):
-        for ip_address in network:
-            ip_set.add(ip_address)
+        ip_set.update(network)
 
     # Find Sonos devices on the list of IPs
     # Use threading to scan the list efficiently

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -332,12 +332,14 @@ def _check_ip_and_port(ip_address, port, timeout):
         bool: True if a connection can be made.
     """
 
+    _socket = None
     try:
         _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         _socket.settimeout(timeout)
         return not bool(_socket.connect_ex((ip_address, port)))
     finally:
-        _socket.close()
+        if _socket:
+            _socket.close()
 
 
 def _is_sonos(ip_address):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -23,10 +23,7 @@ _LOG = logging.getLogger(__name__)
 
 
 def discover(
-    timeout=5,
-    include_invisible=False,
-    interface_addr=None,
-    **network_scan_kwargs,
+    timeout=5, include_invisible=False, interface_addr=None, **network_scan_kwargs
 ):
     """Discover Sonos zones on the local network.
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -332,12 +332,18 @@ def scan_network(max_threads=256, timeout=3.0, include_invisible=False):
     if max_threads > len(ip_check_list):
         max_threads = len(ip_check_list)
     for _ in range(max_threads):
-        thread = threading.Thread(
-            target=sonos_scan_worker_thread,
-            args=(ip_check_list, timeout, sonos_ip_addresses),
-        )
-        thread_list.append(thread)
-        thread.start()
+        try:
+            thread = threading.Thread(
+                target=sonos_scan_worker_thread,
+                args=(ip_check_list, timeout, sonos_ip_addresses),
+            )
+            thread_list.append(thread)
+            thread.start()
+        except RuntimeError:
+            # We probably can't crate any more threads. Continue without
+            # creating additional threads.
+            break
+
     # Wait for all threads to finish
     for thread in thread_list:
         thread.join()

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -343,9 +343,12 @@ def _check_ip_and_port(ip_address, port, timeout):
         bool: True if a connection can be made.
     """
 
-    _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    _socket.settimeout(timeout)
-    return not bool(_socket.connect_ex((ip_address, port)))
+    try:
+        _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        _socket.settimeout(timeout)
+        return not bool(_socket.connect_ex((ip_address, port)))
+    finally:
+        _socket.close()
 
 
 def _is_sonos(ip_address):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -413,19 +413,21 @@ def scan_network_by_household_id(
         include_invisible (bool, optional): Whether to include invisible Sonos devices
             in the set of devices returned.
         **network_scan_kwargs: Arguments for the `scan_network` function.
-            See its docstring for details. Note that the argument
+            See its docstring for details. (Note that the argument
             'multi_household' is forced to `True` when this function is
-            called.
+            called.)
 
     Returns:
         set: A set of `SoCo` instances, one for each zone found, or else `None`.
     """
 
+    # Take a copy to avoid creating side effects
+    new_kwargs = network_scan_kwargs
     # multi_household must be set to True
-    network_scan_kwargs["multi_household"] = True
-    zones = scan_network(include_invisible=include_invisible, **network_scan_kwargs)
+    new_kwargs["multi_household"] = True
+    zones = scan_network(include_invisible=include_invisible, **new_kwargs)
     if zones:
-        zones = {x for x in zones if x.household_id == household_id}
+        zones = {zone for zone in zones if zone.household_id == household_id}
     _LOG.info("Returning zones: %s", zones)
     return zones
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -277,7 +277,7 @@ def by_name(name, allow_network_scan=False, min_netmask=24):
     return None
 
 
-def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible=False):
+def scan_network(max_threads=256, timeout=0.1, min_netmask=24, include_invisible=False):
     """Scan all attached networks for Sonos devices.
 
     Scans the IPv4 network attached to each interface to check for network devices

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -293,8 +293,9 @@ def scan_network(
     This function is intended for use when the usual discovery function is not
     working, perhaps due to multicast problems on the network to which the SoCo
     host is attached. The function can also be used to find a complete list of
-    speakers across multiple Sonos Households. For example, this is the case
-    where there are 'split' S1/S2 Sonos systems on the network.
+    speakers when there are multiple Sonos households present.
+    For example, this is the case where there are 'split' S1/S2 Sonos systems
+    on the network.
 
     Note that this call may fail to find speakers present on the network, and
     this can be due to ARP cache misses and ARP requests that don't
@@ -405,10 +406,10 @@ def scan_network_by_household_id(
     household_id, include_invisible=False, **network_scan_kwargs
 ):
     """Convenience function to find the zones in a specific Sonos
-    Household.
+    household.
 
     Args:
-        household_id (str): The Sonos Household ID to search for. IDs take the
+        household_id (str): The Sonos household ID to search for. IDs take the
             form 'Sonos_XXXXXXXXXXXXXXXXXXXXXXXXXX'.
         include_invisible (bool, optional): Whether to include invisible Sonos devices
             in the set of devices returned.
@@ -421,11 +422,9 @@ def scan_network_by_household_id(
         set: A set of `SoCo` instances, one for each zone found, or else `None`.
     """
 
-    # Take a copy to avoid creating side effects
-    new_kwargs = network_scan_kwargs.copy()
     # multi_household must be set to True
-    new_kwargs["multi_household"] = True
-    zones = scan_network(include_invisible=include_invisible, **new_kwargs)
+    network_scan_kwargs["multi_household"] = True
+    zones = scan_network(include_invisible=include_invisible, **network_scan_kwargs)
     if zones:
         zones = {zone for zone in zones if zone.household_id == household_id}
     _LOG.info("Returning zones: %s", zones)
@@ -443,22 +442,20 @@ def scan_network_get_household_ids(**network_scan_kwargs):
             called.)
 
     Returns:
-        list: A list of Sonos Household IDs, each in the form of a `str`
+        set: A set of Sonos household IDs, each in the form of a `str`
         like 'Sonos_XXXXXXXXXXXXXXXXXXXXXXXXXX'.
     """
 
-    # Take a copy to avoid creating side effects
-    new_kwargs = network_scan_kwargs.copy()
     # multi_household must be set to True
-    new_kwargs["multi_household"] = True
-    zones = scan_network(include_invisible=True, **new_kwargs)
+    network_scan_kwargs["multi_household"] = True
+    zones = scan_network(include_invisible=True, **network_scan_kwargs)
     household_ids = set()
     if zones:
         for zone in zones:
             household_ids.add(zone.household_id)
 
     _LOG.info("Returning household IDs: %s", household_ids)
-    return list(household_ids)
+    return household_ids
 
 
 def scan_network_get_by_name(name, **network_scan_kwargs):
@@ -481,11 +478,9 @@ def scan_network_get_by_name(name, **network_scan_kwargs):
         matching zone is found. Only returns visible zones.
     """
 
-    # Take a copy to avoid creating side effects
-    new_kwargs = network_scan_kwargs.copy()
     # multi_household must be set to True
-    new_kwargs["multi_household"] = True
-    zones = scan_network(include_invisible=False, **new_kwargs)
+    network_scan_kwargs["multi_household"] = True
+    zones = scan_network(include_invisible=False, **network_scan_kwargs)
     matching_zone = None
     if zones:
         for zone in zones:

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -209,11 +209,11 @@ def discover(
                     else:
                         return zone.visible_zones
         elif network_scan_kwargs.get("allow_network_scan", False):
-                _LOG.info("Falling back to network scan discovery")
-                return scan_network(
-                    include_invisible=include_invisible,
-                    **network_scan_kwargs,
-                )
+            _LOG.info("Falling back to network scan discovery")
+            return scan_network(
+                include_invisible=include_invisible,
+                **network_scan_kwargs,
+            )
 
 
 def any_soco(**network_scan_kwargs):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -291,14 +291,14 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
     host is attached.
 
     Args:
-        max_threads (int, optional): The maximum number of threads to use when scanning the
-            network.
+        max_threads (int, optional): The maximum number of threads to use when
+            scanning the network.
         timeout (float, optional): The network timeout in seconds to use when checking
             each IP address for a Sonos device
         min_netmask (int, optional): The minimum number of netmask bits. Used to
                 constrain the network search space.
-        include_invisible (bool, optional): Whether to include invisible Sonos devices in
-            the set of devices returned.
+        include_invisible (bool, optional): Whether to include invisible Sonos devices
+            in the set of devices returned.
 
     Returns:
         set: A set of `SoCo` instances, one for each zone found, or else `None`.
@@ -338,7 +338,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
                             ip_address.ip + "/" + str(ip_address.network_prefix), False
                         )
                         ipv4_net_list.add(network)
-        _LOG.info("List of networks to search: {}".format(ipv4_net_list))
+        _LOG.info("List of networks to search: %s", str(ipv4_net_list))
         return ipv4_net_list
 
     def check_ip_and_port(ip_address, port, timeout):
@@ -356,7 +356,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         while len(ip_list) > 0:
             ip_addr = ip_list.pop()
             if check_ip_and_port(str(ip_addr), 1400, socket_timeout):
-                _LOG.info("Found open port 1400 at IP '{}'".format(str(ip_addr)))
+                _LOG.info("Found open port 1400 at IP '%s'", str(ip_addr))
                 sonos_ip_addresses.append(str(ip_addr))
                 # Clearing the list will eliminate further work by all threads
                 ip_list.clear()
@@ -396,7 +396,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
     for ip_address in sonos_ip_addresses:
         try:
             zone = config.SOCO_CLASS(ip_address)
-            _LOG.info("Found Sonos device at IP '{}'".format(ip_address))
+            _LOG.info("Found Sonos device at IP '%s'", ip_address)
             if include_invisible:
                 return zone.all_zones
             else:
@@ -406,6 +406,6 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
             # Although port 1400 is open, this is probably not a Sonos device.
             # I really do want to catch all exceptions here, then try the next
             # address if there is one.
-            _LOG.info("No Sonos device at IP '{}'".format(ip_address))
+            _LOG.info("No Sonos device at IP '%s'", ip_address)
             continue
     return None

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -363,6 +363,7 @@ def _is_sonos(ip_address):
         return False
 
 
+# pylint: disable=too-many-statements
 def scan_network(
     include_invisible=False,
     multi_household=False,
@@ -492,6 +493,7 @@ def scan_network(
         original_cache_state = core.zone_group_state_shared_cache.enabled
         if original_cache_state:
             core.zone_group_state_shared_cache.enabled = False
+            _LOG.info("Disabled SoCo caching")
 
     # Collect SoCo objects
     zones = set()
@@ -510,5 +512,10 @@ def scan_network(
     # Restore the original cache state if required
     if multi_household and original_cache_state:
         core.zone_group_state_shared_cache.enabled = True
+        _LOG.info("Re-enabled SoCo caching")
+
+    _LOG.info(
+        "Include invisible: %s | %d Zones: %s", include_invisible, len(zones), zones
+    )
 
     return list(zones)

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -338,6 +338,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
                             ip_address.ip + "/" + str(ip_address.network_prefix), False
                         )
                         ipv4_net_list.add(network)
+        _LOG.info("List of networks to search: {}".format(ipv4_net_list))
         return ipv4_net_list
 
     def check_ip_and_port(ip_address, port, timeout):
@@ -355,6 +356,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         while len(ip_list) > 0:
             ip_addr = ip_list.pop()
             if check_ip_and_port(str(ip_addr), 1400, socket_timeout):
+                _LOG.info("Found open port 1400 at IP '{}'".format(str(ip_addr)))
                 sonos_ip_addresses.append(str(ip_addr))
                 # Clearing the list will eliminate further work by all threads
                 ip_list.clear()
@@ -382,6 +384,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         except RuntimeError:
             # We probably can't create any more threads. Continue without
             # creating additional threads.
+            _LOG.info("Runtime error creating threads. Continuing")
             break
 
     # Wait for all threads to finish
@@ -389,10 +392,11 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         thread.join()
 
     # Pick the first IP address in the list to create a SoCo instance, and
-    # use it to determine the remaining zones
+    # use it to find the remaining zones
     for ip_address in sonos_ip_addresses:
         try:
             zone = config.SOCO_CLASS(ip_address)
+            _LOG.info("Found Sonos device at IP '{}'".format(ip_address))
             if include_invisible:
                 return zone.all_zones
             else:
@@ -402,5 +406,6 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
             # Although port 1400 is open, this is probably not a Sonos device.
             # I really do want to catch all exceptions here, then try the next
             # address if there is one.
+            _LOG.info("No Sonos device at IP '{}'".format(ip_address))
             continue
     return None

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -401,6 +401,35 @@ def scan_network(
     return zones
 
 
+def scan_network_by_household_id(
+    household_id, include_invisible=False, **network_scan_kwargs
+):
+    """Convenience function to find the zones in a specific Sonos
+    Household.
+
+    Args:
+        household_id (str): The Sonos Household ID to search for. IDs take the
+            form 'Sonos_XXXXXXXXXXXXXXXXXXXXXXXXXX'.
+        include_invisible (bool, optional): Whether to include invisible Sonos devices
+            in the set of devices returned.
+        **network_scan_kwargs: Arguments for the `scan_network` function.
+            See its docstring for details. Note that the argument
+            'multi_household' is forced to `True` when this function is
+            called.
+
+    Returns:
+        set: A set of `SoCo` instances, one for each zone found, or else `None`.
+    """
+
+    # multi_household must be set to True
+    network_scan_kwargs["multi_household"] = True
+    zones = scan_network(include_invisible=include_invisible, **network_scan_kwargs)
+    if zones:
+        zones = {x for x in zones if x.household_id == household_id}
+    _LOG.info("Returning zones: %s", zones)
+    return zones
+
+
 def _find_ipv4_networks(min_netmask):
     """Discover attached IP networks.
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -422,7 +422,7 @@ def scan_network_by_household_id(
     """
 
     # Take a copy to avoid creating side effects
-    new_kwargs = network_scan_kwargs
+    new_kwargs = network_scan_kwargs.copy()
     # multi_household must be set to True
     new_kwargs["multi_household"] = True
     zones = scan_network(include_invisible=include_invisible, **new_kwargs)

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -365,8 +365,11 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         Once a there is a hit, the list is cleared to prevent any further
         checking of addresses by any thread.
         """
-        while len(ip_list) > 0:
-            ip_address = str(ip_list.pop())
+        while True:
+            try:
+                ip_address = str(ip_list.pop())
+            except KeyError:
+                break
             if check_ip_and_port(ip_address, 1400, socket_timeout):
                 _LOG.info("Found open port 1400 at IP '%s'", ip_address)
                 if is_sonos(ip_address):
@@ -382,8 +385,8 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         for ip_address in network:
             ip_set.add(ip_address)
 
-    # Find IP addresses with open port 1400
-    # Use threading to scan the IP range efficiently
+    # Find Sonos devices on the list of IPs
+    # Use threading to scan the list efficiently
     sonos_ip_addresses = []
     thread_list = []
     if max_threads > len(ip_set):
@@ -414,6 +417,9 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
     # Use the first IP address in the list to create a SoCo instance, and
     # find the remaining zones
     zone = config.SOCO_CLASS(sonos_ip_addresses[0])
+    _LOG.info(
+        "Using zone '%s' (%s) to find other zones", zone.player_name, zone.ip_address
+    )
     if include_invisible:
         _LOG.info("Returning all Sonos zones: %s", str(zone.all_zones))
         return zone.all_zones

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -340,7 +340,7 @@ def scan_network(max_threads=256, timeout=3.0, include_invisible=False):
             thread_list.append(thread)
             thread.start()
         except RuntimeError:
-            # We probably can't crate any more threads. Continue without
+            # We probably can't create any more threads. Continue without
             # creating additional threads.
             break
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -427,6 +427,7 @@ def scan_network(include_invisible=False, **network_scan_kwargs):
 
     # No Sonos devices found
     if len(sonos_ip_addresses) == 0:
+        _LOG.info("No Sonos zones discovered")
         return None
 
     # Use the first IP address in the list to create a SoCo instance, and
@@ -436,8 +437,9 @@ def scan_network(include_invisible=False, **network_scan_kwargs):
         "Using zone '%s' (%s) to find other zones", zone.player_name, zone.ip_address
     )
     if include_invisible:
-        _LOG.info("Returning all Sonos zones: %s", str(zone.all_zones))
-        return zone.all_zones
+        zones = zone.all_zones
+        _LOG.info("Returning all Sonos zones: %s", str(zones))
     else:
-        _LOG.info("Returning visible Sonos zones: %s", str(zone.visible_zones))
-        return zone.visible_zones
+        zones = zone.visible_zones
+        _LOG.info("Returning visible Sonos zones: %s", str(zones))
+    return zones

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -52,7 +52,7 @@ def discover(
         allow_network_scan (bool, optional): If normal discovery fails, fall
             back to a scan of the attached network(s) to detect Sonos
             devices.
-        min_netmask (int): The minimum number of netmask bits. Used to
+        min_netmask (int, optional): The minimum number of netmask bits. Used to
             constrain the network search space when network scanning is
             used.
     Returns:
@@ -223,7 +223,7 @@ def any_soco(allow_network_scan=False, min_netmask=24):
         allow_network_scan (bool, optional): If normal discovery fails, fall
             back to a scan of the attached network(s) to detect Sonos
             devices.
-        min_netmask (int): The minimum number of netmask bits. Used to
+        min_netmask (int, optional): The minimum number of netmask bits. Used to
             constrain the network search space when network scanning is
             used.
 
@@ -259,7 +259,7 @@ def by_name(name, allow_network_scan=False, min_netmask=24):
         allow_network_scan (bool, optional): If normal discovery fails, fall
             back to a scan of the attached network(s) to detect Sonos
             devices.
-        min_netmask (int): The minimum number of netmask bits. Used to
+        min_netmask (int, optional): The minimum number of netmask bits. Used to
             constrain the network search space when network scanning is
             used.
 
@@ -291,13 +291,13 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
     host is attached.
 
     Args:
-        max_threads (int): The maximum number of threads to use when scanning the
+        max_threads (int, optional): The maximum number of threads to use when scanning the
             network.
-        timeout (float): The network timeout in seconds to use when checking
+        timeout (float, optional): The network timeout in seconds to use when checking
             each IP address for a Sonos device
-        min_netmask (int): The minimum number of netmask bits. Used to
+        min_netmask (int, optional): The minimum number of netmask bits. Used to
                 constrain the network search space.
-        include_invisible (bool): Whether to include invisible Sonos devices in
+        include_invisible (bool, optional): Whether to include invisible Sonos devices in
             the set of devices returned.
 
     Returns:
@@ -312,7 +312,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         except ValueError:
             return False
 
-    def find_ipv4_networks(min_netmask=24):
+    def find_ipv4_networks(min_netmask):
         """Helper function to return a set of IPv4 networks to which
         this node is attached.
 
@@ -363,7 +363,7 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
 
     # Generate the set of IPs to check
     ip_set = set()
-    for network in find_ipv4_networks(min_netmask=min_netmask):
+    for network in find_ipv4_networks(min_netmask):
         for ip_address in network:
             ip_set.add(ip_address)
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -284,19 +284,20 @@ def scan_network(max_threads=256, timeout=3.0, include_invisible=False):
         ipv4_net_list = []
         adapters = ifaddr.get_adapters()
         for adapter in adapters:
-            for ip in adapter.ips:
-                if is_ipv4_address(ip.ip):
+            for ip_address in adapter.ips:
+                if is_ipv4_address(ip_address.ip):
                     # Restrict to common domestic private IP ranges and sensible
                     # netmasks. Experimental ... assumptions need to be tested.
                     if (
-                            ip.ip.startswith("192.168") or ip.ip.startswith("10.")
-                    ) and ip.network_prefix <= 24:
-                        nw = ipaddress.ip_network(
-                            ip.ip + "/" + str(ip.network_prefix), False
+                        ip_address.ip.startswith("192.168")
+                        or ip_address.ip.startswith("10.")
+                    ) and ip_address.network_prefix <= 24:
+                        network = ipaddress.ip_network(
+                            ip_address.ip + "/" + str(ip_address.network_prefix), False
                         )
                         # Avoid duplicate subnets
-                        if nw not in ipv4_net_list:
-                            ipv4_net_list.append(nw)
+                        if network not in ipv4_net_list:
+                            ipv4_net_list.append(network)
         return ipv4_net_list
 
     def check_ip_and_port(ip_address, port, timeout):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -253,6 +253,10 @@ def scan_network(max_threads=256, timeout=1.0, include_invisible=False):
     devices. Returns a set of `SoCo` instances, or `None` if no Sonos devices are
     discovered.
 
+    This function is intended for use when the usual discovery functions aren't
+    working, perhaps due to multicast problems on the network to which the SoCo
+    host is attached.
+
     Args:
         max_threads (int): The maximum number of threads to use when scanning the
             network.

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -326,16 +326,16 @@ def scan_network(max_threads=256, timeout=3.0, min_netmask=24, include_invisible
         ipv4_net_list = set()
         adapters = ifaddr.get_adapters()
         for adapter in adapters:
-            for ip_address in adapter.ips:
-                if is_ipv4_address(ip_address.ip):
-                    network_ip = ipaddress.ip_network(ip_address.ip)
+            for ifaddr_network in adapter.ips:
+                if is_ipv4_address(ifaddr_network.ip):
+                    ipv4_network = ipaddress.ip_network(ifaddr_network.ip)
                     # Restrict to private networks and exclude loopback
-                    if network_ip.is_private and not network_ip.is_loopback:
+                    if ipv4_network.is_private and not ipv4_network.is_loopback:
                         # Constrain the size of network that will be searched
-                        if ip_address.network_prefix < min_netmask:
-                            ip_address.network_prefix = min_netmask
+                        if ifaddr_network.network_prefix < min_netmask:
+                            ifaddr_network.network_prefix = min_netmask
                         network = ipaddress.ip_network(
-                            ip_address.ip + "/" + str(ip_address.network_prefix), False
+                            ifaddr_network.ip + "/" + str(ifaddr_network.network_prefix), False
                         )
                         ipv4_net_list.add(network)
         _LOG.info("List of networks to search: %s", str(ipv4_net_list))

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -268,10 +268,10 @@ def scan_network(max_threads=256, timeout=1.0, include_invisible=False):
         set: a set of `SoCo` instances, one for each zone found, or else `None`.
     """
 
-    def is_ipv4_address(ip_address):
+    def is_ipv4_address(_ip_address):
         """Helper function to test for an IPv4 address."""
         try:
-            ipaddress.IPv4Network(ip_address)
+            ipaddress.IPv4Network(_ip_address)
             return True
         except ValueError:
             return False
@@ -296,11 +296,11 @@ def scan_network(max_threads=256, timeout=1.0, include_invisible=False):
                             ipv4_net_list.append(_network)
         return ipv4_net_list
 
-    def check_ip_and_port(ip_address, port, timeout):
+    def check_ip_and_port(_ip_address, port, _timeout):
         """Helper function to check if a port is open"""
         _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        _socket.settimeout(timeout)
-        return not bool(_socket.connect_ex((ip_address, port)))
+        _socket.settimeout(_timeout)
+        return not bool(_socket.connect_ex((_ip_address, port)))
 
     def sonos_scan_worker_thread(ip_list, socket_timeout, sonos_ip_addresses):
         """Helper function worker thread to take IP addresses off a list and

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -79,9 +79,11 @@ def test_by_name():
         # Test not found
         device = by_name("Living Room")
         assert device is None
-        discover_.assert_called_once_with()
+        discover_.assert_called_once_with(allow_network_scan=False)
 
         # Test found
         device = by_name("Kitchen")
         assert device is mock_to_be_found
-        discover_.assert_has_calls([call(), call()])
+        discover_.assert_has_calls(
+            [call(allow_network_scan=False), call(allow_network_scan=False)]
+        )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,7 +15,6 @@ from soco import config
 from soco.discovery import (
     any_soco,
     by_name,
-    _is_ipv4_address,
     _find_ipv4_networks,
     _check_ip_and_port,
     _is_sonos,
@@ -102,13 +101,6 @@ def test_by_name():
 
 
 # Tests for scan_network()
-
-
-def test__is_ipv4_address():
-    assert _is_ipv4_address("192.168.0.1") is True
-    assert _is_ipv4_address("192.168.0.256") is False
-    assert _is_ipv4_address("192.168.0") is False
-    assert _is_ipv4_address("2001:db8:0:1:1:1:1:1") is False
 
 
 def test__find_ipv4_networks(monkeypatch):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,6 +17,9 @@ from soco.discovery import (
     by_name,
     _is_ipv4_address,
     _find_ipv4_networks,
+    _check_ip_and_port,
+    _is_sonos,
+    scan_network,
 )
 
 IP_ADDR = "192.168.1.101"
@@ -98,34 +101,19 @@ def test_by_name():
         )
 
 
+# Tests for scan_network()
+
+
 def test__is_ipv4_address():
     assert _is_ipv4_address("192.168.0.1") is True
+    assert _is_ipv4_address("192.168.0.256") is False
     assert _is_ipv4_address("192.168.0") is False
     assert _is_ipv4_address("2001:db8:0:1:1:1:1:1") is False
 
 
 def test__find_ipv4_networks(monkeypatch):
-    # Set up the response from ifaddr.get_adapters()
-    adapters = OrderedDict()
-    ips = []
-    # Create a variety of networks
-    # Private IP range
-    ips.append(ifaddr.IP("192.168.0.1", 24, "private-24"))
-    # Private IP range: test constraints
-    ips.append(ifaddr.IP("192.168.1.1", 16, "private-16"))
-    # Public IP range
-    ips.append(ifaddr.IP("15.100.100.100", 8, "public"))
-    # Loopback range
-    ips.append(ifaddr.IP("127.0.0.1", 24, "loopback"))
-    index = 1
-    for ip in ips:
-        adapters[ip.nice_name] = ifaddr._shared.Adapter(
-            ip.nice_name, ip.nice_name, [ip], index=index
-        )
-        index += 1
-    monkeypatch.setattr("ifaddr.get_adapters", Mock(return_value=adapters.values()))
-
-    # Check that we get the networks we expect; test different min_netmask values
+    _set_up_adapters(monkeypatch)
+    # Check that we get the expected networks; test different min_netmask values
     assert ipaddress.ip_network("192.168.0.55/24", False) in _find_ipv4_networks(24)
     assert ipaddress.ip_network("192.168.1.1/24", False) in _find_ipv4_networks(24)
     assert ipaddress.ip_network("192.168.1.1/16", False) not in _find_ipv4_networks(24)
@@ -133,3 +121,79 @@ def test__find_ipv4_networks(monkeypatch):
     assert ipaddress.ip_network("192.168.1.1/16", False) in _find_ipv4_networks(0)
     assert ipaddress.ip_network("15.100.100.100/8", False) not in _find_ipv4_networks(8)
     assert ipaddress.ip_network("127.0.0.1/24", False) not in _find_ipv4_networks(24)
+
+
+def test__check_ip_and_port(monkeypatch):
+    _setup_sockets(monkeypatch)
+    assert _check_ip_and_port("192.168.0.1", 1400, 0.1) is True
+    assert _check_ip_and_port("192.168.0.1", 1401, 0.1) is False
+    assert _check_ip_and_port("192.168.0.3", 1400, 0.1) is False
+
+
+def test__is_sonos(monkeypatch):
+    with patch("soco.config.SOCO_CLASS", new=_mock_soco_new):
+        assert _is_sonos("192.168.0.1") is True
+        assert _is_sonos("192.168.0.2") is True
+        assert _is_sonos("192.168.0.3") is False
+
+
+def test_scan_network(monkeypatch):
+    _setup_sockets(monkeypatch)
+    _set_up_adapters(monkeypatch)
+    with patch("soco.config.SOCO_CLASS", new=_mock_soco_new):
+        assert "192.168.0.1" in scan_network(include_invisible=False)
+        assert "192.168.0.2" not in scan_network(include_invisible=False)
+        assert "192.168.0.2" in scan_network(include_invisible=True)
+        assert "192.168.0.1" in scan_network(
+            include_invisible=False, max_threads=5000, min_netmask=16
+        )
+
+
+# Helper functions for scan_network() tests
+
+
+def _set_up_adapters(monkeypatch):
+    """Helper function that creates a number of mock network adapters to be
+    returned by ifaddr.get_adapters()."""
+
+    private_24 = ifaddr.IP("192.168.0.1", 24, "private-24")
+    private_16 = ifaddr.IP("192.168.1.1", 16, "private-16")
+    public = ifaddr.IP("15.100.100.100", 8, "public")
+    loopback = ifaddr.IP("127.0.0.1", 24, "loopback")
+    ips = [private_24, private_16, public, loopback]
+
+    # Set up mock adapters
+    adapters = OrderedDict()
+    for index in range(len(ips)):
+        ip = ips[index]
+        adapters[ip.nice_name] = ifaddr._shared.Adapter(
+            ip.nice_name, ip.nice_name, [ip], index=index + 1
+        )
+
+    # Patch the response from ifaddr.get_adapters()
+    monkeypatch.setattr("ifaddr.get_adapters", Mock(return_value=adapters.values()))
+
+
+def _mock_soco_new(ip_address):
+    """Helper function that replaces the SoCo constructor. Returns Mock objects for
+    Sonos devices at two specific IP addresses."""
+
+    if ip_address in ["192.168.0.1", "192.168.0.2"]:
+        return Mock(
+            visible_zones=["192.168.0.1"], all_zones=["192.168.0.1", "192.168.0.2"]
+        )
+    else:
+        raise ValueError
+
+
+def _setup_sockets(monkeypatch):
+    """Helper function to create fake socket connection responses corresponding to
+    Sonos speakers on specific IP address / port combinations only."""
+
+    def mock_socket_connect_ex_return(_, address_port):
+        if address_port in [("192.168.0.1", 1400), ("192.168.0.2", 1400)]:
+            return 0
+        else:
+            return 1
+
+    monkeypatch.setattr("socket.socket.connect_ex", mock_socket_connect_ex_return)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -135,9 +135,24 @@ def test_scan_network(monkeypatch):
     with patch("soco.config.SOCO_CLASS", new=_mock_soco_new):
         assert "192.168.0.1" in scan_network(include_invisible=False)
         assert "192.168.0.2" not in scan_network(include_invisible=False)
-        assert "192.168.0.2" in scan_network(include_invisible=True)
         assert "192.168.0.1" in scan_network(
-            include_invisible=False, max_threads=5000, min_netmask=16
+            include_invisible=False, multi_household=True
+        )
+        assert "192.168.0.2" not in scan_network(
+            include_invisible=False, multi_household=True
+        )
+        assert "192.168.0.1" in scan_network(
+            include_invisible=True, multi_household=True
+        )
+        assert "192.168.0.2" in scan_network(include_invisible=True)
+        assert "192.168.0.2" in scan_network(
+            include_invisible=True, multi_household=True
+        )
+        assert "192.168.0.1" in scan_network(
+            include_invisible=False,
+            multi_household=True,
+            max_threads=5000,
+            min_netmask=16,
         )
 
 


### PR DESCRIPTION
This is a proof-of-concept to add a new discovery function `scan_network()` that detects Sonos devices by scanning all IPs on the networks to which the SoCo host is attached. I've added the function to the existing `discovery.py` file, but it is standalone and not integrated with the other discovery functions.

This is to circumvent situations where the network is not correctly passing multicast traffic, meaning that the normal discovery functions do not work.

It appears to work on Windows, macOS, and Linux hosts, although my testing has necessarily been restricted to a small number of networks. I'd welcome other people trying it out.

**Edit: The following no longer applies**: _(Like the existing discovery functions, this function is vulnerable to the situation where there are multiple Sonos households/systems operating on the same network, e.g., in the case of an S1/S2 split system. It will return data on the first household that it discovers, ignoring any others.)_