### PR TITLE
Replace 'isAlive()' with 'is_alive()' for Python 3.9 compatibility

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -232,7 +232,7 @@ class EventListener(EventListenerBase):
         # to ensure the main thread does not hang
         self._listener_thread.join(1)
         # check if join timed out and issue a warning if it did
-        if self._listener_thread.isAlive():
+        if self._listener_thread.is_alive():
             log.warning("Event Listener did not shutdown gracefully.")
 
 


### PR DESCRIPTION
Python 3.9 checks are failing because `Thread.isAlive()` was deprecated in Python 3.8 and removed in Python 3.9. Replace with `Thread.is_alive()`.