### PR TITLE
Updated documentation for core.play_mode to add REPEAT_ONE and SHUFFLE_REPEAT_ONE

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -420,6 +420,9 @@ class SoCo(_SocoSingletonBase):
             strange, I know.)
         *   ``'SHUFFLE_NOREPEAT'`` -- Turns on shuffle and turns off
             repeat.
+        *   ``'REPEAT_ONE'`` -- Turns on repeat one and turns off shuffle.
+        *   ``'SHUFFLE_REPEAT_ONE'`` -- Turns on shuffle *and* repeat one. (It's
+            strange, I know.)
 
         """
         result = self.avTransport.GetTransportSettings([("InstanceID", 0),])


### PR DESCRIPTION
Hi,
I updated the documentation that was lacking the REPEAT_ONE and SHUFFLE_REPEAT_ONE play modes.