### PR TITLE
Improve discover(): perform discovery on all NICs/IPs

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -507,7 +507,7 @@ def _find_ipv4_networks(min_netmask):
 
 
 def _find_ipv4_addresses():
-    """Discover all the host's IP addresses.
+    """Discover and return all the host's IPv4 addresses.
 
     Helper function to return a set of IPv4 addresses associated
     with the network interfaces of this host. Loopback and link

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -59,7 +59,7 @@ def discover(
         `None`.
     """
 
-    def create_socket(interface_addr=None):
+    def create_socket(interface_addr):
         """A helper function for creating a socket for discovery purposes.
 
         Create and return a socket with appropriate options set for multicast.
@@ -70,12 +70,9 @@ def discover(
         _sock.setsockopt(
             socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("B", 4)
         )
-        if interface_addr is not None:
-            _sock.setsockopt(
-                socket.IPPROTO_IP,
-                socket.IP_MULTICAST_IF,
-                socket.inet_aton(interface_addr),
-            )
+        _sock.setsockopt(
+            socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(interface_addr)
+        )
         return _sock
 
     # pylint: disable=invalid-name

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -36,25 +36,24 @@ class TestDiscover:
             b"SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)",
             [IP_ADDR],
         )  # (data, # address)
-        # Each time gethostbyname is called, it gets a different value
+        # Return a couple of IP addresses from _find_ipv4_addresses()
         monkeypatch.setattr(
-            "socket.gethostbyname", Mock(side_effect=["192.168.1.15", "192.168.1.16"])
+            "soco.discovery._find_ipv4_addresses",
+            Mock(return_value={"192.168.0.15", "192.168.1.16"}),
         )
-        # Stop getfqdn from working, to avoud network access
-        monkeypatch.setattr("socket.getfqdn", Mock())
-        # prevent creation of soco instances
+        # Prevent creation of soco instances
         monkeypatch.setattr("soco.config.SOCO_CLASS", Mock())
         # Fake return value for select
         monkeypatch.setattr("select.select", Mock(return_value=([sock], 1, 1)))
 
-        # set timeout
+        # Set timeout
         TIMEOUT = 2
         discover(timeout=TIMEOUT)
-        # 9 packets in total should be sent (3 to default, 3 to
-        # 192.168.1.15 and 3 to 192.168.1.15)
-        assert sock.sendto.call_count == 9
+        # 6 packets in total should be sent (3 to
+        # 192.168.0.15 and 3 to 192.168.1.16)
+        assert sock.sendto.call_count == 6
         # select called with the relevant timeout
-        select.select.assert_called_with([sock, sock, sock], [], [], min(TIMEOUT, 0.1))
+        select.select.assert_called_with([sock, sock], [], [], min(TIMEOUT, 0.1))
         # SoCo should be created with the IP address received
         config.SOCO_CLASS.assert_called_with(IP_ADDR)
 
@@ -66,9 +65,9 @@ class TestDiscover:
         assert discover(include_invisible=True) == "ALL"
         assert discover(include_invisible=False) == "VISIBLE"
 
-        # if select does not return within timeout SoCo should not be called
+        # If select does not return within timeout SoCo should not be called
         # at all
-        # simulate no data being returned within timeout
+        # Simulate no data being returned within timeout
         select.select.return_value = (0, 1, 1)
         discover(timeout=1)
         # Check no SoCo instance created

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,6 +15,7 @@ from soco import config
 from soco.discovery import (
     any_soco,
     by_name,
+    _find_ipv4_addresses,
     _find_ipv4_networks,
     _check_ip_and_port,
     _is_sonos,
@@ -114,6 +115,11 @@ def test__find_ipv4_networks(monkeypatch):
     assert ipaddress.ip_network("192.168.1.1/16", False) in _find_ipv4_networks(0)
     assert ipaddress.ip_network("15.100.100.100/8", False) not in _find_ipv4_networks(8)
     assert ipaddress.ip_network("127.0.0.1/24", False) not in _find_ipv4_networks(24)
+
+
+def test__find_ipv4_addresses(monkeypatch):
+    _set_up_adapters(monkeypatch)
+    assert _find_ipv4_addresses() == {"192.168.0.1", "192.168.1.1", "15.100.100.100"}
 
 
 def test__check_ip_and_port(monkeypatch):


### PR DESCRIPTION
This PR changes the way that `discover()` determines the IP addresses to use for multicast discovery. It replaces the use of `gethostbyname()` with a comprehensive list of IPv4 addresses obtained using the `ifaddr` library. This should cover cases where the host has multiple NICs and/or multiple IP addresses associated with those NICs, and prevent some of the common problems encountered when using discovery. 

Addresses #764.