### PR TITLE
Add 'trueplay' property to SoCo

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -968,7 +968,10 @@ class SoCo(_SocoSingletonBase):
 
         Devices that do not support Trueplay, or which do not have
         a current Trueplay calibration, will raise a `NotSupportedException`
-        both when getting and setting the property..
+        when both getting and setting the property.
+
+        Can only be set on visible devices. Attempting to set on non-visible
+        devices will raise a `SoCoNotVisibleException`.
         """
         response = self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])
         if response["RoomCalibrationAvailable"] == "0":
@@ -977,7 +980,7 @@ class SoCo(_SocoSingletonBase):
 
     @trueplay.setter
     def trueplay(self, trueplay):
-        """Switch on/off the device's TruePlay setting. Only available to
+        """Toggle the device's TruePlay setting. Only available to
         Sonos speakers, not the Connect, Amp, etc., and only available to
         speakers that have a current Trueplay calibration.
 
@@ -985,13 +988,13 @@ class SoCo(_SocoSingletonBase):
         :type trueplay: bool
         :raises NotSupportedException: If the device does not support
         Trueplay or doesn't have a current calibration.
+        :raises SoCoNotVisibleException: If the device is not visible.
         """
-        if not int(
-            self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])[
-                "RoomCalibrationAvailable"
-            ]
-        ):
+        response = self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])
+        if response["RoomCalibrationAvailable"] == "0":
             raise NotSupportedException
+        if not self.is_visible:
+            raise SoCoNotVisibleException
         trueplay_value = "1" if trueplay else "0"
         self.renderingControl.SetRoomCalibrationStatus(
             [

--- a/soco/core.py
+++ b/soco/core.py
@@ -197,6 +197,7 @@ class SoCo(_SocoSingletonBase):
         balance
         night_mode
         dialog_mode
+        trueplay
         status_light
 
     ..  rubric:: Playlists and Favorites
@@ -951,6 +952,45 @@ class SoCo(_SocoSingletonBase):
                 ("InstanceID", 0),
                 ("EQType", "DialogLevel"),
                 ("DesiredValue", int(dialog_mode)),
+            ]
+        )
+
+    @property
+    def trueplay(self):
+        """bool: Whether Trueplay is enabled on this device.
+        True if on, False if off.
+
+        Devices that do not support Trueplay, or which do not have
+        a current Trueplay calibration, will raise a `NotSupportedException`
+        both when getting and setting the property..
+        """
+        response = self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])
+        if response["RoomCalibrationAvailable"] == "0":
+            raise NotSupportedException
+        return response["RoomCalibrationEnabled"] == "1"
+
+    @trueplay.setter
+    def trueplay(self, trueplay):
+        """Switch on/off the device's TruePlay setting. Only available to
+        Sonos speakers, not the Connect, Amp, etc., and only available to
+        speakers that have a current Trueplay calibration.
+
+        :param trueplay: Enable or disable Trueplay.
+        :type trueplay: bool
+        :raises NotSupportedException: If the device does not support
+        Trueplay or doesn't have a current calibration.
+        """
+        if not int(
+            self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])[
+                "RoomCalibrationAvailable"
+            ]
+        ):
+            raise NotSupportedException
+        trueplay_value = "1" if trueplay else "0"
+        self.renderingControl.SetRoomCalibrationStatus(
+            [
+                ("InstanceID", 0),
+                ("RoomCalibrationEnabled", trueplay_value),
             ]
         )
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -967,16 +967,18 @@ class SoCo(_SocoSingletonBase):
         True if on, False if off.
 
         Devices that do not support Trueplay, or which do not have
