### PR TITLE
Unpin Pylint version and eliminate new warnings

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
     bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
-    bad-continuation, raise-missing-from
+    bad-continuation
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@
 # progress
 disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
     bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
-    bad-continuation
+    bad-continuation, raise-missing-from
 
 
 [REPORTS]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest >= 2.5
 mock >= 1.0.1
 graphviz
 flake8
-pylint == 2.5
+pylint
 coveralls
 pytest-cov<2.6.0
 wheel

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -134,7 +134,7 @@ class Alarm(object):
                 otherwise. Defaults to `False`.
         """
 
-        super(Alarm, self).__init__()
+        super().__init__()
         self.zone = zone
         if start_time is None:
             start_time = datetime.now().time()

--- a/soco/cache.py
+++ b/soco/cache.py
@@ -24,7 +24,7 @@ class _BaseCache(object):
     # pylint: disable=no-self-use, unused-argument
 
     def __init__(self, *args, **kwargs):
-        super(_BaseCache, self).__init__()
+        super().__init__()
         self._cache = {}
         #: `bool`: whether the cache is enabled
         self.enabled = True
@@ -106,7 +106,7 @@ class TimedCache(_BaseCache):
             default_timeout (int): The default number of seconds after
             which items will be expired.
         """
-        super(TimedCache, self).__init__()
+        super().__init__()
         #: `int`: The default caching expiry interval in seconds.
         self.default_timeout = default_timeout
         # A thread lock for the cache

--- a/soco/core.py
+++ b/soco/core.py
@@ -257,8 +257,8 @@ class SoCo(_SocoSingletonBase):
         # Sonos does not (yet) support IPv6
         try:
             socket.inet_aton(ip_address)
-        except socket.error:
-            raise ValueError("Not a valid IP address string")
+        except socket.error as error:
+            raise ValueError("Not a valid IP address string") from error
         #: The speaker's ip address
         self.ip_address = ip_address
         self.speaker_info = {}  # Stores information about the current speaker
@@ -1872,13 +1872,13 @@ class SoCo(_SocoSingletonBase):
                 raise ValueError(
                     "invalid sleep_time_seconds, must be integer \
                     value between 0 and 86399 inclusive or None"
-                )
+                ) from err
             raise
-        except ValueError:
+        except ValueError as error:
             raise ValueError(
                 "invalid sleep_time_seconds, must be integer \
                 value between 0 and 86399 inclusive or None"
-            )
+            ) from error
 
     @only_on_master
     def get_sleep_timer(self):

--- a/soco/core.py
+++ b/soco/core.py
@@ -252,7 +252,7 @@ class SoCo(_SocoSingletonBase):
     def __init__(self, ip_address):
         # Note: Creation of a SoCo instance should be as cheap and quick as
         # possible. Do not make any network calls here
-        super(SoCo, self).__init__()
+        super().__init__()
         # Check if ip_address is a valid IPv4 representation.
         # Sonos does not (yet) support IPv6
         try:

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1326,7 +1326,9 @@ class SearchResult(ListOfMusicInfoItems):
 
     def __repr__(self):
         return "{0}(items={1}, search_type='{2}')".format(
-            self.__class__.__name__, super().__repr__(), self.search_type,
+            self.__class__.__name__,
+            super().__repr__(),
+            self.search_type,
         )
 
     @property
@@ -1340,4 +1342,7 @@ class Queue(ListOfMusicInfoItems):
     """Container class that represents a queue."""
 
     def __repr__(self):
-        return "{0}(items={1})".format(self.__class__.__name__, super().__repr__(),)
+        return "{0}(items={1})".format(
+            self.__class__.__name__,
+            super().__repr__(),
+        )

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -511,7 +511,7 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # does not use some of them.
 
         # pylint: disable=super-on-old-class
-        super(DidlObject, self).__init__()
+        super().__init__()
         self.title = title
         self.parent_id = parent_id
         self.item_id = item_id
@@ -1256,7 +1256,7 @@ class ListOfMusicInfoItems(list):
     """
 
     def __init__(self, items, number_returned, total_matches, update_id):
-        super(ListOfMusicInfoItems, self).__init__(items)
+        super().__init__(items)
         self._metadata = {
             "item_list": list(items),
             "number_returned": number_returned,
@@ -1293,7 +1293,7 @@ class ListOfMusicInfoItems(list):
             warnings.warn(message, stacklevel=2)
             return self._metadata[key]
         else:
-            return super(ListOfMusicInfoItems, self).__getitem__(key)
+            return super().__getitem__(key)
 
     @property
     def number_returned(self):
@@ -1319,7 +1319,7 @@ class SearchResult(ListOfMusicInfoItems):
     """
 
     def __init__(self, items, search_type, number_returned, total_matches, update_id):
