### PR TITLE
Improve handling of network errors

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -383,8 +383,20 @@ class Subscription(SubscriptionBase):
                 of response headers as its only parameter.
 
         """
-        response = requests.request(method, url, headers=headers)
-        response.raise_for_status()
+        response = None
+        try:
+            response = requests.request(method, url, headers=headers, timeout=3)
+        except requests.exceptions.RequestException:
+            # Ignore timeout for unsubscribe since we are leaving anyway.
+            if method != "UNSUBSCRIBE":
+                raise
+
+        # Ignore "412 Client Error: Precondition Failed for url:" from
+        # rebooted speakers. The reboot will have unsubscribed us which is
+        # what we are trying to do.
+        if response and response.status_code != 412:
+            response.raise_for_status()
+
         if success:
             success(response.headers)
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -477,8 +477,12 @@ class Service:
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
         response = requests.post(
-            self.base_url + self.control_url, headers=headers, data=body.encode("utf-8")
+            self.base_url + self.control_url,
+            headers=headers,
+            data=body.encode("utf-8"),
+            timeout=20,
         )
+
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
         log.info("Received status %s from %s", status, self.soco.ip_address)
@@ -684,7 +688,7 @@ class Service:
         ns = "{urn:schemas-upnp-org:service-1-0}"
         # get the scpd body as bytes, and feed directly to elementtree
         # which likes to receive bytes
-        scpd_body = requests.get(self.base_url + self.scpd_url).content
+        scpd_body = requests.get(self.base_url + self.scpd_url, timeout=10).content
         tree = XML.fromstring(scpd_body)
         # parse the state variables to get the relevant variable types
         vartypes = {}
@@ -744,7 +748,7 @@ class Service:
 
         # pylint: disable=invalid-name
         ns = "{urn:schemas-upnp-org:service-1-0}"
-        scpd_body = requests.get(self.base_url + self.scpd_url).text
+        scpd_body = requests.get(self.base_url + self.scpd_url, timeout=10).text
         tree = XML.fromstring(scpd_body.encode("utf-8"))
         # parse the state variables to get the relevant variable types
         statevars = tree.findall("{}stateVariable".format(ns))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -243,6 +243,7 @@ def test_send_command(service):
             "http://192.168.1.101:1400/Service/Control",
             headers=mock.ANY,
             data=DUMMY_VALID_ACTION.encode("utf-8"),
+            timeout=20,
         )
         # Now the cache should be primed, so try it again
         fake_post.reset_mock()


### PR DESCRIPTION
Add timeout values so network requests cannot hang indefinitely.

Also ignore a couple of error situations during unsubscribe because no error handling is needed in those situations.

These issues were found by running a network conditioner with pretty bad settings.