### PR TITLE
Add DIDL class for `object.item.audioItem.podcast`

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -942,6 +942,14 @@ class DidlRecentShow(DidlMusicTrack):
     item_class = "object.item.audioItem.musicTrack.recentShow"
 
 
+class DidlPodcast(DidlAudioItem):
+
+    """Class that represents a podcast."""
+
+    # the DIDL Lite class for this object.
+    item_class = "object.item.audioItem.podcast"
+
+
 class DidlAudioBroadcastFavorite(DidlAudioBroadcast):
 
     """Class that represents an audio broadcast Sonos favorite."""

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -54,9 +54,12 @@ def from_didl_string(string):
     return items
 
 
-# Obviously imcomplete, but missing entries will not result in error, but just
+# Obviously incomplete, but missing entries will not result in error, but just
 # a logged warning and no upgrade of the data structure
-DIDL_NAME_TO_QUALIFIED_MS_NAME = {"DidlMusicTrack": "MediaMetadataTrack"}
+DIDL_NAME_TO_QUALIFIED_MS_NAME = {
+    "DidlMusicTrack": "MediaMetadataTrack",
+    "DidlPodcast": "MediaMetadataTrack",
+}
 
 
 def attempt_datastructure_upgrade(didl_item):

--- a/tests/official_and_extended_didl_classes.txt
+++ b/tests/official_and_extended_didl_classes.txt
@@ -7,6 +7,7 @@
 # O object.item.audioItem.musicTrack                        -> <class 'soco.data_structures.DidlMusicTrack'>
 # O object.item.audioItem.audioBook                         -> <class 'soco.data_structures.DidlAudioBook'>
 # O object.item.audioItem.audioBroadcast                    -> <class 'soco.data_structures.DidlAudioBroadcast'>
+# E object.item.audioItem.podcast                           -> <class 'soco.data_structures.DidlPodcast'>
 # E object.item.audioItem.musicTrack.recentShow             -> <class 'soco.data_structures.DidlRecentShow'>
 # E object.item.audioItem.audioBroadcast.sonos-favorite     -> <class 'soco.data_structures.DidlAudioBroadcastFavorite'>
 # E object.itemobject.item.sonos-favorite                   -> <class 'soco.data_structures.DidlFavorite'>


### PR DESCRIPTION
Adds a new DIDL class for `object.item.audioItem.podcast`. Fixes #734.