### PR TITLE
Fix event unsubscription logic v2

### DIFF
--- a/soco/events.py
+++ b/soco/events.py
@@ -370,7 +370,7 @@ class Subscription(SubscriptionBase):
         self._auto_renew_thread_flag.set()
 
     # pylint: disable=no-self-use, too-many-arguments
-    def _request(self, method, url, headers, success):
+    def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 
         Args:
@@ -381,6 +381,9 @@ class Subscription(SubscriptionBase):
             success (function): A function to be called if the
                 request succeeds. The function will be called with a dict
                 of response headers as its only parameter.
+            unconditional (function): An optional function to be called after
+                the request is complete, regardless of its success. Takes
+                no parameters.
 
         """
         response = None
@@ -399,6 +402,8 @@ class Subscription(SubscriptionBase):
 
         if success:
             success(response.headers)
+        if unconditional:
+            unconditional()
 
     # pylint: disable=inconsistent-return-statements
     def _wrap(self, method, strict, *args, **kwargs):

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -474,7 +474,7 @@ class Subscription(SubscriptionBase):
             self._auto_renew_task = None
 
     # pylint: disable=no-self-use, too-many-branches, too-many-arguments
-    def _request(self, method, url, headers, success):
+    def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 
         Args:
@@ -485,6 +485,9 @@ class Subscription(SubscriptionBase):
             success (function): A function to be called if the
                 request succeeds. The function will be called with a dict
                 of response headers as its only parameter.
+            unconditional (function): An optional function to be called after
+                the request is complete, regardless of its success. Takes
+                no parameters.
 
         """
 
@@ -494,6 +497,8 @@ class Subscription(SubscriptionBase):
             )
             if response.ok:
                 success(response.headers)
+            if unconditional:
+                unconditional()
 
         return _async_make_request()
 

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -546,8 +546,6 @@ class SubscriptionBase:
         if self._has_been_unsubscribed or not self.is_subscribed:
             return None
 
-        self._cancel_subscription()
-
         # If the subscription has timed out, an attempt to
         # unsubscribe from it will fail silently.
         if self.time_left == 0:
@@ -572,6 +570,7 @@ class SubscriptionBase:
             self.service.base_url + self.service.event_subscription_url,
             headers,
             success,
+            self._cancel_subscription,
         )
 
     def send_event(self, event):
@@ -621,7 +620,7 @@ class SubscriptionBase:
         raise NotImplementedError
 
     # pylint: disable=missing-docstring, too-many-arguments
-    def _request(self, method, url, headers, success):
+    def _request(self, method, url, headers, success, unconditional=None):
         """Send a HTTP request
 
         Args:
@@ -632,6 +631,9 @@ class SubscriptionBase:
             success (function): A function to be called if the
                 request succeeds. The function will be called with a dict
                 of response headers as its only parameter.
+            unconditional (function): An optional function to be called after
+                the request is complete, regardless of its success. Takes
+                no parameters.
 
         Note:
             This method must be overridden in the class that inherits from

--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -337,7 +337,7 @@ class Subscription(SubscriptionBase):
             self._auto_renew_loop = None
 
     # pylint: disable=no-self-use, too-many-branches, too-many-arguments
-    def _request(self, method, url, headers, success):
+    def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 
         Args:
@@ -348,6 +348,9 @@ class Subscription(SubscriptionBase):
             success (function): A function to be called if the
                 request succeeds. The function will be called with a dict
                 of response headers as its only parameter.
+            unconditional (function): An optional function to be called after
+                the request is complete, regardless of its success. Takes
+                no parameters.
 
         """
         agent = BrowserLikeRedirectAgent(Agent(reactor))
@@ -376,6 +379,8 @@ class Subscription(SubscriptionBase):
             return self
 
         d.addCallback(on_success)
+        if unconditional:
+            d.addBoth(unconditional)
         return d
 
     def _wrap(self, method, strict, *args, **kwargs):


### PR DESCRIPTION
The currrent event handlers are not able to send unsubscription requests to speakers because of a logic issue. This can lead to unintentionally leaving subscriptions active.

This change defers the internal unsubscription cleanup steps until after the outbound request is sent. This is achieved by adding an `unconditional` parameter to each implementations' request handler which is called after any request is sent. Only the `unsubscribe` method uses this for now.

This is an updated PR of #841 which adds missing changes in the default event handler.