### PR TITLE
Add pre-commit hooks option; code/docstring tidy-ups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
   - id: black
     language_version: python3
 
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+
 - repo: https://github.com/pycqa/pylint
   rev: v2.9.3
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-yaml
+  - id: check-json
+  - id: debug-statements
+  - id: check-ast
+
+- repo: https://github.com/psf/black
+  rev: 21.6b0
+  hooks:
+  - id: black
+    language_version: python3
+
+- repo: https://github.com/pycqa/pylint
+  rev: v2.9.3
+  hooks:
+  - id: pylint
+    args: [--rcfile, "pylintrc"]
+    exclude: tests|doc|examples|setup.py|dev_tools
+    additional_dependencies: ["requests", "xmltodict", "ifaddr"]

--- a/dev_tools/analyse_ws.py
+++ b/dev_tools/analyse_ws.py
@@ -62,7 +62,7 @@ ENDS = ["</s:Envelope>", "</e:propertyset>"]
 
 
 class AnalyzeWS:
-    """ Class for analysis of WireShark dumps. Also shows the parts of the
+    """Class for analysis of WireShark dumps. Also shows the parts of the
     WireShark dumps syntax highlighted in the terminal and/or writes them to
     files and shows them in a browser.
 
@@ -93,7 +93,7 @@ class AnalyzeWS:
         self.pages = {}
 
     def set_file(self, filename):
-        """ Analyse the file with the captured content """
+        """Analyse the file with the captured content"""
         # Use the file name as prefix if none is given
         if self.output_prefix is None:
             _, self.output_prefix = os.path.split(filename)
@@ -134,7 +134,7 @@ class AnalyzeWS:
             sys.exit(0)
 
     def _parse_load(self, load):
-        """ Parse the load from a single packet """
+        """Parse the load from a single packet"""
         # If the load is ??
         if load in ["??"]:
             self._debug("IGNORING")
@@ -166,7 +166,7 @@ class AnalyzeWS:
                 self._debug("NOTHING TO DO")
 
     def _debug(self, message, load=False, no_prefix=False):
