### PR TITLE
Raise exceptions on aiohttp status in async event handler

### DIFF
--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -206,7 +206,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
             if not port:
                 return
             self.address = (ip_address, port)
-            self.session = ClientSession()
+            self.session = ClientSession(raise_for_status=True)
             self.is_running = True
             log.debug("Event Listener started")
 


### PR DESCRIPTION
The current async events module does not actually raise `aiohttp` exceptions inside of `try:` blocks as the `raise_for_status` argument was missing. This can lead to problems such as failed subscription renewals being silently ignored.