### PR TITLE
Add AudioIn Service

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -47,6 +47,7 @@ from .services import (
     AlarmClock,
     SystemProperties,
     MusicServices,
+    AudioIn,
     GroupRenderingControl,
 )
 from .utils import really_utf8, camel_to_underscore, deprecated
@@ -281,6 +282,7 @@ class SoCo(_SocoSingletonBase):
         self.alarmClock = AlarmClock(self)
         self.systemProperties = SystemProperties(self)
         self.musicServices = MusicServices(self)
+        self.audioIn = AudioIn(self)
 
         self.music_library = MusicLibrary(self)
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -776,6 +776,10 @@ class MusicServices(Service):
     services."""
 
 
+class AudioIn(Service):
+    """Sonos audio in service, for functions related to RCA audio input."""
+
+
 class DeviceProperties(Service):
     """Sonos device properties service, for functions relating to zones, LED
     state, stereo pairs etc."""


### PR DESCRIPTION
This PR adds the definitions so that the AudioIn service is created. This allows one to obtain the names of the inputs and to register for notification of active inputs.