### PR TITLE
Cleanup async_events renewal logging and exceptions

### DIFF
--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -417,7 +417,9 @@ class Subscription(SubscriptionBase):
             return await super().renew(requested_timeout, is_autorenew)
         except Exception as exc:  # pylint: disable=broad-except
             self._cancel_subscription(exc)
-            if self.auto_renew_fail is not None and hasattr(self.auto_renew_fail, "__call__"):
+            if self.auto_renew_fail is not None and hasattr(
+                self.auto_renew_fail, "__call__"
+            ):
                 # pylint: disable=not-callable
                 self.auto_renew_fail(exc)
             else:

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -416,22 +416,14 @@ class Subscription(SubscriptionBase):
         try:
             return await super().renew(requested_timeout, is_autorenew)
         except Exception as exc:  # pylint: disable=broad-except
-            msg = (
-                "An Exception occurred. Subscription to"
-                + " {}, sid: {} has been cancelled".format(
-                    self.service.base_url + self.service.event_subscription_url,
-                    self.sid,
-                )
-            )
-            log.exception(msg)
-            self._cancel_subscription(msg)
-            if self.auto_renew_fail is not None:
-                if hasattr(self.auto_renew_fail, "__call__"):
-                    # pylint: disable=not-callable
-                    self.auto_renew_fail(exc)
+            self._cancel_subscription(exc)
+            if self.auto_renew_fail is not None and hasattr(self.auto_renew_fail, "__call__"):
+                # pylint: disable=not-callable
+                self.auto_renew_fail(exc)
+            else:
+                self._log_exception(exc)
             if strict:
                 raise
-            self._log_exception(exc)
             return self
 
     async def unsubscribe(
@@ -470,7 +462,7 @@ class Subscription(SubscriptionBase):
         )
 
     def _auto_renew_run(self, interval):
-        asyncio.ensure_future(self.renew(is_autorenew=True))
+        asyncio.ensure_future(self.renew(is_autorenew=True, strict=False))
         self._auto_renew_start(interval)
 
     def _auto_renew_cancel(self):


### PR DESCRIPTION
The logging and exception handling was a bit noisy and redundant in the new async event handler.

This change will not make subscription auto-renew calls `strict`. This matches the behavior in `events_twisted.py`: https://github.com/SoCo/SoCo/blob/bb71285d5d9255a2eca942b357f292d613891f93/soco/events_twisted.py#L325-L329)

If a call to the `auto_renew_fail` callback is made, we will no longer log an exception traceback from `SoCo` as it's assumed the caller now has that information.