### PR TITLE
Restore compatibility for Sonos firmware < v10.1

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1210,7 +1210,8 @@ class SoCo(_SocoSingletonBase):
         # and the set of all members
         self._all_zones.clear()
         self._visible_zones.clear()
-        # Compatibilty fix for pre-10.1 firmwares
+        # Compatibility fallback for pre-10.1 firmwares
+        # where a "ZoneGroups" element is not used
         tree = tree.find("ZoneGroups") or tree
         # Loop over each ZoneGroup Element
         for group_element in tree.findall("ZoneGroup"):

--- a/soco/core.py
+++ b/soco/core.py
@@ -1210,8 +1210,10 @@ class SoCo(_SocoSingletonBase):
         # and the set of all members
         self._all_zones.clear()
         self._visible_zones.clear()
+        # Compatibilty fix for pre-10.1 firmwares
+        tree = tree.find("ZoneGroups") or tree
         # Loop over each ZoneGroup Element
-        for group_element in tree.find("ZoneGroups").findall("ZoneGroup"):
+        for group_element in tree.findall("ZoneGroup"):
             coordinator_uid = group_element.attrib["Coordinator"]
             group_uid = group_element.attrib["ID"]
             group_coordinator = None


### PR DESCRIPTION
Adjustment to https://github.com/SoCo/SoCo/pull/662 to preserve pre-10.1 compatibility without breaking current firmware versions.

Integrated in `pysonos` [here](https://github.com/amelchio/pysonos/pull/99) and now in use by the latest Home Assistant release.

Waiting for confirmation from the end-user before marking this ready for review.