### PR TITLE
Adjust log levels

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -110,7 +110,7 @@ class EventNotifyHandler(BaseHTTPRequestHandler, EventNotifyHandlerBase):
 
     # pylint: disable=no-self-use, missing-docstring
     def log_event(self, seq, service_id, timestamp):
-        log.info(
+        log.debug(
             "Event %s received for %s service on thread %s at %s",
             seq,
             service_id,
@@ -145,7 +145,7 @@ class EventServerThread(threading.Thread):
         Handling of requests is delegated to an instance of the
         `EventNotifyHandler` class.
         """
-        log.info("Event listener running on %s", self.server.server_address)
+        log.debug("Event listener running on %s", self.server.server_address)
         # Listen for events until told to stop
         while not self.stop_flag.is_set():
             self.server.handle_request()

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -152,7 +152,7 @@ class EventNotifyHandler(EventNotifyHandlerBase):
 
     # pylint: disable=no-self-use, missing-docstring
     def log_event(self, seq, service_id, timestamp):
-        log.info("Event %s received for %s service at %s", seq, service_id, timestamp)
+        log.debug("Event %s received for %s service at %s", seq, service_id, timestamp)
 
 
 class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-attributes
@@ -238,7 +238,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
         ):
             try:
                 if port_number > self.requested_port_number:
-                    log.warning("Trying next port (%d)", port_number)
+                    log.debug("Trying next port (%d)", port_number)
                 # pylint: disable=no-member
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.bind((ip_address, port_number))
@@ -267,7 +267,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
         await self.runner.setup()
         self.site = web.SockSite(self.runner, self.sock)
         await self.site.start()
-        log.info("Event listener running on %s", (self.ip_address, self.port))
+        log.debug("Event listener running on %s", (self.ip_address, self.port))
 
     async def async_stop(self):
         """Stop the listener."""

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -102,7 +102,7 @@ def parse_event_xml(xml_event):
                         try:
                             value = from_didl_string(value)[0]
                         except SoCoException as original_exception:
-                            log.warning(
+                            log.debug(
                                 "Event contains illegal metadata"
                                 "for '%s'.\n"
                                 "Error message: '%s'\n"
@@ -302,7 +302,7 @@ class EventListenerBase:
             return
         self.is_running = False
         self.stop_listening(self.address)
-        log.info("Event Listener stopped")
+        log.debug("Event Listener stopped")
 
     # pylint: disable=missing-docstring
     def listen(self, ip_address):
@@ -443,7 +443,7 @@ class SubscriptionBase:
                 self.timeout = int(timeout.lstrip("Second-"))
             self._timestamp = time.time()
             self.is_subscribed = True
-            log.info(
+            log.debug(
                 "Subscribed to %s, sid: %s",
                 service.base_url + service.event_subscription_url,
                 self.sid,
@@ -492,7 +492,7 @@ class SubscriptionBase:
             log_msg = "Autorenewing subscription %s"
         else:
             log_msg = "Renewing subscription %s"
-        log.info(log_msg, self.sid)
+        log.debug(log_msg, self.sid)
 
         if self._has_been_unsubscribed:
             raise SoCoException("Cannot renew subscription once unsubscribed")
@@ -523,7 +523,7 @@ class SubscriptionBase:
                 self.timeout = int(timeout.lstrip("Second-"))
             self._timestamp = time.time()
             self.is_subscribed = True
-            log.info(
+            log.debug(
                 "Renewed subscription to %s, sid: %s",
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
@@ -561,7 +561,7 @@ class SubscriptionBase:
 
         # pylint: disable=missing-docstring, unused-argument
         def success(*arg):
-            log.info(
+            log.debug(
                 "Unsubscribed from %s, sid: %s",
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
@@ -598,7 +598,7 @@ class SubscriptionBase:
                 self.events.put(event)
             # pylint: disable=broad-except
             except Exception as ex:
-                log.debug("Error putting event %s, ex=%s", event, ex)
+                log.warning("Error putting event %s, ex=%s", event, ex)
 
     # pylint: disable=missing-docstring
     def _auto_renew_start(self, interval):

--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -128,7 +128,7 @@ class EventNotifyHandler(Resource, EventNotifyHandlerBase):
 
     # pylint: disable=no-self-use, missing-docstring
     def log_event(self, seq, service_id, timestamp):
-        log.info("Event %s received for %s service at %s", seq, service_id, timestamp)
+        log.debug("Event %s received for %s service at %s", seq, service_id, timestamp)
 
 
 class EventListener(EventListenerBase):
@@ -173,7 +173,7 @@ class EventListener(EventListenerBase):
         ):
             try:
                 if port_number > self.requested_port_number:
-                    log.warning("Trying next port (%d)", port_number)
+                    log.debug("Trying next port (%d)", port_number)
                 # pylint: disable=no-member
                 self.port = reactor.listenTCP(
                     port_number, factory, interface=ip_address
@@ -185,7 +185,7 @@ class EventListener(EventListenerBase):
                 continue
 
         if self.port:
-            log.info("Event listener running on %s", (ip_address, self.port.port))
+            log.debug("Event listener running on %s", (ip_address, self.port.port))
             return self.port.port
         else:
             return None

--- a/soco/services.py
+++ b/soco/services.py
@@ -473,7 +473,7 @@ class Service:
             return result
         # Cache miss, so go ahead and make a network call
         headers, body = self.build_command(action, args)
-        log.info("Sending %s %s to %s", action, args, self.soco.ip_address)
+        log.debug("Sending %s %s to %s", action, args, self.soco.ip_address)
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
         response = requests.post(
@@ -485,7 +485,7 @@ class Service:
 
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
-        log.info("Received status %s from %s", status, self.soco.ip_address)
+        log.debug("Received status %s from %s", status, self.soco.ip_address)
         if status == 200:
             # The response is good. Get the output params, and return them.
             # NB an empty dict is a valid result. It just means that no


### PR DESCRIPTION
This downgrades some logging statements so SoCo does not log above the DEBUG level in normal use.

A single log level has been increased since it could be a real problem (client code raising an exception while handling an event).

Some related discussion in #792.