### PR TITLE
Exclude link local networks from scan_network()

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -288,8 +288,8 @@ def scan_network(
     searching for Sonos devices. Multiple parallel threads are used to
     scan IP addresses in parallel for faster discovery.
 
-    Public and loopback IP ranges are excluded from the scan, and the scope of
-    the search can be controlled by setting a minimum netmask.
+    Public, loopback and link local IP ranges are excluded from the scan,
+    and the scope of the search can be controlled by setting a minimum netmask.
 
     Alternatively, a list of networks to scan can be provided.
 
@@ -540,7 +540,7 @@ def _find_ipv4_networks(min_netmask):
 
     Helper function to return a set of IPv4 networks to which
     the network interfaces on this node are attached.
-    Exclude public and loopback network ranges.
+    Exclude public, loopback and link local network ranges.
 
     Args:
         min_netmask(int): The minimum netmask to be used.
@@ -560,8 +560,12 @@ def _find_ipv4_networks(min_netmask):
                 continue
 
             ipv4_network = ipaddress.ip_network(ifaddr_network.ip)
-            # Restrict to private networks and exclude loopback
-            if ipv4_network.is_private and not ipv4_network.is_loopback:
+            # Restrict to private networks, and exclude loopback and link local
+            if (
+                ipv4_network.is_private
+                and not ipv4_network.is_loopback
+                and not ipv4_network.is_link_local
+            ):
                 # Constrain the size of network that will be searched
                 netmask = ifaddr_network.network_prefix
                 if netmask < min_netmask:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -114,6 +114,7 @@ def test__find_ipv4_networks(monkeypatch):
     assert ipaddress.ip_network("192.168.1.1/16", False) in _find_ipv4_networks(0)
     assert ipaddress.ip_network("15.100.100.100/8", False) not in _find_ipv4_networks(8)
     assert ipaddress.ip_network("127.0.0.1/24", False) not in _find_ipv4_networks(24)
+    assert ipaddress.ip_network("169.254.1.10/16", False) not in _find_ipv4_networks(16)
 
 
 def test__check_ip_and_port(monkeypatch):
@@ -147,7 +148,7 @@ def test__sonos_scan_worker_thread(monkeypatch):
         sonos_ip_addresses = []
         _sonos_scan_worker_thread(ip_set, 0.1, sonos_ip_addresses, True)
         assert len(sonos_ip_addresses) == 2
-        assert set(["192.168.0.1", "192.168.0.2"]) == set(sonos_ip_addresses)
+        assert {"192.168.0.1", "192.168.0.2"} == set(sonos_ip_addresses)
         assert "192.168.0.3" not in sonos_ip_addresses
 
 
@@ -203,7 +204,8 @@ def _set_up_adapters(monkeypatch):
     private_16 = ifaddr.IP("192.168.1.1", 16, "private-16")
     public = ifaddr.IP("15.100.100.100", 8, "public")
     loopback = ifaddr.IP("127.0.0.1", 24, "loopback")
-    ips = [private_24, private_16, public, loopback]
+    link_local = ifaddr.IP("169.254.1.10", 16, "link_local")
+    ips = [private_24, private_16, public, loopback, link_local]
 
     # Set up mock adapters
     adapters = OrderedDict()


### PR DESCRIPTION
This PR excludes any link local networks from `scan_network()` discovery. Windows systems seem to report these networks when their network interfaces are interrogated, but they don't need to be scanned.