### PR TITLE
Workaround for #819

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 xmltodict
 ifaddr
-aiohttp

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ AUTHOR, EMAIL = re.match(r"(.*) <(.*)>", AUTHOR_EMAIL).groups()
 
 REQUIREMENTS = list(open("requirements.txt"))
 
+# See https://github.com/SoCo/SoCo/issues/819
+EXTRAS_REQUIRE = {"events_asyncio": ["aiohttp"]}
+
 setup(
     name=NAME,
     version=VERSION,
@@ -83,6 +86,7 @@ setup(
     url=WEBSITE,
     packages=PACKAGES,
     install_requires=REQUIREMENTS,
+    extras_require=EXTRAS_REQUIRE,
     tests_require=TEST_REQUIREMENTS,
     long_description=LONG_DESCRIPTION,
     cmdclass={"test": PyTest},

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -59,10 +59,24 @@ Example:
 
 import logging
 import socket
+import sys
 import time
 import asyncio
 
-from aiohttp import ClientSession, web
+try:
+    from aiohttp import ClientSession, web
+except ImportError as error:
+    print(
+        """ImportError: {}:
+    Use of the SoCo events_asyncio module requires the 'aiohttp'
+    package and its dependencies to be installed. aiohttp is not
+    installed with SoCo by default due to potential issues installing
+    the dependencies 'mutlidict' and 'yarl' on some platforms.
+    See: https://github.com/SoCo/SoCo/issues/819""".format(
+            error
+        )
+    )
+    sys.exit(1)
 
 # Event is imported for compatibility with events.py
 # pylint: disable=unused-import


### PR DESCRIPTION
This PR removes the hard dependency on the `aiohttp` package, and introduces a descriptive error message if `events_asyncio` is imported but its `aiohttp` requirements are not satisfied.

The `aiohttp` package can be installed independently if required, or with SoCo by using:
`pip install "soco[events_asyncio]"`.