### PR TITLE
Fix unsubscription logic

### DIFF
--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -546,12 +546,12 @@ class SubscriptionBase:
         if self._has_been_unsubscribed or not self.is_subscribed:
             return None
 
-        self._cancel_subscription()
-
         # If the subscription has timed out, an attempt to
         # unsubscribe from it will fail silently.
         if self.time_left == 0:
             return None
+
+        self._cancel_subscription()
 
         # Send an unsubscribe request like this:
         # UNSUBSCRIBE publisher path HTTP/1.1


### PR DESCRIPTION
I noticed that unsubscription messages are _never_ sent to speakers because of the ordering of guards in `soco.events_base.unsubscription`.

Once `_cancel_subscription()` is called, the `_timestamp` attribute is set to `None`. This in turns causes the `time_left` property to always return 0. This aborts the unsubscription call early and the outgoing request is never fired.