-        super(SearchResult, self).__init__(
+        super().__init__(
             items, number_returned, total_matches, update_id
         )
         self._metadata["search_type"] = search_type
@@ -1327,7 +1327,7 @@ class SearchResult(ListOfMusicInfoItems):
     def __repr__(self):
         return "{0}(items={1}, search_type='{2}')".format(
             self.__class__.__name__,
-            super(SearchResult, self).__repr__(),
+            super().__repr__(),
             self.search_type,
         )
 
@@ -1343,5 +1343,5 @@ class Queue(ListOfMusicInfoItems):
 
     def __repr__(self):
         return "{0}(items={1})".format(
-            self.__class__.__name__, super(Queue, self).__repr__(),
+            self.__class__.__name__, super().__repr__(),
         )

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -257,10 +257,10 @@ class DidlResource(object):
             if result is not None:
                 try:
                     return int(result)
-                except ValueError:
+                except ValueError as error:
                     raise DIDLMetadataError(
                         "Could not convert {0} to an integer".format(name)
-                    )
+                    ) from error
             else:
                 return None
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1319,16 +1319,12 @@ class SearchResult(ListOfMusicInfoItems):
     """
 
     def __init__(self, items, search_type, number_returned, total_matches, update_id):
-        super().__init__(
-            items, number_returned, total_matches, update_id
-        )
+        super().__init__(items, number_returned, total_matches, update_id)
         self._metadata["search_type"] = search_type
 
     def __repr__(self):
         return "{0}(items={1}, search_type='{2}')".format(
-            self.__class__.__name__,
-            super().__repr__(),
-            self.search_type,
+            self.__class__.__name__, super().__repr__(), self.search_type,
         )
 
     @property
@@ -1342,6 +1338,4 @@ class Queue(ListOfMusicInfoItems):
     """Container class that represents a queue."""
 
     def __repr__(self):
-        return "{0}(items={1})".format(
-            self.__class__.__name__, super().__repr__(),
-        )
+        return "{0}(items={1})".format(self.__class__.__name__, super().__repr__(),)

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -97,10 +97,10 @@ def discover(timeout=5, include_invisible=False, interface_addr=None):
     if interface_addr is not None:
         try:
             address = socket.inet_aton(interface_addr)
-        except socket.error:
+        except socket.error as e:
             raise ValueError(
                 "{0} is not a valid IP address string".format(interface_addr)
-            )
+            ) from e
         _sockets.append(create_socket(interface_addr))
         _LOG.info("Sending discovery packets on default interface")
     else:

--- a/soco/events.py
+++ b/soco/events.py
@@ -100,7 +100,7 @@ class EventNotifyHandler(BaseHTTPRequestHandler, EventNotifyHandlerBase):
         self.subscriptions_map = subscriptions_map
         # super appears at the end of __init__, because
         # BaseHTTPRequestHandler.__init__ does not return.
-        super(EventNotifyHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def do_NOTIFY(self):  # pylint: disable=invalid-name
         """Serve a ``NOTIFY`` request by calling `handle_notification`
@@ -137,7 +137,7 @@ class EventServerThread(threading.Thread):
             address (tuple): The (ip, port) address on which the server
                 should listen.
         """
-        super(EventServerThread, self).__init__()
+        super().__init__()
         #: `threading.Event`: Used to signal that the server should stop.
         self.stop_flag = threading.Event()
         #: `tuple`: The (ip, port) address on which the server is
@@ -169,7 +169,7 @@ class EventListener(EventListenerBase):
     """
 
     def __init__(self):
-        super(EventListener, self).__init__()
+        super().__init__()
         #: `EventServerThread`: thread on which to run.
         self._listener_thread = None
 
@@ -251,7 +251,7 @@ class Subscription(SubscriptionBase):
                 events will be put. If not specified, a queue will be
                 created and used.
         """
-        super(Subscription, self).__init__(service, event_queue)
+        super().__init__(service, event_queue)
         # Used to keep track of the auto_renew thread
         self._auto_renew_thread = None
         self._auto_renew_thread_flag = threading.Event()
@@ -294,7 +294,7 @@ class Subscription(SubscriptionBase):
             `Subscription`: The Subscription instance.
 
         """
