### PR TITLE
Add a 'fixed_volume' property to the SoCo class

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -197,6 +197,7 @@ class SoCo(_SocoSingletonBase):
         balance
         night_mode
         dialog_mode
+        fixed_volume
         status_light
 
     ..  rubric:: Playlists and Favorites
@@ -812,7 +813,7 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def loudness(self):
-        """bool: The Sonos speaker's loudness compensation.
+        """bool: The speaker's loudness compensation.
 
         True if on, False otherwise.
 
@@ -921,7 +922,7 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def dialog_mode(self):
-        """bool: Get the Sonos speaker's dialog mode.
+        """bool: The speaker's dialog mode.
 
         True if on, False if off, None if not supported.
         """
@@ -953,6 +954,45 @@ class SoCo(_SocoSingletonBase):
                 ("DesiredValue", int(dialog_mode)),
             ]
         )
+
+    @property
+    def fixed_volume(self):
+        """bool: The device's fixed volume output setting.
+
+        True if on, False if off. Only applicable to certain
+        Sonos devices (Connect and Port at the time of writing).
+        All other devices always return False.
+
+        Attempting to set the property for a non-applicable device
+        will raise a `NotSupportedException`.
+        """
+        response = self.renderingControl.GetOutputFixed([("InstanceID", 0)])
+        return bool(int(response["CurrentFixed"]))
+
+    @fixed_volume.setter
+    def fixed_volume(self, fixed_volume):
+        """Switch on/off the device's fixed volume output setting.
+
+        Only applicable to certain Sonos devices.
+
+        :param fixed_volume: Enable or disable fixed volume output mode.
+        :type fixed_volume: bool
+        :raises NotSupportedException: If the device does not support
+        fixed volume output mode.
+        """
+        if int(
+            self.renderingControl.GetSupportsOutputFixed([("InstanceID", 0)])[
+                "CurrentSupportsFixed"
+            ]
+        ):
+            self.renderingControl.SetOutputFixed(
+                [
+                    ("InstanceID", 0),
+                    ("DesiredFixed", int(fixed_volume)),
+                ]
+            )
+        else:
+            raise NotSupportedException
 
     def _parse_zone_group_state(self):
         """The Zone Group State contains a lot of useful information.

--- a/soco/core.py
+++ b/soco/core.py
@@ -985,10 +985,11 @@ class SoCo(_SocoSingletonBase):
                 "CurrentSupportsFixed"
             ]
         ):
+            fixed_volume_value = "1" if fixed_volume else "0"
             self.renderingControl.SetOutputFixed(
                 [
                     ("InstanceID", 0),
-                    ("DesiredFixed", int(fixed_volume)),
+                    ("DesiredFixed", fixed_volume_value),
                 ]
             )
         else:

--- a/soco/core.py
+++ b/soco/core.py
@@ -966,12 +966,14 @@ class SoCo(_SocoSingletonBase):
         Attempting to get or set this property for a non-applicable
         device will raise a `NotSupportedException`.
         """
+
         if not int(
             self.renderingControl.GetSupportsOutputFixed([("InstanceID", 0)])[
                 "CurrentSupportsFixed"
             ]
         ):
             raise NotSupportedException
+
         response = self.renderingControl.GetOutputFixed([("InstanceID", 0)])
         return response["CurrentFixed"] == "1"
 
@@ -986,19 +988,16 @@ class SoCo(_SocoSingletonBase):
         :raises NotSupportedException: If the device does not support
         fixed volume output mode.
         """
-        if not int(
-            self.renderingControl.GetSupportsOutputFixed([("InstanceID", 0)])[
-                "CurrentSupportsFixed"
-            ]
-        ):
-            raise NotSupportedException
-        fixed_volume_value = "1" if fixed_volume else "0"
-        self.renderingControl.SetOutputFixed(
-            [
-                ("InstanceID", 0),
-                ("DesiredFixed", fixed_volume_value),
-            ]
-        )
+
+        # Will throw an exception if fixed_volume not supported
+        # If no change in state, do nothing
+        if fixed_volume != self.fixed_volume:
+            self.renderingControl.SetOutputFixed(
+                [
+                    ("InstanceID", 0),
+                    ("DesiredFixed", "1" if fixed_volume else "0"),
+                ]
+            )
 
     def _parse_zone_group_state(self):
         """The Zone Group State contains a lot of useful information.

--- a/soco/core.py
+++ b/soco/core.py
@@ -963,11 +963,17 @@ class SoCo(_SocoSingletonBase):
         Sonos devices (Connect and Port at the time of writing).
         All other devices always return False.
 
-        Attempting to set the property for a non-applicable device
-        will raise a `NotSupportedException`.
+        Attempting to get or set this property for a non-applicable
+        device will raise a `NotSupportedException`.
         """
+        if not int(
+            self.renderingControl.GetSupportsOutputFixed([("InstanceID", 0)])[
+                "CurrentSupportsFixed"
+            ]
+        ):
+            raise NotSupportedException
         response = self.renderingControl.GetOutputFixed([("InstanceID", 0)])
-        return bool(int(response["CurrentFixed"]))
+        return response["CurrentFixed"] == "1"
 
     @fixed_volume.setter
     def fixed_volume(self, fixed_volume):
