### PR TITLE
Pin pylint to v2.5 and Black to v19, to avoid new warnings until after 0.20 release. 

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
     bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
-    bad-continuation
+    bad-continuation, super-with-arguments, raise-missing-from
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
     bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
-    bad-continuation, super-with-arguments, raise-missing-from
+    bad-continuation
 
 
 [REPORTS]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pylint >= 1.4
 coveralls
 pytest-cov<2.6.0
 wheel
-black; python_version >= "3.6" and implementation_name == "cpython"
+black==19.10b0; python_version >= "3.6" and implementation_name == "cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest >= 2.5
 mock >= 1.0.1
 graphviz
 flake8
-pylint >= 1.4
+pylint == 2.5
 coveralls
 pytest-cov<2.6.0
 wheel


### PR DESCRIPTION
All checks are currently failing due to the pylint update to v2.6. This PR suppresses two additional pylint warnings, allowing the checks to pass.

Also, the update to Black v20 flags multiple files for reformatting, hence failing the Black check. Pin Black to v19 for the time being.