### PR TITLE
Prevent binary installs of 'multidict' and 'yarl' (fixes 819)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 requests
 xmltodict
 ifaddr
---no-binary=multidict
---no-binary=yarl
-aiohttp
+aiohttp --no-binary multidict,yarl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 requests
 xmltodict
 ifaddr
+--no-binary=multidict
+--no-binary=yarl
 aiohttp


### PR DESCRIPTION
This change forces a Python-only installation of the `multidict` and `yarl` packages, to prevent installation issues on some platforms on which binary wheels need to be built as part of the installation.