### PR TITLE
docs: fix simple typo, unknonwn -> unknown

### DIFF
--- a/soco/services.py
+++ b/soco/services.py
@@ -461,7 +461,7 @@ class Service(object):
             ValueError: If the argument lists do not match the action
                 signature.
             `SoCoUPnPException`: if a SOAP error occurs.
-            `UnknownSoCoException`: if an unknonwn UPnP error occurs.
+            `UnknownSoCoException`: if an unknown UPnP error occurs.
             `requests.exceptions.HTTPError`: if an http error occurs.
 
         """


### PR DESCRIPTION
There is a small typo in soco/services.py.

Should read `unknown` rather than `unknonwn`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md