### PR TITLE
Add get_current_media_info() method to the SoCo class

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -156,6 +156,7 @@ class SoCo(_SocoSingletonBase):
         ramp_to_volume
         set_relative_volume
         get_current_track_info
+        get_current_media_info
         get_speaker_info
         get_current_transport_info
 
@@ -1620,6 +1621,31 @@ class SoCo(_SocoSingletonBase):
                 )
 
         return track
+
+    def get_current_media_info(self):
+        """Get information about the currently playing media.
+
+        Returns:
+            dict: A dictionary containing information about the currently
+            playing media: uri, channel.
+
+        If we're unable to return data for a field, we'll return an empty
+        string.
+        """
+        response = self.avTransport.GetMediaInfo([("InstanceID", 0)])
+        media = {"uri": "", "channel": ""}
+
+        media["uri"] = response["CurrentURI"]
+
+        metadata = response.get("CurrentURIMetaData")
+        if metadata:
+            metadata = XML.fromstring(really_utf8(metadata))
+            md_title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")
+
+            if md_title:
+                media["channel"] = md_title
+
+        return media
 
     def get_speaker_info(self, refresh=False, timeout=None):
         """Get information about the Sonos speaker.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -319,7 +319,7 @@ class TestGetCurrentTrackInfo:
     )
 
     def test_get(self, soco):
-        """Test is the return value is a dictinary and contains the following
+        """Test that the return value is a dictionary and contains the following
         keys: album, artist, title, uri, playlist_position, duration,
         album_art and position.
         """
@@ -339,7 +339,7 @@ class TestGetCurrentMediaInfo:
     )
 
     def test_get(self, soco):
-        """Test that the return value is a dictinary and contains the expected
+        """Test that the return value is a dictionary and contains the expected
         keys.
         """
         info = soco.get_current_media_info()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -328,6 +328,25 @@ class TestGetCurrentTrackInfo:
         assert sorted(info.keys()) == self.info_keys
 
 
+class TestGetCurrentMediaInfo:
+    """Integration test for the get_current_media_info method."""
+
+    info_keys = sorted(
+        [
+            "uri",
+            "channel",
+        ]
+    )
+
+    def test_get(self, soco):
+        """Test that the return value is a dictinary and contains the expected
+        keys.
+        """
+        info = soco.get_current_media_info()
+        assert isinstance(info, dict)
+        assert sorted(info.keys()) == self.info_keys
+
+
 class TestGetSpeakerInfo:
     """Integration test for the get_speaker_info method."""
 


### PR DESCRIPTION
This adds a `get_current_media_info()` method which is very similar to `get_current_track_info()`, but for the `GetMediaInfo` service.

We are using this in Home Assistant to get the channel name when playing radio. The `uri` is useful for finding out whether a favorite is playing since it matches those, unlike `get_current_track_info()['uri']`.

![Screenshot](https://user-images.githubusercontent.com/26174915/119271560-5eb7ea80-bc02-11eb-814a-8ec26cc2ceef.png)

No other information from `GetMediaInfo` seemed interesting, here is an example of the full data:
```
{'CurrentURI': 'x-sonosapi-stream:s216726?sid=254&flags=8224&sn=0',
 'CurrentURIMetaData': '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" '
                       'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" '
                       'xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" '
                       'xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item '
                       'id="-1" parentID="-1" '
                       'restricted="true"><dc:title>myROCK</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc '
                       'id="cdudn" '
                       'nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>',
 'MediaDuration': 'NOT_IMPLEMENTED',
 'NextURI': '',
 'NextURIMetaData': '',
 'NrTracks': '2',
 'PlayMedium': 'NETWORK',
 'RecordMedium': 'NOT_IMPLEMENTED',
 'WriteStatus': 'NOT_IMPLEMENTED'}
```