-        subscribe = super(Subscription, self).subscribe
+        subscribe = super().subscribe
         return self._wrap(subscribe, strict, requested_timeout, auto_renew)
 
     def renew(self, requested_timeout=None, is_autorenew=False, strict=True):
@@ -320,7 +320,7 @@ class Subscription(SubscriptionBase):
             `Subscription`: The Subscription instance.
 
         """
-        renew = super(Subscription, self).renew
+        renew = super().renew
         return self._wrap(renew, strict, requested_timeout, is_autorenew)
 
     def unsubscribe(self, strict=True):
@@ -340,7 +340,7 @@ class Subscription(SubscriptionBase):
             `Subscription`: The Subscription instance.
 
         """
-        unsubscribe = super(Subscription, self).unsubscribe
+        unsubscribe = super().unsubscribe
         return self._wrap(unsubscribe, strict)
 
     def _auto_renew_start(self, interval):
@@ -352,7 +352,7 @@ class Subscription(SubscriptionBase):
             """
 
             def __init__(self, interval, stop_flag, sub, *args, **kwargs):
-                super(AutoRenewThread, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
                 self.interval = interval
                 self.subscription = sub
                 self.stop_flag = stop_flag

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -705,7 +705,7 @@ class SubscriptionsMap(object):
     """
 
     def __init__(self):
-        super(SubscriptionsMap, self).__init__()
+        super().__init__()
         #: `weakref.WeakValueDictionary`: Thread safe mapping.
         #: Used to store a mapping of sid to subscription
         self.subscriptions = weakref.WeakValueDictionary()

--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -109,7 +109,7 @@ class EventNotifyHandler(Resource, EventNotifyHandlerBase):
     isLeaf = True
 
     def __init__(self):
-        super(EventNotifyHandler, self).__init__()
+        super().__init__()
         # The SubscriptionsMapTwisted instance created when this module is
         # imported. This is referenced by
         # soco.events_base.EventNotifyHandlerBase.
@@ -142,7 +142,7 @@ class EventListener(EventListenerBase):
     """
 
     def __init__(self):
-        super(EventListener, self).__init__()
+        super().__init__()
         #:  :py:class:`twisted.internet.tcp.Port`: set at `listen`
         self.port = None
 
@@ -214,7 +214,7 @@ class Subscription(SubscriptionBase):
                 created and used.
 
         """
-        super(Subscription, self).__init__(service, event_queue)
+        super().__init__(service, event_queue)
         #: :py:obj:`function`: callback function to be called whenever an
         #: `Event` is received. If it is set and is callable, the callback
         #: function will be called with the `Event` as the only parameter and
@@ -266,7 +266,7 @@ class Subscription(SubscriptionBase):
                 will point to the Subscription instance.
 
         """
-        subscribe = super(Subscription, self).subscribe
+        subscribe = super().subscribe
         return self._wrap(subscribe, strict, requested_timeout, auto_renew)
 
     def renew(self, requested_timeout=None, is_autorenew=False, strict=True):
@@ -297,7 +297,7 @@ class Subscription(SubscriptionBase):
                 will point to the Subscription instance.
 
         """
-        renew = super(Subscription, self).renew
+        renew = super().renew
         return self._wrap(renew, strict, requested_timeout, is_autorenew)
 
     def unsubscribe(self, strict=True):
@@ -321,7 +321,7 @@ class Subscription(SubscriptionBase):
                 Subscription instance and the subscription property of which
                 will point to the Subscription instance.
         """
-        unsubscribe = super(Subscription, self).unsubscribe
+        unsubscribe = super().unsubscribe
         return self._wrap(unsubscribe, strict)
 
     def _auto_renew_start(self, interval):
@@ -519,7 +519,7 @@ class SubscriptionsMapTwisted(SubscriptionsMap):
     """
 
     def __init__(self):
-        super(SubscriptionsMapTwisted, self).__init__()
+        super().__init__()
         # A counter of calls to Subscription.subscribe
         # that have started but not completed. This is
         # to prevent the event listener from being stopped prematurely

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -38,7 +38,7 @@ class SoCoUPnPException(SoCoException):
                 encoded string.
             error_description (str): A description of the error. Default is ""
         """
-        super(SoCoUPnPException, self).__init__()
+        super().__init__()
         self.message = message
         self.error_code = error_code
         self.error_description = error_description
@@ -101,7 +101,7 @@ class EventParseException(SoCoException):
             metadata (str): The metadata which failed to parse
             cause (Exception): The original exception
         """
