### PR TITLE
Add DIDL Lite support for AirPlay 2 streams

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -111,6 +111,8 @@ _OFFICIAL_CLASSES = {
     "object.item.audioItem.musicTrack",
     "object.item.audioItem.audioBroadcast",
     "object.item.audioItem.audioBook",
+    "object.item.audioItem.linein",
+    "object.item.audioItem.linein.airplay",
     "object.container",
     "object.container.person",
     "object.container.person.musicArtist",
@@ -940,6 +942,22 @@ class DidlRecentShow(DidlMusicTrack):
 
     # the DIDL Lite class for this object.
     item_class = "object.item.audioItem.musicTrack.recentShow"
+
+
+class DidlLineIn(DidlAudioItem):
+
+    """Class that represents audio from LineIn."""
+
+    # the DIDL Lite class for this object.
+    item_class = "object.item.audioItem.linein"
+
+
+class DidlAirPlayTrack(DidlLineIn):
+
+    """Class that represents audio from an AirPlay Stream."""
+
+    # the DIDL Lite class for this object.
+    item_class = "object.item.audioItem.linein.airplay"
 
 
 class DidlAudioBroadcastFavorite(DidlAudioBroadcast):

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -54,9 +54,12 @@ def from_didl_string(string):
     return items
 
 
-# Obviously imcomplete, but missing entries will not result in error, but just
+# Obviously incomplete, but missing entries will not result in error, but just
 # a logged warning and no upgrade of the data structure
-DIDL_NAME_TO_QUALIFIED_MS_NAME = {"DidlMusicTrack": "MediaMetadataTrack"}
+DIDL_NAME_TO_QUALIFIED_MS_NAME = {
+    "DidlMusicTrack": "MediaMetadataTrack",
+    "DidlAirPlayTrack": "MediaMetadataTrack",
+}
 
 
 def attempt_datastructure_upgrade(didl_item):

--- a/tests/official_and_extended_didl_classes.txt
+++ b/tests/official_and_extended_didl_classes.txt
@@ -8,6 +8,7 @@
 # O object.item.audioItem.audioBook                         -> <class 'soco.data_structures.DidlAudioBook'>
 # O object.item.audioItem.audioBroadcast                    -> <class 'soco.data_structures.DidlAudioBroadcast'>
 # E object.item.audioItem.musicTrack.recentShow             -> <class 'soco.data_structures.DidlRecentShow'>
+# E object.item.audioItem.linein.airplay                    -> <class 'soco.data_structures.DidlAirPlayTrack'>
 # E object.item.audioItem.audioBroadcast.sonos-favorite     -> <class 'soco.data_structures.DidlAudioBroadcastFavorite'>
 # E object.itemobject.item.sonos-favorite                   -> <class 'soco.data_structures.DidlFavorite'>
 # O object.container                                        -> <class 'soco.data_structures.DidlContainer'>


### PR DESCRIPTION
An AirPlay 2 stream will cause exceptions to be thrown in `attempt_datastructure_upgrade`. This PR adds the required DIDL classes.