### PR TITLE
Add plugin for playback of Spotify & Tidal ShareLinks

### DIFF
--- a/doc/api/soco.plugins.rst
+++ b/doc/api/soco.plugins.rst
@@ -9,6 +9,7 @@ Submodules
    soco.plugins.example
    soco.plugins.spotify
    soco.plugins.wimp
+   soco.plugins.sharelink
 
 Module contents
 ---------------

--- a/doc/api/soco.plugins.sharelink.rst
+++ b/doc/api/soco.plugins.sharelink.rst
@@ -1,0 +1,6 @@
+soco.plugins.sharelink module
+=============================
+
+.. automodule:: soco.plugins.sharelink
+    :member-order: bysource
+    :members:

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -359,6 +359,7 @@ class DidlResource:
         if remove_nones:
             # delete any elements that have a value of None to optimize size
             # of the returned structure
+            # pylint: disable=C0206
             nones = [k for k in content if content[k] is None]
             for k in nones:
                 del content[k]

--- a/soco/events.py
+++ b/soco/events.py
@@ -219,6 +219,7 @@ class EventListener(EventListenerBase):
         self._listener_thread.stop()
         # Send a dummy request in case the http server is currently listening
         try:
+            # pylint: disable=R1732
             urlopen("http://{}:{}/".format(address[0], address[1]))
         except URLError:
             # If the server is already shut down, we receive a socket error,

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -18,7 +18,7 @@ class ShareClass:
         """Recognize a share link and return its canonical representation.
 
         Args:
-            uri (str): A URI like `https://tidal.com/browse/album/157273956`.
+            uri (str): A URI like "https://tidal.com/browse/album/157273956".
 
         Returns:
             str: The canonical URI or None if not recognized.
@@ -145,11 +145,11 @@ class ShareLinkPlugin(SoCoPlugin):
         files.
 
         Args:
-            uri (str): A URI like `spotify:album:6wiUBliPe76YAVpNEdidpY`.
+            uri (str): A URI like "spotify:album:6wiUBliPe76YAVpNEdidpY".
             position (int): The index (1-based) at which the URI should be
                 added. Default is 0 (add URI at the end of the queue).
             as_next (bool): Whether this URI should be played as the next
-                track in shuffle mode. This only works if `play_mode=SHUFFLE`.
+                track in shuffle mode. This only works if "play_mode=SHUFFLE".
 
         Returns:
             int: The index of the new item in the queue.

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -1,0 +1,194 @@
+"""ShareLink Plugin."""
+
+import re
+
+from ..plugins import SoCoPlugin
+from ..music_services import MusicService
+from ..exceptions import SoCoException
+
+
+class ShareClass:
+    """Base class for supported services."""
+
+    def __init__(self, soco):
+        """Initialize the share object."""
+        self.soco = soco
+
+    def canonical_uri(self, uri):
+        """Recognize a share link and return its canonical representation.
+
+        Args:
+            uri (str): A URI like `https://tidal.com/browse/album/157273956`.
+
+        Returns:
+            str: The canonical URI or None if not recognized.
+        """
+        raise NotImplementedError
+
+    def service_name(self):
+        """Return the service name.
+
+        Returns:
+            int: A name identifying the supported music service.
+        """
+        raise NotImplementedError
+
+    def service_number(self):
+        """Return the service number.
+
+        Returns:
+            int: An ID matching the service_name().
+        """
+        service = MusicService.get_data_for_name(self.service_name())
+        return service["ServiceType"]
+
+    @staticmethod
+    def magic():
+        """Return magic.
+
+        Returns:
+            dict: Magic prefix/key/class values for each share type.
+        """
+        return {
+            "album": {
+                "prefix": "x-rincon-cpcontainer:1004206c",
+                "key": "00040000",
+                "class": "object.container.album.musicAlbum",
+            },
+            "track": {
+                "prefix": "",
+                "key": "00032020",
+                "class": "object.item.audioItem.musicTrack",
+            },
+            "playlist": {
+                "prefix": "x-rincon-cpcontainer:1006206c",
+                "key": "1006206c",
+                "class": "object.container.playlistContainer",
+            },
+        }
+
+    def extract(self, uri):
+        """Extract the share type and encoded URI from a share link.
+
+        Returns:
+            share_type: The shared type, like "album" or "track".
+            encoded_uri: An escaped URI with a service-specific format.
+        """
+        raise NotImplementedError
+
+
+class SpotifyShare(ShareClass):
+    """Spotify share class."""
+
+    def canonical_uri(self, uri):
+        match = re.search(r"spotify.*[:/](album|track|playlist)[:/](\w+)", uri)
+        if match:
+            return "spotify:" + match.group(1) + ":" + match.group(2)
+
+        return None
+
+    def service_name(self):
+        return "Spotify"
+
+    def extract(self, uri):
+        spotify_uri = self.canonical_uri(uri)
+        share_type = spotify_uri.split(":")[1]
+        encoded_uri = spotify_uri.replace(":", "%3a")
+        return (share_type, encoded_uri)
+
+
+class TIDALShare(ShareClass):
+    """TIDAL share class."""
+
+    def canonical_uri(self, uri):
+        match = re.search(r"https://tidal.*[:/](album|track|playlist)[:/]([\w-]+)", uri)
+        if match:
+            return "tidal:" + match.group(1) + ":" + match.group(2)
+
+        return None
+
+    def service_name(self):
+        return "TIDAL"
+
+    def extract(self, uri):
+        tidal_uri = self.canonical_uri(uri)
+        share_type = tidal_uri.split(":")[1]
+        encoded_uri = tidal_uri.replace("tidal:", "").replace(":", "%2f")
+        return (share_type, encoded_uri)
+
+
+class ShareLinkPlugin(SoCoPlugin):
+    """A SoCo plugin for playing Spotify/Tidal share links."""
+
+    def __init__(self, soco):
+        """Initialize the plugin."""
+        super().__init__(soco)
+        self.services = [SpotifyShare(soco), TIDALShare(soco)]
+
+    @property
+    def name(self):
+        return "ShareLink Plugin"
+
+    def is_share_link(self, uri):
+        """bool: Is the URI for a supported music service."""
+        for service in self.services:
+            if service.canonical_uri(uri):
+                return True
+
+        return False
+
+    def add_share_link_to_queue(self, uri, position=0, as_next=False):
+        """Add a Spotify/Tidal/... item to the queue.
+
+        This is similar to soco.add_uri_to_queue() but will work with
+        music service share links that do not directly point to sound
+        files.
+
+        Args:
+            uri (str): A URI like `spotify:album:6wiUBliPe76YAVpNEdidpY`.
+            position (int): The index (1-based) at which the URI should be
+                added. Default is 0 (add URI at the end of the queue).
+            as_next (bool): Whether this URI should be played as the next
+                track in shuffle mode. This only works if `play_mode=SHUFFLE`.
+
+        Returns:
+            int: The index of the new item in the queue.
+        """
+        for service in self.services:
+            if service.canonical_uri(uri):
+                (share_type, encoded_uri) = service.extract(uri)
+                magic = service.magic()
+
+                enqueue_uri = magic[share_type]["prefix"] + encoded_uri
+
+                metadata_template = (
+                    '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'
+                    '/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata'
+                    '-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-'
+                    'com:metadata-1-0/" xmlns="urn:schemas-upnp-org:m'
+                    'etadata-1-0/DIDL-Lite/"><item id="{item_id}" res'
+                    'tricted="true"><upnp:class>{item_class}</upnp:cl'
+                    'ass><desc id="cdudn" nameSpace="urn:schemas-rinc'
+                    'onnetworks-com:metadata-1-0/">SA_RINCON{sn}_X_#S'
+                    "vc{sn}-0-Token</desc></item></DIDL-Lite>"
+                )
+
+                metadata = metadata_template.format(
+                    item_id=magic[share_type]["key"] + encoded_uri,
+                    item_class=magic[share_type]["class"],
+                    sn=service.service_number(),
+                )
+
+                response = self.soco.avTransport.AddURIToQueue(
+                    [
+                        ("InstanceID", 0),
+                        ("EnqueuedURI", enqueue_uri),
+                        ("EnqueuedURIMetaData", metadata),
+                        ("DesiredFirstTrackNumberEnqueued", position),
+                        ("EnqueueAsNext", int(as_next)),
+                    ]
+                )
+                qnumber = response["FirstTrackNumberEnqueued"]
+                return int(qnumber)
+
+        raise SoCoException("Unsupported URI: " + uri)


### PR DESCRIPTION
This is a different take on supporting music services. It is a bit rough so I placed it in a plugin.

The plugin allows playing from the "share links" that some music services provide. No authentication step is needed but the matching music service must be installed on Sonos. 

Supported link formats:
* `https://open.spotify.com/track/6cpcorzV5cmVjBsuAXq4wD`
* `spotify:album:6wiUBliPe76YAVpNEdidpY`
* `https://tidal.com/browse/album/157273956`

The constructed message data was found with Wireshark while pressing play in the native app. I have no idea what it means but it does work :). Adding other services is probably straightforward but it requires an active account in order to do the network dump.

There is a US and a non-US Spotify service so the service ID is looked up dynamically. I have only been able to test this version of the code on non-US Spotify; if someone can test with US Spotify and TIDAL, that would be great.

```python
>>> from soco import SoCo
>>> from soco.plugins.sharelink import ShareLinkPlugin
>>> speaker=SoCo("10.0.2.13")
>>> sharelink=ShareLinkPlugin(speaker)
>>> sharelink.add_share_link_to_queue("https://open.spotify.com/album/14IYDXybb1XKu51QHDryak")
1
```