-        super(EventParseException, self).__init__()
+        super().__init__()
         self.tag = tag
         self.metadata = metadata
         self.__cause__ = cause

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -52,7 +52,7 @@ class MusicServiceItem(object):
     required_fields = None
 
     def __init__(self, **kwargs):
-        super(MusicServiceItem, self).__init__()
+        super().__init__()
         self.content = kwargs
 
     @classmethod
@@ -369,7 +369,7 @@ class MSTrack(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSTrack, self).__init__(**content)
+        super().__init__(**content)
 
     @property
     def album(self):
@@ -435,7 +435,7 @@ class MSAlbum(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSAlbum, self).__init__(**content)
+        super().__init__(**content)
 
     @property
     def artist(self):
@@ -488,7 +488,7 @@ class MSAlbumList(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSAlbumList, self).__init__(**content)
+        super().__init__(**content)
 
     @property
     def uri(self):
@@ -537,7 +537,7 @@ class MSPlaylist(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSPlaylist, self).__init__(**content)
+        super().__init__(**content)
 
     @property
     def uri(self):
@@ -575,7 +575,7 @@ class MSArtistTracklist(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSArtistTracklist, self).__init__(**content)
+        super().__init__(**content)
 
     @property
     def uri(self):
@@ -614,7 +614,7 @@ class MSArtist(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSArtist, self).__init__(**content)
+        super().__init__(**content)
 
 
 class MSFavorites(MusicServiceItem):
@@ -643,7 +643,7 @@ class MSFavorites(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSFavorites, self).__init__(**content)
+        super().__init__(**content)
 
 
 class MSCollection(MusicServiceItem):
@@ -672,7 +672,7 @@ class MSCollection(MusicServiceItem):
             "service_id": service_id,
         }
         content.update(kwargs)
-        super(MSCollection, self).__init__(**content)
+        super().__init__(**content)
 
 
 MS_TYPE_TO_CLASS = {

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -30,7 +30,7 @@ class Account(object):
     _all_accounts = weakref.WeakValueDictionary()
 
     def __init__(self):
-        super(Account, self).__init__()
+        super().__init__()
         #: str: A unique identifier for the music service to which this
         #: account relates, eg ``'2311'`` for Spotify.
         self.service_type = ""

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -221,9 +221,11 @@ class MetadataDictBase(object):
         """Return item from metadata in case of unknown attribute"""
         try:
             return self.metadata[key]
-        except KeyError:
+        except KeyError as error:
             message = 'Class {} has no attribute "{}"'
-            raise AttributeError(message.format(self.__class__.__name__, key))
+            raise AttributeError(
+                message.format(self.__class__.__name__, key)
+            ) from error
 
 
 class MusicServiceItem(MetadataDictBase):

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -263,7 +263,7 @@ class MusicServiceItem(MetadataDictBase):
             uri,
             music_service,
         )
-        super(MusicServiceItem, self).__init__(metadata_dict)
+        super().__init__(metadata_dict)
         self.item_id = item_id
         self.desc = desc
         self.resources = resources

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -188,7 +188,7 @@ class MusicServiceSoapClient(object):
                 result_elt = message.call()
 
             else:
-                raise MusicServiceException(exc.faultstring, exc.faultcode)
+                raise MusicServiceException(exc.faultstring, exc.faultcode) from exc
 
         # The top key in the OrderedDict will be the methodResult. Its
         # value may be None if no results were returned.

--- a/soco/plugins/example.py
+++ b/soco/plugins/example.py
@@ -20,7 +20,7 @@ class ExamplePlugin(SoCoPlugin):
         least accept a soco instance which it passes on to the base
         class when calling super's __init__.
         """
-        super(ExamplePlugin, self).__init__(soco)
+        super().__init__(soco)
         self.username = username
 
     @property

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -155,7 +155,7 @@ class Wimp(SoCoPlugin):
             -jeg-ikke-logge-p%C3%A5-WiMP-med-min-Sonos-n%C3%A5r-jeg-har-et
             -gyldigt-abonnement->`_ (In Danish)
         """
