### PR TITLE
Add properties for surround speakers in TV, music and ambient modes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
   - id: pylint
     args: [--rcfile, "pylintrc"]
     exclude: tests|doc|examples|setup.py|dev_tools
-    additional_dependencies: ["requests", "xmltodict", "ifaddr"]
+    additional_dependencies: ["requests", "xmltodict", "ifaddr", "appdirs"]

--- a/soco/core.py
+++ b/soco/core.py
@@ -256,8 +256,7 @@ class SoCo(_SocoSingletonBase):
         audio_delay
         night_mode
         dialog_mode
-        surround_mode
-        surround_mode_music_playback
+        surround_music_playback
         surround_volume_tv
         surround_volume_music
         soundbar_audio_input_format
@@ -1213,7 +1212,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        return self.renderingControl.get_eq_variable("NightMode")
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "NightMode")]
+        )
+        return bool(int(response["CurrentValue"]))
 
     @night_mode.setter
     @only_on_soundbars
@@ -1225,7 +1227,13 @@ class SoCo(_SocoSingletonBase):
         :raises NotSupportedException: If the device does not support
         night mode.
         """
-        self.renderingControl.set_eq_variable("NightMode", int(night_mode))
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "NightMode"),
+                ("DesiredValue", int(night_mode)),
+            ]
+        )
 
     @property
     def dialog_mode(self):
@@ -1236,7 +1244,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        return bool(self.renderingControl.get_eq_variable("DialogLevel"))
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "DialogLevel")]
+        )
+        return bool(int(response["CurrentValue"]))
 
     @dialog_mode.setter
     @only_on_soundbars
@@ -1248,32 +1259,16 @@ class SoCo(_SocoSingletonBase):
         :raises NotSupportedException: If the device does not support
         dialog mode.
         """
-        self.renderingControl.set_eq_variable("DialogLevel", int(dialog_mode))
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "DialogLevel"),
+                ("DesiredValue", int(dialog_mode)),
+            ]
+        )
 
     @property
-    def surround_mode(self) -> Optional[bool]:
-        """bool: The speaker's surround mode.
-
-        True if on, False if off, None if not supported.
-        """
-        if not self.is_soundbar:
-            return None
-
-        return bool(self.renderingControl.get_eq_variable("SurroundEnable"))
-
-    @surround_mode.setter
-    @only_on_soundbars
-    def surround_mode(self, surround_mode: bool):
-        """Switch on/off the speaker's surround mode.
-
-        :param surround_mode: Enable or disable surround mode
-        :type surround_mode: bool
-        :raises NotSupportedException: If the device does not support
-        surround mode."""
-        self.renderingControl.set_eq_variable("SurroundEnable", int(surround_mode))
-
-    @property
-    def surround_mode_music_playback(self) -> Optional[int]:
+    def surround_music_playback(self) -> Optional[int]:
         """Return the music playback mode (ambient, full volume) for surrounds.
 
         Note: this does not apply to the TV mode.
@@ -1286,11 +1281,14 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        return self.renderingControl.get_eq_variable("SurroundMode")
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "SurroundMode")]
+        )
+        return int(response["CurrentValue"])
 
-    @surround_mode_music_playback.setter
+    @surround_music_playback.setter
     @only_on_soundbars
-    def surround_mode_music_playback(self, value: int):
+    def surround_music_playback(self, value: int):
         """Set the music playback mode (ambient, full volume) for surrounds.
 
         Note: this does not apply to the TV mode.
