### PR TITLE
Improve efficiency of 'get_battery_info()' and add tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ coveralls
 pytest-cov<2.6.0
 wheel
 black >= 20.0b0; python_version >= "3.6" and implementation_name == "cpython"
+requests-mock


### PR DESCRIPTION
This is a much more efficient implementation of `get_battery_info()`, using a different speaker URL to get the battery status. Tests have been added. Note the additional requirement for the `requests-mock` library in order to run the tests.