-        super(Wimp, self).__init__(soco)
+        super().__init__(soco)
 
         # Instantiate variables
         self._url = "http://client.wimpmusic.com/sonos/services/Sonos"

--- a/soco/services.py
+++ b/soco/services.py
@@ -762,7 +762,7 @@ class AlarmClock(Service):
     """Sonos alarm service, for setting and getting time and alarms."""
 
     def __init__(self, soco):
-        super(AlarmClock, self).__init__(soco)
+        super().__init__(soco)
         self.UPNP_ERRORS.update(
             {801: "Already an alarm for this time",}
         )
@@ -814,7 +814,7 @@ class ContentDirectory(Service):
     browsing, searching and listing available music."""
 
     def __init__(self, soco):
-        super(ContentDirectory, self).__init__(soco)
+        super().__init__(soco)
         self.control_url = "/MediaServer/ContentDirectory/Control"
         self.event_subscription_url = "/MediaServer/ContentDirectory/Event"
         # For error codes, see table 2.7.16 in
@@ -849,7 +849,7 @@ class MS_ConnectionManager(Service):  # pylint: disable=invalid-name
     """UPnP standard connection manager service for the media server."""
 
     def __init__(self, soco):
-        super(MS_ConnectionManager, self).__init__(soco)
+        super().__init__(soco)
         self.service_type = "ConnectionManager"
         self.control_url = "/MediaServer/ConnectionManager/Control"
         self.event_subscription_url = "/MediaServer/ConnectionManager/Event"
@@ -861,7 +861,7 @@ class RenderingControl(Service):
     playback rendering, eg bass, treble, volume and EQ."""
 
     def __init__(self, soco):
-        super(RenderingControl, self).__init__(soco)
+        super().__init__(soco)
         self.control_url = "/MediaRenderer/RenderingControl/Control"
         self.event_subscription_url = "/MediaRenderer/RenderingControl/Event"
         self.DEFAULT_ARGS.update({"InstanceID": 0})
@@ -872,7 +872,7 @@ class MR_ConnectionManager(Service):  # pylint: disable=invalid-name
     """UPnP standard connection manager service for the media renderer."""
 
     def __init__(self, soco):
-        super(MR_ConnectionManager, self).__init__(soco)
+        super().__init__(soco)
         self.service_type = "ConnectionManager"
         self.control_url = "/MediaRenderer/ConnectionManager/Control"
         self.event_subscription_url = "/MediaRenderer/ConnectionManager/Event"
@@ -884,7 +884,7 @@ class AVTransport(Service):
     management, eg play, stop, seek, playlists etc."""
 
     def __init__(self, soco):
-        super(AVTransport, self).__init__(soco)
+        super().__init__(soco)
         self.control_url = "/MediaRenderer/AVTransport/Control"
         self.event_subscription_url = "/MediaRenderer/AVTransport/Event"
         # For error codes, see
@@ -923,7 +923,7 @@ class Queue(Service):
     queues etc."""
 
     def __init__(self, soco):
-        super(Queue, self).__init__(soco)
+        super().__init__(soco)
         self.control_url = "/MediaRenderer/Queue/Control"
         self.event_subscription_url = "/MediaRenderer/Queue/Event"
 
@@ -934,7 +934,7 @@ class GroupRenderingControl(Service):
     volume etc."""
 
     def __init__(self, soco):
-        super(GroupRenderingControl, self).__init__(soco)
+        super().__init__(soco)
         self.control_url = "/MediaRenderer/GroupRenderingControl/Control"
         self.event_subscription_url = "/MediaRenderer/GroupRenderingControl/Event"
         self.DEFAULT_ARGS.update({"InstanceID": 0})

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -58,7 +58,7 @@ class SoapFault(SoCoException):
         self.faultstring = faultstring
         self.detail = detail
         self.detail_string = XML.tostring(detail) if detail is not None else ""
-        super(SoapFault, self).__init__(faultcode, faultstring)
+        super().__init__(faultcode, faultstring)
 
     def __str__(self):
         return "%s: %s" % (self.faultcode, self.faultstring)


### PR DESCRIPTION
This PR removes the Pylint version pin used in the checks, and eliminates the multiple instances of two new warnings that are reported under Pylint 2.6:

1. Removes 'super-with-arguments' warnings (R1725) by changing all `super()` invocations to Python 3 style.
2. Removes 'raise-missing-from' warnings (W0707) by adding `from <initial exception>` where required.