@@ -1300,7 +1298,13 @@ class SoCo(_SocoSingletonBase):
         0: ambient
         1: full
         """
-        return self.renderingControl.set_eq_variable("SurroundMode", value)
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "SurroundMode"),
+                ("DesiredValue", value),
+            ]
+        )
 
     @property
     def surround_volume_tv(self) -> Optional[int]:
@@ -1308,7 +1312,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        return self.renderingControl.get_eq_variable("SurroundLevel")
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "SurroundLevel")]
+        )
+        return int(response["CurrentValue"])
 
     @surround_volume_tv.setter
     @only_on_soundbars
@@ -1320,7 +1327,13 @@ class SoCo(_SocoSingletonBase):
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
 
-        self.renderingControl.set_eq_variable("SurroundLevel", relative_volume)
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "SurroundLevel"),
+                ("DesiredValue", relative_volume),
+            ]
+        )
 
     @property
     def surround_volume_music(self) -> Optional[int]:
@@ -1331,7 +1344,10 @@ class SoCo(_SocoSingletonBase):
         if not self.is_soundbar:
             return None
 
-        return self.renderingControl.get_eq_variable("MusicSurroundLevel")
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "MusicSurroundLevel")]
+        )
+        return int(response["CurrentValue"])
 
     @surround_volume_music.setter
     @only_on_soundbars
@@ -1340,7 +1356,13 @@ class SoCo(_SocoSingletonBase):
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
 
-        self.renderingControl.set_eq_variable("MusicSurroundLevel", relative_volume)
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "MusicSurroundLevel"),
+                ("DesiredValue", relative_volume),
+            ]
+        )
 
     @property
     def dialog_level(self):

--- a/soco/core.py
+++ b/soco/core.py
@@ -1265,12 +1265,12 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
-    def surround_music_playback(self) -> Optional[int]:
-        """Return the music playback mode (ambient, full volume) for surrounds.
+    def surround_ambient_enabled(self) -> Optional[bool]:
+        """Return the True if surround ambient mode is enabled.
+
+        If False, the playback on surround speakers uses full volume.
 
         Note: this does not apply to the TV mode.
-
-        TODO: enumize this?
 
         0: ambient
         1: full
@@ -1281,25 +1281,20 @@ class SoCo(_SocoSingletonBase):
         response = self.renderingControl.GetEQ(
             [("InstanceID", 0), ("EQType", "SurroundMode")]
         )
-        return int(response["CurrentValue"])
+        return not int(response["CurrentValue"])
 
-    @surround_music_playback.setter
+    @surround_ambient_enabled.setter
     @only_on_soundbars
-    def surround_music_playback(self, value: int):
-        """Set the music playback mode (ambient, full volume) for surrounds.
+    def surround_ambient_enabled(self, value: bool):
+        """Set the surround music playback mode to ambient.
 
         Note: this does not apply to the TV mode.
-
-        TODO: enumize this?
-
-        0: ambient
-        1: full
         """
         self.renderingControl.SetEQ(
             [
                 ("InstanceID", 0),
                 ("EQType", "SurroundMode"),
-                ("DesiredValue", value),
+                ("DesiredValue", int(not value)),
             ]
         )
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -12,7 +12,6 @@ from functools import wraps
 import urllib.parse
 from xml.sax.saxutils import escape
 from xml.parsers.expat import ExpatError
-from typing import Optional
 import warnings
 import xmltodict
 
@@ -1265,7 +1264,7 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
-    def surround_ambient_enabled(self) -> Optional[bool]:
+    def surround_ambient_enabled(self):
         """Return True if surround ambient mode is enabled for surround music
         playback.
 
@@ -1283,7 +1282,7 @@ class SoCo(_SocoSingletonBase):
 
     @surround_ambient_enabled.setter
     @only_on_soundbars
-    def surround_ambient_enabled(self, value: bool):
+    def surround_ambient_enabled(self, value):
         """Toggle surround music playback mode. True = ambient mode.
 
         Note: this does not apply to TV playback.
@@ -1297,7 +1296,7 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
-    def surround_volume_tv(self) -> Optional[int]:
+    def surround_volume_tv(self):
         """Get the relative volume for surround speakers in TV
         playback mode. Ranges from -15 to +15."""
         if not self.is_soundbar:
@@ -1310,7 +1309,7 @@ class SoCo(_SocoSingletonBase):
 
     @surround_volume_tv.setter
     @only_on_soundbars
-    def surround_volume_tv(self, relative_volume: int):
+    def surround_volume_tv(self, relative_volume):
         """Set the relative volume for surround speakers in TV playback mode,
         in the range -15 to +15.
         """
@@ -1326,7 +1325,7 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
-    def surround_volume_music(self) -> Optional[int]:
+    def surround_volume_music(self):
         """Return the relative volume for surround speakers in music mode,
         in the range -15 to +15.
         """
@@ -1340,7 +1339,7 @@ class SoCo(_SocoSingletonBase):
 
     @surround_volume_music.setter
     @only_on_soundbars
