### PR TITLE
WIP: Add soundbar_audio_input_format

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1072,6 +1072,42 @@ class SoCo(_SocoSingletonBase):
             ]
         )
 
+    def soundbar_audio_input_format(self) -> Optional[str]:
+        """Return string presentation of the audio input format.
+
+        Returns None when the device is not a soundbar.
+        While the variable is available on non-soundbar devices,
+        it is likely always 0 as as there is no audio inputs.
+
+        TODO: move to a separate PR?
+        """
+        if self.is_soundbar:
+            return None
+
+        value_map = {
+            0: "No input connected",
+            2: "Stereo",
+            7: "Dolby 2.0",
+            18: "Dolby 5.1",
+            21: "No input",
+            22: "No audio",
+            # TODO: I didn't receive the above values (besides 0, 21 and 22),
+            # but the following instead based on some testing.
+            33554434: "PCM 2.0",
+            33554454: "PCM 2.0 no audio",
+            33554488: "Dolby 2.0",
+            84934713: "Dolby 5.1",
+        }
+
+        response = self.deviceProperties.GetZoneInfo()
+        format = int(response["HTAudioIn"])
+        if format not in value_map:
+            logging.warning("Unknown audio input format: %s", format)
+
+        format_str = value_map.get(format, f"Unknown format: {format}")
+
+        return format_str
+
     @property
     def supports_fixed_volume(self):
         """bool: Whether the device supports fixed volume output."""


### PR DESCRIPTION
This is extracted from #780 to avoid overloading that PR with multiple different features.

This new property returns a string representation of the currently active audio input format, i.e., the type of signal received in the HDMI/toslink input.

I'm not completely happy about this:

* The mapping is very incomplete, but contains log output to simplify extending it in the future.
* Some values found in the internet (https://en.community.sonos.com/advanced-setups-229000/getzoneinfo-htaudioin-codes-6750870) do not match to the ones I'm seeing on my system.
* Maybe this should be an enum instead of a string?