### PR TITLE
Add a 'buttons_enabled' property to the SoCo class

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -35,6 +35,7 @@ from .exceptions import (
     SoCoSlaveException,
     SoCoUPnPException,
     NotSupportedException,
+    SoCoNotVisibleException,
 )
 from .groups import ZoneGroup
 from .music_library import MusicLibrary
@@ -198,6 +199,7 @@ class SoCo(_SocoSingletonBase):
         night_mode
         dialog_mode
         status_light
+        buttons_enabled
 
     ..  rubric:: Playlists and Favorites
     ..  autosummary::
@@ -1301,6 +1303,42 @@ class SoCo(_SocoSingletonBase):
         self.deviceProperties.SetLEDState(
             [
                 ("DesiredLEDState", led_state),
+            ]
+        )
+
+    @property
+    def buttons_enabled(self):
+        """bool: Whether the control buttons on the device are enabled.
+
+        `True` if the control buttons are enabled, `False` if disabled.
+
+        This property can only be set on visible speakers, and will enable
+        or disable the buttons for all speakers in any bonded set (e.g., a
+        stereo pair). Attempting to set it on invisible speakers
+        (e.g., the RH speaker of a stereo pair) will raise a
+        `SoCoNotVisibleException`.
+        """
+        lock_state = self.deviceProperties.GetButtonLockState()[
+            "CurrentButtonLockState"
+        ]
+        return lock_state == "Off"
+
+    @buttons_enabled.setter
+    def buttons_enabled(self, enabled):
+        """Enable or disable the device's control buttons.
+
+        Args:
+            bool: True to enable the buttons, False to disable.
+
+        Raises:
+            SoCoNotVisibleException: If the speaker is not visible.
+        """
+        if not self.is_visible:
+            raise SoCoNotVisibleException
+        lock_state = "Off" if enabled else "On"
+        self.deviceProperties.SetButtonLockState(
+            [
+                ("DesiredButtonLockState", lock_state),
             ]
         )
 

--- a/soco/exceptions.py
+++ b/soco/exceptions.py
@@ -81,6 +81,11 @@ class SoCoSlaveException(SoCoException):
     """Raised when a master command is called on a slave."""
 
 
+class SoCoNotVisibleException(SoCoException):
+    """Raised when a command intended for a visible speaker is called
+    on an invisible one."""
+
+
 class NotSupportedException(SoCoException):
     """Raised when something is not supported by the device"""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,11 @@ import pytest
 
 from soco import SoCo
 from soco.data_structures import DidlMusicTrack, to_didl_string
-from soco.exceptions import SoCoSlaveException, SoCoUPnPException
+from soco.exceptions import (
+    SoCoSlaveException,
+    SoCoUPnPException,
+    SoCoNotVisibleException,
+)
 from soco.groups import ZoneGroup
 from soco.xml import XML
 
@@ -1188,6 +1192,36 @@ class TestDeviceProperties:
         moco.deviceProperties.SetLEDState.assert_called_with(
             [("DesiredLEDState", "On")]
         )
+
+    def test_buttons_enabled(self, moco):
+        moco.deviceProperties.GetButtonLockState.return_value = {
+            "CurrentButtonLockState": "On"
+        }
+        assert not moco.buttons_enabled
+        moco.deviceProperties.GetButtonLockState.return_value = {
+            "CurrentButtonLockState": "Off"
+        }
+        assert moco.buttons_enabled
+        moco.deviceProperties.GetButtonLockState.assert_called_with()
+        # Setter tests for 'is_visible' property, so this needs to be
+        # mocked.
+        with mock.patch(
+            "soco.SoCo.is_visible", new_callable=mock.PropertyMock
+        ) as mock_is_visible:
+            mock_is_visible.return_value = True
+            moco.buttons_enabled = False
+            moco.deviceProperties.SetButtonLockState.assert_called_once_with(
+                [("DesiredButtonLockState", "On")]
+            )
+            moco.buttons_enabled = True
+            moco.deviceProperties.SetButtonLockState.assert_called_with(
+                [("DesiredButtonLockState", "Off")]
+            )
+            # Check for exception if attempt to set the property on a
+            # non-visible speaker.
+            mock_is_visible.return_value = False
+            with pytest.raises(SoCoNotVisibleException):
+                moco.buttons_enabled = True
 
     def test_soco_set_player_name(self, moco):
         moco.player_name = "μИⅠℂ☺ΔЄ💋"


### PR DESCRIPTION
This PR adds a gettable/settable `buttons_enabled` property to the SoCo class, including accompanying tests.

Note that this inverts the function of the underlying `deviceProperties.ButtonLockState*` operations. I think it's more meaningful to deal with buttons that are enabled or disabled, rather than locked or unlocked.

Can only be set on visible speakers, or an exception (`SoCoNotVisibleException`) is raised. Applying to non-visible speakers does 'interesting' things, and probably not what's desired.

Tested on S1 and S2 devices, with and without control buttons. For devices without buttons (e.g., Sonos Port) the operations still succeed and don't appear to have any effect nor to do any harm.