### PR TITLE
Add reference to soco-cli in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,6 +203,13 @@ Related Projects
 Socos is a command line tool for controlling Sonos devices. It is developed
 in conjunction with Soco, but in a `separate repository <https://github.com/SoCo/socos>`_.
 
+SoCo-CLI (`soco-cli <https://github.com/avantrec/soco-cli>`_) is a powerful and
+fully-featured command line tool suitable for use in scripts, scheduled tasks, etc. It
+supports time-based and state-based actions, and repeated commands using loops. It also
+provides an alternative speaker discovery mechanism for situations where SoCo discovery
+does not work, and it functions with multiple Sonos systems on the same network as is the
+case with split S1/S2 systems.
+
 More of a Ruby fan? Not a problem, `Sam Soffes`_ is building out an
 awesome `Ruby gem`_.
 


### PR DESCRIPTION
I'd like to add a link to the README for the `soco-cli` command line wrapper for SoCo. `soco-cli` is now fully-featured and quite stable.

Link: https://github.com/avantrec/soco-cli