### PR TITLE
Suppress false-positive Pylint errors with Python 3.9 on macOS 11.0.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -25,5 +25,4 @@ max-line-length=88
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus extisting member attributes cannot be deduced by static analysis
-ignored-modules=pytest
-
+ignored-modules=pytest,socket,struct,select,xml.parsers.expat


### PR DESCRIPTION
Note: false positives not seen on Ubuntu.

Mentioned in Pylint issues:
- https://github.com/PyCQA/pylint/issues/4300
- https://github.com/PyCQA/pylint/issues/4297