-    def surround_volume_music(self, relative_volume: int):
+    def surround_volume_music(self, relative_volume):
         """Set the relative volume for surround speakers in music mode,
         in the range -15 to +15."""
         if not -15 <= relative_volume <= 15:

--- a/soco/core.py
+++ b/soco/core.py
@@ -12,9 +12,10 @@ from functools import wraps
 import urllib.parse
 from xml.sax.saxutils import escape
 from xml.parsers.expat import ExpatError
+from typing import Optional
 import warnings
 import xmltodict
-from typing import Optional
+
 
 import requests
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -158,13 +159,14 @@ def only_on_master(function):
 
 
 def only_on_soundbars(function):
-    """Decorator that raises NotSupportedException when trying to use soundbar methods on unsupported devices."""
+    """Decorator to raise an exception on soundbar property access on non-soundbars."""
 
     @wraps(function)
     def inner_function(self, *args, **kwargs):
         if not self.is_soundbar:
             raise NotSupportedException(
-                f"The device is not a soundbar and doesn't support {function.__name__}."
+                "The device is not a soundbar and doesn't support %s."
+                % function.__name__
             )
 
         return function(self, *args, **kwargs)
@@ -1272,7 +1274,7 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_mode_music_playback(self) -> Optional[int]:
-        """Return the music playback mode (ambient, full volume) for the music surround playback.
+        """Return the music playback mode (ambient, full volume) for surrounds.
 
         Note: this does not apply to the TV mode.
 
@@ -1289,7 +1291,12 @@ class SoCo(_SocoSingletonBase):
     @surround_mode_music_playback.setter
     @only_on_soundbars
     def surround_mode_music_playback(self, value: int):
-        """
+        """Set the music playback mode (ambient, full volume) for surrounds.
+
+        Note: this does not apply to the TV mode.
+
+        TODO: enumize this?
+
         0: ambient
         1: full
         """
@@ -1306,7 +1313,10 @@ class SoCo(_SocoSingletonBase):
     @surround_volume_tv.setter
     @only_on_soundbars
     def surround_volume_tv(self, relative_volume: int):
-        """Set the relative volume [-15,15} for surround speakers in the TV mode."""
+        """Set the relative volume for surround speakers in the TV mode.
+
+        Range [-15,15]
+        """
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
 
@@ -1314,7 +1324,10 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_volume_music(self) -> Optional[int]:
-        """Return the relative volume [-15,15] for surround speakers in the music mode."""
+        """Return the relative volume for surround speakers in the music mode.
+
+        Range: [-15,15]
+        """
         if not self.is_soundbar:
             return None
 
@@ -1323,7 +1336,7 @@ class SoCo(_SocoSingletonBase):
     @surround_volume_music.setter
     @only_on_soundbars
     def surround_volume_music(self, relative_volume: int):
-        """Set the relative volume [-15,15} for surround speakers in the music mode."""
+        """Set the relative volume [-15,15] for surround speakers in the music mode."""
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -242,7 +242,6 @@ class SoCo(_SocoSingletonBase):
         is_bridge
         is_coordinator
         is_soundbar
-        surround_enabled
         is_satellite
         has_satellites
         sub_enabled
@@ -256,6 +255,7 @@ class SoCo(_SocoSingletonBase):
         audio_delay
         night_mode
         dialog_mode
+        surround_enabled
         surround_music_playback
         surround_volume_tv
         surround_volume_music
@@ -1070,16 +1070,13 @@ class SoCo(_SocoSingletonBase):
         return bool(int(response["CurrentValue"]))
 
     @surround_enabled.setter
+    @only_on_soundbars
     def surround_enabled(self, enable):
         """Enable/disable the connected surround speakers.
 
         :param enable: Enable or disable surround speakers
         :type enable: bool
         """
-        if not self.is_soundbar:
-            message = "This device does not support surrounds"
-            raise NotSupportedException(message)
-
         self.renderingControl.SetEQ(
             [
                 ("InstanceID", 0),

--- a/soco/core.py
+++ b/soco/core.py
@@ -256,7 +256,7 @@ class SoCo(_SocoSingletonBase):
         night_mode
         dialog_mode
         surround_enabled
-        surround_music_playback
+        surround_ambient_enabled
         surround_volume_tv
         surround_volume_music
         soundbar_audio_input_format
@@ -1266,14 +1266,12 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_ambient_enabled(self) -> Optional[bool]:
-        """Return the True if surround ambient mode is enabled.
+        """Return True if surround ambient mode is enabled for surround music
+        playback.
 
-        If False, the playback on surround speakers uses full volume.
+        If False, playback on surround speakers uses full volume.
 
-        Note: this does not apply to the TV mode.
-
-        0: ambient
-        1: full
+        Note: does not apply to TV playback.
         """
         if not self.is_soundbar:
             return None