-        """ Output debug information """
+        """Output debug information"""
         if self.args.debug_analysis:
             if load:
                 message = "\r\n".join(
@@ -183,12 +183,12 @@ class AnalyzeWS:
                     print(message)
 
     def to_file_mode(self):
-        """ Write all the messages to files """
+        """Write all the messages to files"""
         for message_no in range(len(self.messages)):
             self.__to_file(message_no)
 
     def __to_file(self, message_no):
-        """ Write a single message to file """
+        """Write a single message to file"""
         filename = self.__create_file_name(message_no)
         try:
             with codecs.open(
@@ -206,18 +206,18 @@ class AnalyzeWS:
         return filename
 
     def __create_file_name(self, message_no):
-        """ Create the filename to save to """
+        """Create the filename to save to"""
         cwd = os.getcwd()
         filename = "{}_{}.xml".format(self.output_prefix, message_no)
         return os.path.join(cwd, filename)
 
     def to_browser_mode(self):
-        """ Write all the messages to files and open them in the browser """
+        """Write all the messages to files and open them in the browser"""
         for message_no in range(len(self.messages)):
             self.__to_browser(message_no)
 
     def __to_browser(self, message_no):
-        """ Write a single message to file and open the file in a
+        """Write a single message to file and open the file in a
         browser
 
         """
@@ -240,7 +240,7 @@ class AnalyzeWS:
             sys.exit(21)
 
     def interactive_mode(self):
-        """ Interactive mode """
+        """Interactive mode"""
         if PLATFORM == "win32":
             # Defaulting to 80 on windows, better ideas are welcome, but the
             # solutions I found online are rather bulky
@@ -275,7 +275,7 @@ class AnalyzeWS:
                 self.__to_file(message_no)
 
     def __update_window(self, width, height, message_no, page_no):
-        """ Update the window with the menu and the new text """
+        """Update the window with the menu and the new text"""
         file_exists_label = "-F-ILE"
         if not os.path.exists(self.__create_file_name(message_no)):
             file_exists_label = "(f)ile"
@@ -319,7 +319,7 @@ class AnalyzeWS:
         return page_no
 
     def _form_pages(self, message_no, content, out, height, width):
-        """ Form the pages """
+        """Form the pages"""
         self.pages[message_no] = []
         page_height = height - 4  # 2-3 for menu, 1 for cursor
         outline = ""
@@ -363,7 +363,7 @@ class AnalyzeWS:
 
 
 class WSPart:
-    """ This class parses and represents a single Sonos UPnP message """
+    """This class parses and represents a single Sonos UPnP message"""
 
     def __init__(self, captured, args):
         self.external_inner_xml = args.external_inner_xml
@@ -385,18 +385,18 @@ class WSPart:
             self.encoding = "utf-8"
 
     def add_content(self, captured):
-        """ Adds content to the main UPnP message """
+        """Adds content to the main UPnP message"""
         self.raw_body += captured
 
     def finalize_content(self):
-        """ Finalize the additons """
+        """Finalize the additons"""
         self.write_closed = True
         body = self.raw_body.decode(self.encoding)
         self._init_xml(body)
         self._form_output()
 
     def _init_xml(self, body):
-        """ Parse the present body as xml """
+        """Parse the present body as xml"""
         tree = etree.fromstring(body.encode(self.encoding), PARSER)
         # Extract and replace inner DIDL xml in tags
         for text in tree.xpath('.//text()[contains(., "DIDL")]'):
@@ -427,7 +427,7 @@ class WSPart:
         # sys.exit(1)
 
     def _form_output(self):
-        """ Form the output """
+        """Form the output"""
         self.output = ""
         if self.external_inner_xml:
             self.output += "<Dummy_tag_to_create_valid_xml_on_external_inner" "_xml>\n"
@@ -442,7 +442,7 @@ class WSPart:
 
 
 def __build_option_parser():
-    """ Build the option parser for this script """
+    """Build the option parser for this script"""
     description = """
     Tool to analyze Wireshark dumps of Sonos traffic.
 
@@ -534,7 +534,7 @@ def __build_option_parser():
 
 
 def getch():
-    """ Read a single character non-echoed and return it. Recipe from:
+    """Read a single character non-echoed and return it. Recipe from:
     http://code.activestate.com/recipes/
     134892-getch-like-unbuffered-character-reading-from-stdin/
     """
@@ -552,7 +552,7 @@ def getch():
 
 
 def main():
-    """ Main method of the script """
+    """Main method of the script"""
     parser = __build_option_parser()
     args = parser.parse_args()
     analyze_ws = AnalyzeWS(args)

--- a/dev_tools/sonosdump.py
+++ b/dev_tools/sonosdump.py
@@ -11,22 +11,23 @@ import soco.services
 
 
 def main():
-    """ Run the main script """
+    """Run the main script"""
     parser = argparse.ArgumentParser(
-        prog='',
-        description='Dump data about Sonos services'
+        prog="", description="Dump data about Sonos services"
     )
     parser.add_argument(
-        '-d', '--device',
+        "-d",
+        "--device",
         default=None,
         help="The ip address of the device to query. "
-             "If none is supplied, a random device will be used"
+        "If none is supplied, a random device will be used",
     )
     parser.add_argument(
-        '-s', '--service',
+        "-s",
+        "--service",
         default=None,
         help="Dump data relating to services matching this regexp "
-             "only, e.g. %(prog)s -s GroupRenderingControl"
+        "only, e.g. %(prog)s -s GroupRenderingControl",
     )
 
     args = parser.parse_args()
@@ -42,14 +43,12 @@ def main():
     services = (srv(device) for srv in soco.services.Service.__subclasses__())
 
     for srv in services:
-        if args.service is None or re.search(
-                args.service, srv.service_type):
+        if args.service is None or re.search(args.service, srv.service_type):
             print_details(srv)
 
 
 def print_details(srv):
-    """ Print the details of a service
-    """
+    """Print the details of a service"""
     name = srv.service_type
     box = "=" * 79
     print("{0}\n|{1:^77}|\n{0}\n".format(box, name))
@@ -66,5 +65,5 @@ def print_details(srv):
         print("\n\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys
 import os
 import shlex
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 import soco
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -27,39 +27,39 @@ import soco
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.3'
+needs_sphinx = "1.3"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'SoCo'
-copyright = '2015-2021, The SoCo Team'
+project = "SoCo"
+copyright = "2015-2021, The SoCo Team"
 author = "`The SoCo Team"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -76,7 +76,7 @@ release = soco.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -86,11 +86,11 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = 'any'
+default_role = "any"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True
@@ -104,10 +104,10 @@ default_role = 'any'
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-modindex_common_prefix = ['soco.', 'soco.music_services.']
+modindex_common_prefix = ["soco.", "soco.music_services."]
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
 keep_warnings = True
@@ -117,40 +117,44 @@ todo_include_todos = True
 
 # Allow auto links into the Python and Requests docs
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'requests': ('https://requests.readthedocs.io/en/master/', None)
+    "python": ("https://docs.python.org/3", None),
+    "requests": ("https://requests.readthedocs.io/en/master/", None),
 }
 
 # Shortcuts to Github Issues etc. Use them like this:
 # :issue:`123` (which will generate a link to issue 123)
 extlinks = {
-    'issue': ('https://github.com/SoCo/SoCo/issues/%s', '#'),
-    'PR': ('https://github.com/SoCo/SoCo/pull/%s', '#')
+    "issue": ("https://github.com/SoCo/SoCo/issues/%s", "#"),
+    "PR": ("https://github.com/SoCo/SoCo/pull/%s", "#"),
 }
 
 # Document members by default, and in source order. This allows the stub files
 # in the api directory to be much shorter.
-autodoc_default_flags = ['members']
-autodoc_member_order = 'bysource'
+autodoc_default_flags = ["members"]
+autodoc_member_order = "bysource"
 
 # Concatenate the class and __init__ docstrings
-autoclass_content = 'both'
+autoclass_content = "both"
 
 # Nicer inheritance graphs for RTD theme.  NB the image map does not rescale
 # properly, so we have had to add some javascript to handle it.  See
 # _templates and _static
 inheritance_node_attrs = dict(
-    fontsize=14, height=0.75, color='dodgerblue', style='rounded',
+    fontsize=14,
+    height=0.75,
+    color="dodgerblue",
+    style="rounded",
 )
 inheritance_graph_attrs = dict(
-    rankdir="LR", size='""',
+    rankdir="LR",
+    size='""',
 )
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -179,7 +183,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -242,20 +246,17 @@ html_static_path = ['_static']
 # html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'socodoc'
+htmlhelp_basename = "socodoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -264,8 +265,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'soco.tex', 'soco Documentation',
-     'Author', 'manual'),
+    (master_doc, "soco.tex", "soco Documentation", "Author", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -293,10 +293,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'soco', 'soco Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "soco", "soco Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -308,9 +305,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'soco', 'soco Documentation',
-     author, 'soco', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "soco",
+        "soco Documentation",
+        author,
+        "soco",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -372,7 +375,7 @@ epub_copyright = copyright
 # epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
 # epub_tocdepth = 3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,10 +14,9 @@
 
 import sys
 import os
-import shlex
 
 sys.path.insert(0, os.path.abspath(".."))
-import soco
+import soco  # noqa: E402
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/play_local_files/play_local_files.py
+++ b/examples/play_local_files/play_local_files.py
@@ -17,7 +17,6 @@ supply the zone name. The local machine IP should be autodetected.
 """
 
 
-
 import os
 import sys
 import time

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 lint: soco
 	flake8 soco
-	flake8 --ignore=F401,F841 tests
+	flake8 tests
 	pylint soco
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import io
 import re
 import sys
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,7 @@ import pytest
 import requests_mock
 
 from soco import SoCo
-from soco.data_structures import DidlMusicTrack, to_didl_string
+from soco.data_structures import to_didl_string
 from soco.exceptions import (
     SoCoSlaveException,
     SoCoUPnPException,
@@ -37,7 +37,7 @@ def moco():
     with mock.patch(
         "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
     ) as is_coord:
-        is_coord = True
+        is_coord = True  # noqa: F841
         yield SoCo(IP_ADDR)
     for patch in reversed(patchers):
         patch.stop()
@@ -411,7 +411,7 @@ class TestSoco:
     @pytest.mark.parametrize("bad_ip_addr", ["not_ip", "555.555.555.555"])
     def test_soco_bad_ip(self, bad_ip_addr):
         with pytest.raises(ValueError):
-            speaker = SoCo(bad_ip_addr)
+            _ = SoCo(bad_ip_addr)
 
     def test_soco_init(self, moco):
         assert moco.ip_address == IP_ADDR
@@ -1097,7 +1097,7 @@ class TestAVTransport:
     @pytest.mark.parametrize("bad_sleep_time", ["BadTime", "00:43:23", "4200s", ""])
     def test_set_sleep_timer_bad_sleep_time(self, moco, bad_sleep_time):
         with pytest.raises(ValueError):
-            result = moco.set_sleep_timer(bad_sleep_time)
+            _ = moco.set_sleep_timer(bad_sleep_time)
 
     def test_get_sleep_timer(self, moco):
         moco.avTransport.reset_mock()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,12 +5,11 @@ import ifaddr
 
 from collections import OrderedDict
 
-from unittest.mock import patch, MagicMock as Mock, PropertyMock, call
+from unittest.mock import patch, MagicMock as Mock, call
 
 from soco import discover
 from soco import config
 from soco.discovery import (
-    any_soco,
     by_name,
     _find_ipv4_addresses,
     _find_ipv4_networks,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -76,7 +76,7 @@ def test_event_object():
     assert dummy_event.zone == "kitchen"
     # Should not access non-existent attributes
     with pytest.raises(AttributeError):
-        var = dummy_event.non_existent
+        _ = dummy_event.non_existent
     # Should be read only
     with pytest.raises(TypeError):
         dummy_event.new_var = 4

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -27,7 +27,7 @@ def moco():
     with mock.patch(
         "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
     ) as is_coord:
-        is_coord = True
+        is_coord = True  # noqa: F841
         yield SoCo(IP_ADDR)
     for patch in reversed(patchers):
         patch.stop()

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import pytest
 from unittest.mock import PropertyMock, Mock, patch
 from soco.music_services import data_structures
-from soco.data_structures import DidlResource
 
 # DATA
 RESPONSES = []
@@ -192,7 +191,7 @@ def test_form_uri():
     assert non_track_uri == "x-rincon-cpcontainer:dummy_id"
 
     # Test track uri
-    track_uri = data_structures.form_uri("dummy_id", music_service, True)
+    _ = data_structures.form_uri("dummy_id", music_service, True)
     music_service.sonos_uri_from_id.assert_called_once_with("dummy_id")
 
 

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -9,7 +9,6 @@ from soco.exceptions import MusicServiceException
 from soco.music_services.accounts import Account
 from soco.music_services.music_service import (
     MusicService,
-    MusicServiceSoapClient,
     desc_from_uri,
 )
 
@@ -260,10 +259,10 @@ def test_create_music_service():
     ms = MusicService("Spotify")
     assert ms.account.username == "12345678"
     with pytest.raises(MusicServiceException) as excinfo:
-        unknown = MusicService("Unknown Music Service")
+        _ = MusicService("Unknown Music Service")
     assert "Unknown music service" in str(excinfo.value)
     with pytest.raises(MusicServiceException) as excinfo:
-        soundcloud = MusicService("SoundCloud")
+        _ = MusicService("SoundCloud")
     assert "No account found" in str(excinfo.value)
 
 

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -67,7 +67,7 @@ class TestResource:
 
     def test_create_didl_resource_with_no_params(self):
         with pytest.raises(TypeError):
-            res = data_structures.DidlResource()
+            _ = data_structures.DidlResource()
 
     def test_create_didl_resource(self):
         res = data_structures.DidlResource("a%20uri", "a:protocol:info:xx")
@@ -136,11 +136,11 @@ class TestDidlObject:
 
     def test_create_didl_object_with_no_params(self):
         with pytest.raises(TypeError):
-            didl_object = data_structures.DidlObject()
+            _ = data_structures.DidlObject()
 
     def test_create_didl_object_with_disallowed_params(self):
         with pytest.raises(ValueError) as excinfo:
-            didl_object = data_structures.DidlObject(
+            _ = data_structures.DidlObject(
                 title="a_title", parent_id="pid", item_id="iid", bad_args="other"
             )
         assert "not allowed" in str(excinfo.value)
@@ -165,7 +165,7 @@ class TestDidlObject:
         # Using the wrong element
         elt = XML.fromstring("""<res>URI</res>""")
         with pytest.raises(DIDLMetadataError) as excinfo:
-            didl_object = data_structures.DidlObject.from_element(elt)
+            _ = data_structures.DidlObject.from_element(elt)
         assert "Wrong element. Expected <item> or <container>, "
         "got <res> for class object" in str(excinfo.value)
 
@@ -207,7 +207,7 @@ class TestDidlObject:
         """
         )
         with pytest.raises(DIDLMetadataError) as excinfo:
-            didl_object = data_structures.DidlObject.from_element(bad_elt1)
+            _ = data_structures.DidlObject.from_element(bad_elt1)
         assert ("UPnP class is incorrect. Expected 'object', got 'object.item'") in str(
             excinfo.value
         )

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,8 +1,6 @@
 """Tests for the SoCoSingletonBase and _ArgsSingleton classes in core."""
 
 
-import pytest
-
 from soco.core import _SocoSingletonBase as Base
 
 


### PR DESCRIPTION
pre-commit is the go-to method for making it simple to verify that all linters and other checks are performed before a commit can be done, or when executing `pre-commit run -a` manually. Having it in-place makes it easier to contribute without a need to wait for the CI to inform about styling issues.

This PR adds the same checks (black, pylint, flake8) as running `make` does (hopefully), but also removes the blanket ignores for blake8 and uses `# noqa: <id>` for two cases (import order for docs, unused variable for propertymocks for tests). This PR also includes the changes wanted by the checks that were not caught previously for some reason.

