### PR TITLE
Fix #810: Change in behaviour of urllib parse

### DIFF
--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -838,7 +838,10 @@ def desc_from_uri(uri):
     # the uri as if it were http
     if ":" in uri:
         _, uri = uri.split(":", 1)
-    query_string = parse_qs(urlparse(uri, "http").query)
+    query_string_initial = parse_qs(urlparse(uri, "http").query)
+    # Strip 'amp;' prefix from keys if required
+    #   See https://github.com/SoCo/SoCo/issues/810
+    query_string = {k.replace("amp;", ""): v for k, v in query_string_initial.items()}
     # Is there an account serial number?
     if query_string.get("sn"):
         account_serial_number = query_string["sn"][0]


### PR DESCRIPTION
Introduces a step that cleans up the incorrectly parsed URL due to the breaking change in Python outlined in #810. Also works with earlier versions of Python that don't include the change.