@@ -1286,9 +1284,9 @@ class SoCo(_SocoSingletonBase):
     @surround_ambient_enabled.setter
     @only_on_soundbars
     def surround_ambient_enabled(self, value: bool):
-        """Set the surround music playback mode to ambient.
+        """Toggle surround music playback mode. True = ambient mode.
 
-        Note: this does not apply to the TV mode.
+        Note: this does not apply to TV playback.
         """
         self.renderingControl.SetEQ(
             [
@@ -1300,7 +1298,8 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_volume_tv(self) -> Optional[int]:
-        """Return the relative volume [-15,15] for surround speakers in the TV mode."""
+        """Get the relative volume for surround speakers in TV
+        playback mode. Ranges from -15 to +15."""
         if not self.is_soundbar:
             return None
 
@@ -1312,9 +1311,8 @@ class SoCo(_SocoSingletonBase):
     @surround_volume_tv.setter
     @only_on_soundbars
     def surround_volume_tv(self, relative_volume: int):
-        """Set the relative volume for surround speakers in the TV mode.
-
-        Range [-15,15]
+        """Set the relative volume for surround speakers in TV playback mode,
+        in the range -15 to +15.
         """
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
@@ -1329,9 +1327,8 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_volume_music(self) -> Optional[int]:
-        """Return the relative volume for surround speakers in the music mode.
-
-        Range: [-15,15]
+        """Return the relative volume for surround speakers in music mode,
+        in the range -15 to +15.
         """
         if not self.is_soundbar:
             return None
@@ -1344,7 +1341,8 @@ class SoCo(_SocoSingletonBase):
     @surround_volume_music.setter
     @only_on_soundbars
     def surround_volume_music(self, relative_volume: int):
-        """Set the relative volume [-15,15] for surround speakers in the music mode."""
+        """Set the relative volume for surround speakers in music mode,
+        in the range -15 to +15."""
         if not -15 <= relative_volume <= 15:
             raise ValueError("Value must be [-15, 15]")
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -872,6 +872,22 @@ class RenderingControl(Service):
         self.event_subscription_url = "/MediaRenderer/RenderingControl/Event"
         self.DEFAULT_ARGS.update({"InstanceID": 0})
 
+    def get_eq_variable(self, variable: str) -> int:
+        """Return the EQ value for given variable as an integer."""
+        response = self.GetEQ([("InstanceID", 0), ("EQType", variable)])
+
+        return int(response["CurrentValue"])
+
+    def set_eq_variable(self, variable: str, value: int):
+        """Set the EQ variable to given (integer) value."""
+        return self.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", variable),
+                ("DesiredValue", value),
+            ]
+        )
+
 
 class MR_ConnectionManager(Service):  # pylint: disable=invalid-name
     """UPnP standard connection manager service for the media renderer."""

--- a/soco/services.py
+++ b/soco/services.py
@@ -872,22 +872,6 @@ class RenderingControl(Service):
         self.event_subscription_url = "/MediaRenderer/RenderingControl/Event"
         self.DEFAULT_ARGS.update({"InstanceID": 0})
 
-    def get_eq_variable(self, variable: str) -> int:
-        """Return the EQ value for given variable as an integer."""
-        response = self.GetEQ([("InstanceID", 0), ("EQType", variable)])
-
-        return int(response["CurrentValue"])
-
-    def set_eq_variable(self, variable: str, value: int):
-        """Set the EQ variable to given (integer) value."""
-        return self.SetEQ(
-            [
-                ("InstanceID", 0),
-                ("EQType", variable),
-                ("DesiredValue", value),
-            ]
-        )
-
 
 class MR_ConnectionManager(Service):  # pylint: disable=invalid-name
     """UPnP standard connection manager service for the media renderer."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1280,7 +1280,7 @@ class TestRenderingControl:
 
     def test_soco_audio_delay(self, moco):
         moco._is_soundbar = False
