### PR TITLE
Release v0.21 preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ script:
 
 after_script:
   - coveralls
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,3 @@ script:
 after_script:
   - coveralls
 
-deploy:
-  provider: pypi
-  user: soco-bot
-  password:
-    secure: IgMK3d7ON41NRlfIPYhlk7BPfT/jPRqC1Qn2Lcj69/vqSK5be0vyWloGRAI26v9r9VS1+slSocSUZ05BiUXQj6+srvgWLQfuRnivz6ZjttL/P+oHEvqeV917NqXU2gV7Xejs4j1Y1lu38KdAlul1XZ+0leq3tm88q8bNKAij/C0=
-  on:
-    tags: true
-  distributions: sdist bdist_wheel

--- a/doc/releases/0.21.rst
+++ b/doc/releases/0.21.rst
@@ -1,0 +1,41 @@
+SoCo 0.21 release notes
+***********************
+
+**SoCo 0.21** (Release date 2021-01-17), contains significant improvements to the speaker discovery process, which should address most of the common problems that are encountered.
+
+Multi-household Sonos systems can now be discovered and controlled.
+
+The `AudioIn` service has been added, providing access to Line In operations and events.
+
+A number of additional miscellaneous speaker state controls have been provided, for speaker buttons, fixed volume output, and Trueplay. The battery status of Sonos Move speakers can also now be obtained. The `music_source` property on SoCo objects provides a convenient way to determine what type of source is being played by a speaker.
+
+SoCo is now fully Python 3.9 compatible.
+
+New Features and Improvements
+=============================
+
+* Add support for **network scan discovery**, including allowing multi-household systems to be discovered: pull requests `#733 <https://github.com/SoCo/SoCo/pull/733>`_,  `#755 <https://github.com/SoCo/SoCo/pull/755>`_, and `#770 <https://github.com/SoCo/SoCo/pull/770>`_.
+* Add the **AudioIn service** for access to Line In operations and events: PR `#777 <https://github.com/SoCo/SoCo/pull/777>`_.
+* Add the ability to inspect and set  **Fixed Volume** output: PR `#773 <https://github.com/SoCo/SoCo/pull/773>`_.
+* Add the ability to inspect and set whether **speaker buttons** are enabled: PR `#774 <https://github.com/SoCo/SoCo/pull/774>`_.
+* Add the ability to inspect and set  **Trueplay** enablement: PR `#775 <https://github.com/SoCo/SoCo/pull/775>`_.
+* Add the ability to determine the **battery state** of Sonos Move speakers: PR `#756 <https://github.com/SoCo/SoCo/pull/756>`_.
+
+Bug Fixes
+=========
+
+* Improve zone group state caching to accommodate multi-household systems: PR `#656 <https://github.com/SoCo/SoCo/pull/656>`_. (Note: possible **breaking change**: if you've previously been setting the ``soco.core.zone_group_state_shared_cache.enabled`` property, this property is no longer global but is instead now a private property of SoCo instances.)
+* When restoring snapshots, do not try to restore bass/treble/loudness on devices with fixed volume enabled: PR `#772 <https://github.com/SoCo/SoCo/pull/772>`_.
+* Ensure that all relevant NICs and IP addresses are included in multicast speaker discovery: PR `#767 <https://github.com/SoCo/SoCo/pull/767>`_.
+
+Developer Improvements
+======================
+
+* Numerous fixes to allow the documentation to build cleanly: PR `#753 <https://github.com/SoCo/SoCo/pull/753>`_.
+* Full Python 3.9 compatibility, including updated check jobs: PRs `#745 <https://github.com/SoCo/SoCo/pull/745>`_ and `#751 <https://github.com/SoCo/SoCo/pull/751>`_.
+* Code changes to allow Pylint and Black to be updated to their most recent versions: PRs `#748 <https://github.com/SoCo/SoCo/pull/748>`_ and `#749 <https://github.com/SoCo/SoCo/pull/749>`_.
+
+List of Changes Associated with the 0.21 Milestone
+==================================================
+
+See: https://github.com/SoCo/SoCo/milestone/17?closed=1

--- a/doc/releases/0.21.rst
+++ b/doc/releases/0.21.rst
@@ -1,7 +1,7 @@
 SoCo 0.21 release notes
 ***********************
 
-**SoCo 0.21** (Release date 2021-01-17), contains significant improvements to the speaker discovery process, which should address most of the common problems that are encountered.
+**SoCo 0.21** (Released on 2021-01-17), contains significant improvements to the speaker discovery process, which should address most of the common problems that are encountered.
 
 Multi-household Sonos systems can now be discovered and controlled.
 
@@ -9,7 +9,7 @@ The `AudioIn` service has been added, providing access to Line In operations and
 
 A number of additional miscellaneous speaker state controls have been provided, for speaker buttons, fixed volume output, and Trueplay. The battery status of Sonos Move speakers can also now be obtained. The `music_source` property on SoCo objects provides a convenient way to determine what type of source is being played by a speaker.
 
-SoCo is now fully Python 3.9 compatible.
+SoCo 0.21 is now fully Python 3.9 compatible, requires Python 3.5+, and is no longer compatible with Python 2.x.
 
 New Features and Improvements
 =============================

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -7,6 +7,7 @@ SoCo releases
 .. toctree::
    :maxdepth: 1
 
+   0.21
    0.20
    0.19
    0.18

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import SoCoException, UnknownSoCoException
 __author__ = "The SoCo-Team <python-soco@googlegroups.com>"
 # Please add the suffix "+" to the version after release, to make it
 # possible infer whether in development code from the version string
-__version__ = "0.20+"
+__version__ = "0.21"
 __website__ = "https://github.com/SoCo/SoCo"
 __license__ = "MIT License"
 


### PR DESCRIPTION
**Note**: this PR will be merged when v0.21 is ready for release.

- Increment version number to 0.21
- Add release notes for v0.21
- Remove 'deploy' section from .travis.yml