### PR TITLE
Do not refresh zone group cache on join/unjoin

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1243,7 +1243,6 @@ class SoCo(_SocoSingletonBase):
             ]
         )
         self._zgs_cache.clear()
-        self._parse_zone_group_state()
 
     def unjoin(self):
         """Remove this speaker from a group.
@@ -1255,7 +1254,6 @@ class SoCo(_SocoSingletonBase):
 
         self.avTransport.BecomeCoordinatorOfStandaloneGroup([("InstanceID", 0)])
         self._zgs_cache.clear()
-        self._parse_zone_group_state()
 
     def create_stereo_pair(self, rh_slave_speaker):
         """Create a stereo pair.


### PR DESCRIPTION
We currently reload the zone group cache after group changes (join/unjoin). As this is a synchronous operation, it actually slows the client down.

If we end up using the cache, the time we save has already been spent filling it. If we do not use the cache within 5 seconds, filling it was redundant.

Also note that group changes often happen to multiple speakers in turn and we are currently reloading the cache after each such operation.

So it seems that _not_ reloading the cache is always at least as good. Thus, this PR removes the preloading.