-        assert moco.audio_delay == None
+        assert moco.audio_delay is None
         assert not moco.renderingControl.GetEQ.called
 
         with pytest.raises(NotSupportedException):
@@ -1355,12 +1355,15 @@ class TestRenderingControl:
             [("InstanceID", 0), ("Channel", "RF"), ("DesiredVolume", 100)]
         )
 
-    @pytest.mark.parametrize("prop,variable,type,min,max", [
-        ("surround_enabled", "SurroundEnable", bool, None, None),
-        ("surround_ambient_enabled", "SurroundMode", bool, None, None),
-        ("surround_volume_tv", "SurroundLevel", int, -15, 15),
-        ("surround_volume_music", "MusicSurroundLevel", int, -15, 15),
-    ])
+    @pytest.mark.parametrize(
+        "prop,variable,type,min,max",
+        [
+            ("surround_enabled", "SurroundEnable", bool, None, None),
+            ("surround_ambient_enabled", "SurroundMode", bool, None, None),
+            ("surround_volume_tv", "SurroundLevel", int, -15, 15),
+            ("surround_volume_music", "MusicSurroundLevel", int, -15, 15),
+        ],
+    )
     def test_soco_surround_settings(self, moco, prop, variable, type, min, max):
         """Test the surround settings.
 
@@ -1368,6 +1371,7 @@ class TestRenderingControl:
         * For boolean values, check toggling and payloads
         * For ranged int values, check the ranges and payloads.
         """
+
         def _assert_seteq_call(prop, variable, value, type):
             desired_value = value
             setattr(moco, prop, value)
@@ -1383,27 +1387,24 @@ class TestRenderingControl:
                 ]
             )
 
-            moco.renderingControl.GetEQ.return_value = {"CurrentValue": int(desired_value)}
+            moco.renderingControl.GetEQ.return_value = {
+                "CurrentValue": int(desired_value)
+            }
             if type == bool:
                 assert getattr(moco, prop) == bool(value)
             elif type == int:
                 assert getattr(moco, prop) == value
 
             moco.renderingControl.GetEQ.assert_any_call(
-                [
-                    ("InstanceID", 0),
-                    ("EQType", variable)
-                ]
+                [("InstanceID", 0), ("EQType", variable)]
             )
             moco.renderingControl.SetEQ.reset_mock()
             moco.renderingControl.GetEQ.reset_mock()
 
-
-
         with mock.patch(
-                "soco.SoCo.is_soundbar", new_callable=mock.PropertyMock
+            "soco.SoCo.is_soundbar", new_callable=mock.PropertyMock
         ) as mock_is_soundbar:
-            mock_is_soundbar = True
+            mock_is_soundbar = True  # noqa: F841
 
             if type == bool:
                 for target in [True, False]:
@@ -1413,13 +1414,12 @@ class TestRenderingControl:
                 for target in [min, max]:
                     _assert_seteq_call(prop, variable, target, type)
 
-                for target in [min-5, max+5]:
+                for target in [min - 5, max + 5]:
                     with pytest.raises(ValueError):
                         setattr(moco, prop, target)
 
             else:
                 raise Exception("unhandled type %s" % type)
-
 
 
 class TestDeviceProperties:

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -7,10 +7,7 @@ import pytest
 import soco.soap
 from soco.exceptions import MusicServiceException
 from soco.music_services.accounts import Account
-from soco.music_services.music_service import (
-    MusicService,
-    MusicServiceSoapClient,
-)
+from soco.music_services.music_service import MusicService
 
 
 # Typical account data from http://{Sonos-ip}:1400/status/accounts


### PR DESCRIPTION
Adds following (setable) properties (see https://support.sonos.com/s/article/4804?language=en_US):
* ~~`surround_mode`: surround enabled/disabled~~ (already done in #870)
* `surround_ambient_enabled`: ambient/full volume in the music mode (bool)
* `surround_volume_tv`: surround volume adjustment [-15,15] for the tv mode (int)
* `surround_volume_music`: surround volume adjustment [15,15] for the music mode (int)

Currently missing reseting to defaults, and adjusting the surround speaker balance (which can only be done when trueplay is disabled, see https://github.com/SoCo/SoCo/pull/646#pullrequestreview-541049818).

Obsoletes #646. Fixes #461.