-        a current Trueplay calibration, will raise a `NotSupportedException`
-        when both getting and setting the property.
+        a current Trueplay calibration, will return `None` on getting
+        the property, and  raise a `NotSupportedException` when
+        setting the property.
 
         Can only be set on visible devices. Attempting to set on non-visible
         devices will raise a `SoCoNotVisibleException`.
         """
         response = self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])
         if response["RoomCalibrationAvailable"] == "0":
-            raise NotSupportedException
-        return response["RoomCalibrationEnabled"] == "1"
+            return None
+        else:
+            return response["RoomCalibrationEnabled"] == "1"
 
     @trueplay.setter
     def trueplay(self, trueplay):
@@ -993,8 +995,10 @@ class SoCo(_SocoSingletonBase):
         response = self.renderingControl.GetRoomCalibrationStatus([("InstanceID", 0)])
         if response["RoomCalibrationAvailable"] == "0":
             raise NotSupportedException
+
         if not self.is_visible:
             raise SoCoNotVisibleException
+
         trueplay_value = "1" if trueplay else "0"
         self.renderingControl.SetRoomCalibrationStatus(
             [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1155,28 +1155,47 @@ class TestRenderingControl:
 
     def test_soco_trueplay(self, moco):
         moco.renderingControl.GetRoomCalibrationStatus.return_value = {
-            "RoomCalibrationAvailable": "1",
-            "RoomCalibrationEnabled": "1",
-        }
-        assert moco.trueplay
-        moco.renderingControl.GetRoomCalibrationStatus.assert_called_once_with(
-            [("InstanceID", 0)]
-        )
-        moco.trueplay = False
-        moco.renderingControl.GetRoomCalibrationStatus.assert_called_with(
-            [("InstanceID", 0)]
-        )
-        moco.renderingControl.SetRoomCalibrationStatus.assert_called_once_with(
-            [("InstanceID", 0), ("RoomCalibrationEnabled", "0")]
-        )
-        moco.renderingControl.GetRoomCalibrationStatus.return_value = {
             "RoomCalibrationAvailable": "0",
             "RoomCalibrationEnabled": "0",
         }
         with pytest.raises(NotSupportedException):
             assert not moco.trueplay
-        with pytest.raises(NotSupportedException):
+            moco.renderingControl.GetRoomCalibrationStatus.assert_called_with(
+                [("InstanceID", 0)]
+            )
+        moco.renderingControl.GetRoomCalibrationStatus.return_value = {
+            "RoomCalibrationAvailable": "1",
+            "RoomCalibrationEnabled": "1",
+        }
+        assert moco.trueplay
+        moco.renderingControl.GetRoomCalibrationStatus.assert_called_with(
+            [("InstanceID", 0)]
+        )
+        # Setter tests for 'is_visible' property, so this needs to be
+        # mocked.
+        with mock.patch(
+            "soco.SoCo.is_visible", new_callable=mock.PropertyMock
+        ) as mock_is_visible:
+            mock_is_visible.return_value = True
+            moco.trueplay = False
+            moco.renderingControl.SetRoomCalibrationStatus.assert_called_with(
+                [
+                    ("InstanceID", 0),
+                    ("RoomCalibrationEnabled", "0"),
+                ]
+            )
             moco.trueplay = True
+            moco.renderingControl.SetRoomCalibrationStatus.assert_called_with(
+                [
+                    ("InstanceID", 0),
+                    ("RoomCalibrationEnabled", "1"),
+                ]
+            )
+            # Check for exception if attempt to set the property on a
+            # non-visible speaker.
+            mock_is_visible.return_value = False
+            with pytest.raises(SoCoNotVisibleException):
+                moco.trueplay = True
 
     def test_soco_fixed_volume(self, moco):
         moco.renderingControl.GetSupportsOutputFixed.return_value = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1158,11 +1158,10 @@ class TestRenderingControl:
             "RoomCalibrationAvailable": "0",
             "RoomCalibrationEnabled": "0",
         }
-        with pytest.raises(NotSupportedException):
-            assert not moco.trueplay
-            moco.renderingControl.GetRoomCalibrationStatus.assert_called_with(
-                [("InstanceID", 0)]
-            )
+        assert moco.trueplay is None
+        moco.renderingControl.GetRoomCalibrationStatus.assert_called_with(
+            [("InstanceID", 0)]
+        )
         moco.renderingControl.GetRoomCalibrationStatus.return_value = {
             "RoomCalibrationAvailable": "1",
             "RoomCalibrationEnabled": "1",


### PR DESCRIPTION
This PR adds a gettable/settable property `trueplay`, with accompanying tests. The property allows the Trueplay state of a speaker (`True` or `False`) to be determined, and to be changed.

Devices that do not support Trueplay, or which do not have  a current Trueplay calibration, will return `None` on getting the property, and  raise a `NotSupportedException` when setting the property. Can only be set on visible devices. Attempting to set on non-visible devices will raise a `SoCoNotVisibleException`.

Tested on S1 and S2 devices, devices that don't support Trueplay, and devices that do support Trueplay, with and without a current calibration profile.