@@ -980,20 +986,19 @@ class SoCo(_SocoSingletonBase):
         :raises NotSupportedException: If the device does not support
         fixed volume output mode.
         """
-        if int(
+        if not int(
             self.renderingControl.GetSupportsOutputFixed([("InstanceID", 0)])[
                 "CurrentSupportsFixed"
             ]
         ):
-            fixed_volume_value = "1" if fixed_volume else "0"
-            self.renderingControl.SetOutputFixed(
-                [
-                    ("InstanceID", 0),
-                    ("DesiredFixed", fixed_volume_value),
-                ]
-            )
-        else:
             raise NotSupportedException
+        fixed_volume_value = "1" if fixed_volume else "0"
+        self.renderingControl.SetOutputFixed(
+            [
+                ("InstanceID", 0),
+                ("DesiredFixed", fixed_volume_value),
+            ]
+        )
 
     def _parse_zone_group_state(self):
         """The Zone Group State contains a lot of useful information.

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -21,6 +21,8 @@ Warning:
     one use.
 """
 
+from soco.exceptions import NotSupportedException
+
 
 class Snapshot(object):
     """A snapshot of the current state.
@@ -224,7 +226,10 @@ class Snapshot(object):
         # command to check, fixed volume always has volume set to 100.
         # So only checked fixed volume if volume is 100.
         if self.volume == 100:
-            fixed_vol = self.device.fixed_volume
+            try:
+                fixed_vol = self.device.fixed_volume
+            except NotSupportedException:
+                fixed_vol = False
         else:
             fixed_vol = False
 

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -21,8 +21,6 @@ Warning:
     one use.
 """
 
-from soco.exceptions import NotSupportedException
-
 
 class Snapshot(object):
     """A snapshot of the current state.
@@ -226,10 +224,7 @@ class Snapshot(object):
         # command to check, fixed volume always has volume set to 100.
         # So only checked fixed volume if volume is 100.
         if self.volume == 100:
-            try:
-                fixed_vol = self.device.fixed_volume
-            except NotSupportedException:
-                fixed_vol = False
+            fixed_vol = self.device.fixed_volume
         else:
             fixed_vol = False
 

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -224,9 +224,7 @@ class Snapshot(object):
         # command to check, fixed volume always has volume set to 100.
         # So only checked fixed volume if volume is 100.
         if self.volume == 100:
-            fixed_vol = self.device.renderingControl.GetOutputFixed(
-                [("InstanceID", 0)]
-            )["CurrentFixed"]
+            fixed_vol = self.device.fixed_volume
         else:
             fixed_vol = False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1148,6 +1148,20 @@ class TestRenderingControl:
             [("InstanceID", 0), ("Channel", "Master"), ("DesiredLoudness", "0")]
         )
 
+    def test_soco_fixed_volume(self, moco):
+        moco.renderingControl.GetOutputFixed.return_value = {"CurrentFixed": "1"}
+        assert moco.fixed_volume
+        moco.renderingControl.GetOutputFixed.assert_called_once_with(
+            [("InstanceID", 0)]
+        )
+        moco.fixed_volume = False
+        moco.renderingControl.GetSupportsOutputFixed.assert_called_once_with(
+            [("InstanceID", 0)]
+        )
+        moco.renderingControl.SetOutputFixed.assert_called_once_with(
+            [("InstanceID", 0), ("DesiredFixed", "0")]
+        )
+
     def test_soco_balance(self, moco):
         # GetVolume is called twice, once for each of the left
         # and right channels

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1149,26 +1149,33 @@ class TestRenderingControl:
         )
 
     def test_soco_fixed_volume(self, moco):
-        moco.renderingControl.GetOutputFixed.return_value = {"CurrentFixed": "1"}
         moco.renderingControl.GetSupportsOutputFixed.return_value = {
             "CurrentSupportsFixed": "1"
         }
+        assert moco.supports_fixed_volume
+        moco.renderingControl.GetSupportsOutputFixed.assert_called_with(
+            [("InstanceID", 0)]
+        )
+        moco.renderingControl.GetSupportsOutputFixed.return_value = {
+            "CurrentSupportsFixed": "0"
+        }
+        assert not moco.supports_fixed_volume
+        moco.renderingControl.GetSupportsOutputFixed.assert_called_with(
+            [("InstanceID", 0)]
+        )
+
+        moco.renderingControl.GetOutputFixed.return_value = {"CurrentFixed": "1"}
         assert moco.fixed_volume
         moco.renderingControl.GetOutputFixed.assert_called_once_with(
             [("InstanceID", 0)]
         )
         moco.fixed_volume = False
-        moco.renderingControl.GetSupportsOutputFixed.assert_called_with(
-            [("InstanceID", 0)]
-        )
         moco.renderingControl.SetOutputFixed.assert_called_once_with(
             [("InstanceID", 0), ("DesiredFixed", "0")]
         )
-        moco.renderingControl.GetSupportsOutputFixed.return_value = {
-            "CurrentSupportsFixed": "0"
-        }
-        with pytest.raises(NotSupportedException):
-            assert moco.fixed_volume
+        moco.renderingControl.SetOutputFixed.side_effect = SoCoUPnPException(
+            None, None, None
+        )
         with pytest.raises(NotSupportedException):
             moco.fixed_volume = True
 


### PR DESCRIPTION
This PR adds a gettable/settable `fixed_volume` property to the SoCo class, with accompanying tests. It also adds a `supports_fixed_volume` property to determine if a device supports this feature.

This (currently) only applies to Sonos Connect and Sonos Port devices. All non-applicable devices raise a `NotSupportedException` on set attempts, and will always return `False` on gets.

Tested with both Sonos Connect (S1) and Sonos Port (S2), as well as with devices for which `fixed_volume` is non-applicable.