### PR TITLE
Refactor alarm handling

### DIFF
--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -95,7 +95,7 @@ class Alarms(_SocoSingletonBase):
 
     def __init__(self) -> None:
         """Initialize the instance."""
-        self.alarms: Dict[int, Alarm] = {}
+        self.alarms: Dict[int, 'Alarm'] = {}
         self._last_zone_used: Optional[SoCo] = None
         self._last_alarm_list_version: Optional[str] = None
         self.last_uid: Optional[str] = None
@@ -191,10 +191,10 @@ class Alarm:
         self,
         zone: SoCo,
         start_time: Optional[datetime.time] = None,
-        duration: datetime.time | None = None,
+        duration: Optional[datetime.time] = None,
         recurrence: str = "DAILY",
         enabled: bool = True,
-        program_uri: str = None,
+        program_uri: Optional[str] = None,
         program_metadata: str = "",
         play_mode: str = "NORMAL",
         volume: int = 20,
@@ -372,7 +372,7 @@ class Alarm:
         return self._alarm_id
 
 
-def get_alarms(zone: Optional[SoCo] = None) -> Set[Alarm]:
+def get_alarms(zone: Optional[SoCo] = None) -> Set['Alarm']:
     """Get a set of all alarms known to the Sonos system.
 
     Args:

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -117,6 +117,10 @@ class Alarms(_SocoSingletonBase):
         for alarm in list(self.alarms.values()):
             yield alarm
 
+    def __len__(self):
+        """Return the number of alarms."""
+        return len(self.alarms)
+
     def __getitem__(self, alarm_id):
         """Return the alarm by ID."""
         return self.alarms[alarm_id]

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -1,19 +1,21 @@
 """This module contains classes relating to Sonos Alarms."""
+from __future__ import annotations
 
 import logging
 import re
-import weakref
 from datetime import datetime
+from typing import Any, Iterable
 
 from . import discovery
-from .core import PLAY_MODES
+from .core import _SocoSingletonBase, PLAY_MODES, SoCo
+from .exceptions import SoCoException
 from .xml import XML
 
-log = logging.getLogger(__name__)  # pylint: disable=C0103
+log = logging.getLogger(__name__)
 TIME_FORMAT = "%H:%M:%S"
 
 
-def is_valid_recurrence(text):
+def is_valid_recurrence(text) -> bool:
     """Check that ``text`` is a valid recurrence string.
 
     A valid recurrence string is  ``DAILY``, ``ONCE``, ``WEEKDAYS``,
@@ -48,54 +50,158 @@ def is_valid_recurrence(text):
     return re.search(r"^ON_[0-6]{1,7}$", text) is not None
 
 
+class Alarms(_SocoSingletonBase):
+    """A class representing all known Sonos Alarms.
+
+    Is a singleton and every `Alarms()` object will return the same instance.
+
+    Example use:
+
+        >>> get_alarms()
+        {469: <Alarm id:469@22:07:41 at 0x7f5198797dc0>,
+         470: <Alarm id:470@22:07:46 at 0x7f5198797d60>}
+        >>> alarms = Alarms()
+        >>> alarms.update()
+        >>> alarms.alarms
+        {469: <Alarm id:469@22:07:41 at 0x7f5198797dc0>,
+         470: <Alarm id:470@22:07:46 at 0x7f5198797d60>}
+        >>> for alarm in alarms:
+        ...     alarm
+        ...
+        <Alarm id:469@22:07:41 at 0x7f5198797dc0>
+        <Alarm id:470@22:07:46 at 0x7f5198797d60>
+        >>> alarms[470]
+        <Alarm id:470@22:07:46 at 0x7f5198797d60>
+        >>> new_alarm = Alarm(zone)
+        >>> new_alarm.save()
+        471
+        >>> new_alarm.recurrence = "ONCE"
+        >>> new_alarm.save()
+        471
+        >>> alarms.alarms
+        {469: <Alarm id:469@22:07:41 at 0x7f5198797dc0>,
+         470: <Alarm id:470@22:07:46 at 0x7f5198797d60>,
+         471: <Alarm id:471@22:08:40 at 0x7f51987f1b50>}
+        >>> alarms[470].remove()
+        >>> alarms.alarms
+        {469: <Alarm id:469@22:07:41 at 0x7f5198797dc0>,
+         471: <Alarm id:471@22:08:40 at 0x7f51987f1b50>}
+        >>> for alarm in alarms:
+        ...     alarm.remove()
+        ...
+        >>> a.alarms
+        {}
+    """
+
+    _class_group = "Alarms"
+
+    def __init__(self) -> None:
+        """Initialize the instance."""
+        self.alarms: dict[int, Alarm] = {}
+        self._last_zone_used: SoCo | None = None
+        self._last_alarm_list_version: str | None = None
+        self.last_uid: str | None = None
+        self.last_id: int = 0
+
+    @property
+    def last_alarm_list_version(self) -> str:
+        """Return last seen alarm list version."""
+        return self._last_alarm_list_version
+
+    @last_alarm_list_version.setter
+    def last_alarm_list_version(self, alarm_list_version: str):
+        """Store alarm list version and store UID/ID values."""
+        self.last_uid, last_id = alarm_list_version.split(":")
+        self.last_id = int(last_id)
+        self._last_alarm_list_version = alarm_list_version
+
+    def __iter__(self) -> Iterable:
+        """Return an interator for all alarms."""
+        for alarm in list(self.alarms.values()):
+            yield alarm
+
+    def __getitem__(self, alarm_id: int) -> Alarm:
+        """Return the alarm by ID."""
+        return self.alarms[alarm_id]
+
+    def get(self, alarm_id: int) -> Alarm | None:
+        """Return the alarm by ID or None."""
+        return self.alarms.get(alarm_id)
+
+    def update(self, zone: SoCo | None = None) -> None:
+        """Update all alarms and current alarm list version.
+
+        Raises:
+            SoCoException: If the `CurrentAlarmListVersion` value is unexpected.
+                May occur if the provided zone is from a different household.
+        """
+        if zone is None:
+            zone = self._last_zone_used or discovery.any_soco()
+
+        self._last_zone_used = zone
+
+        response = zone.alarmClock.ListAlarms()
+        current_alarm_list_version = response["CurrentAlarmListVersion"]
+
+        if self.last_alarm_list_version:
+            alarm_list_uid, alarm_list_id = current_alarm_list_version.split(":")
+            if self.last_uid != alarm_list_uid:
+                matching_zone = next(
+                    (z for z in zone.all_zones if z.uid == alarm_list_uid), None
+                )
+                if not matching_zone:
+                    raise SoCoException(
+                        "Alarm list UID {} does not match {}".format(
+                            current_alarm_list_version, self.last_alarm_list_version
+                        )
+                    )
+
+            if int(alarm_list_id) <= self.last_id:
+                return
+
+        self.last_alarm_list_version = current_alarm_list_version
+
+        new_alarms = parse_alarm_payload(response, zone)
+
+        # Update existing and create new Alarm instances
+        for alarm_id, kwargs in new_alarms.items():
+            existing_alarm = self.alarms.get(alarm_id)
+            if existing_alarm:
+                existing_alarm.update(**kwargs)
+            else:
+                new_alarm = Alarm(**kwargs)
+                new_alarm._alarm_id = alarm_id  # pylint: disable=protected-access
+                self.alarms[alarm_id] = new_alarm
+
+        # Prune alarms removed externally
+        for alarm_id in list(self.alarms):
+            if not new_alarms.get(alarm_id):
+                self.alarms.pop(alarm_id)
+
+
 class Alarm:
 
     """A class representing a Sonos Alarm.
 
     Alarms may be created or updated and saved to, or removed from the Sonos
     system. An alarm is not automatically saved. Call `save()` to do that.
-
-    Example:
-
-        >>> device = discovery.any_soco()
-        >>> # create an alarm with default properties
-        >>> alarm = Alarm(device)
-        >>> print alarm.volume
-        20
-        >>> print get_alarms()
-        set([])
-        >>> # save the alarm to the Sonos system
-        >>> alarm.save()
-        >>> print get_alarms()
-        set([<Alarm id:88@15:26:15 at 0x107abb090>])
-        >>> # update the alarm
-        >>> alarm.recurrence = "ONCE"
-        >>> # Save it again for the change to take effect
-        >>> alarm.save()
-        >>> # Remove it
-        >>> alarm.remove()
-        >>> print get_alarms()
-        set([])
     """
 
     # pylint: disable=too-many-instance-attributes
-
-    _all_alarms = weakref.WeakValueDictionary()
-
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        zone,
-        start_time=None,
-        duration=None,
-        recurrence="DAILY",
-        enabled=True,
-        program_uri=None,
-        program_metadata="",
-        play_mode="NORMAL",
-        volume=20,
-        include_linked_zones=False,
-    ):
+        zone: SoCo,
+        start_time: datetime.time | None = None,
+        duration: datetime.time | None = None,
+        recurrence: str = "DAILY",
+        enabled: bool = True,
+        program_uri: str = None,
+        program_metadata: str = "",
+        play_mode: str = "NORMAL",
+        volume: int = 20,
+        include_linked_zones: bool = False,
+    ) -> None:
         """
         Args:
             zone (`SoCo`): The soco instance which will play the alarm.
@@ -127,36 +233,35 @@ class Alarm:
                 otherwise. Defaults to `False`.
         """
 
-        super().__init__()
+        self._alarm_id: int | None = None
         self.zone = zone
         if start_time is None:
-            start_time = datetime.now().time()
-        #: `datetime.time`: The alarm's start time.
+            start_time = datetime.now().time().replace(microsecond=0)
         self.start_time = start_time
-        #: `datetime.time`: The alarm's duration.
         self.duration = duration
         self._recurrence = recurrence
-        #: `bool`: `True` if the alarm is enabled, else `False`.
         self.enabled = enabled
-        #:
         self.program_uri = program_uri
-        #: `str`: The uri to play.
         self.program_metadata = program_metadata
         self._play_mode = play_mode
         self._volume = volume
-        #: `bool`: `True` if the alarm should be played on the other speakers
-        #: in the same group, `False` otherwise.
         self.include_linked_zones = include_linked_zones
-        self._alarm_id = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         middle = str(self.start_time.strftime(TIME_FORMAT))
         return "<{} id:{}@{} at {}>".format(
-            self.__class__.__name__, self._alarm_id, middle, hex(id(self))
+            self.__class__.__name__, self.alarm_id, middle, hex(id(self))
         )
 
+    def update(self, **kwargs) -> None:
+        """Update an existing Alarm instance using the same arguments as __init__."""
+        for attr, value in kwargs.items():
+            if not hasattr(self, attr):
+                raise SoCoException("Alarm does not have atttribute {}".format(attr))
+            setattr(self, attr, value)
+
     @property
-    def play_mode(self):
+    def play_mode(self) -> str:
         """
         `str`: The play mode for the alarm.
 
@@ -166,7 +271,7 @@ class Alarm:
         return self._play_mode
 
     @play_mode.setter
-    def play_mode(self, play_mode):
+    def play_mode(self, play_mode: str):
         """See `playmode`."""
         play_mode = play_mode.upper()
         if play_mode not in PLAY_MODES:
@@ -174,19 +279,19 @@ class Alarm:
         self._play_mode = play_mode
 
     @property
-    def volume(self):
+    def volume(self) -> int:
         """`int`: The alarm's volume (0-100)."""
         return self._volume
 
     @volume.setter
-    def volume(self, volume):
+    def volume(self, volume: int | str):
         """See `volume`."""
         # max 100
         volume = int(volume)
         self._volume = max(0, min(volume, 100))  # Coerce in range
 
     @property
-    def recurrence(self):
+    def recurrence(self) -> str:
         """`str`: How often the alarm should be triggered.
 
         Can be ``DAILY``, ``ONCE``, ``WEEKDAYS``, ``WEEKENDS`` or of the form
@@ -197,25 +302,24 @@ class Alarm:
         return self._recurrence
 
     @recurrence.setter
-    def recurrence(self, recurrence):
+    def recurrence(self, recurrence: str):
         """See `recurrence`."""
         if not is_valid_recurrence(recurrence):
             raise KeyError("'%s' is not a valid recurrence value" % recurrence)
 
         self._recurrence = recurrence
 
-    def save(self):
+    def save(self) -> int | None:
         """Save the alarm to the Sonos system.
 
         Returns:
-            str: The alarm ID, or `None` if no alarm was saved.
+            int: The alarm ID, or `None` if no alarm was saved.
 
         Raises:
             ~soco.exceptions.SoCoUPnPException: if the alarm cannot be created
                 because there
                 is already an alarm for this room at the specified time.
         """
-        # pylint: disable=bad-continuation
         args = [
             ("StartLocalTime", self.start_time.strftime(TIME_FORMAT)),
             (
@@ -234,37 +338,43 @@ class Alarm:
             ("Volume", self.volume),
             ("IncludeLinkedZones", "1" if self.include_linked_zones else "0"),
         ]
-        if self._alarm_id is None:
+        if self.alarm_id is None:
             response = self.zone.alarmClock.CreateAlarm(args)
-            self._alarm_id = response["AssignedID"]
-            Alarm._all_alarms[self._alarm_id] = self
+            self._alarm_id = int(response["AssignedID"])
+            alarms = Alarms()
+            if alarms.last_id == self.alarm_id - 1:
+                alarms.last_alarm_list_version = "{}:{}".format(
+                    alarms.last_uid, self.alarm_id
+                )
+            alarms.alarms[self.alarm_id] = self
         else:
             # The alarm has been saved before. Update it instead.
-            args.insert(0, ("ID", self._alarm_id))
+            args.insert(0, ("ID", self.alarm_id))
             self.zone.alarmClock.UpdateAlarm(args)
-        return self._alarm_id
+        return self.alarm_id
 
-    def remove(self):
+    def remove(self) -> bool:
         """Remove the alarm from the Sonos system.
 
         There is no need to call `save`. The Python instance is not deleted,
         and can be saved back to Sonos again if desired.
+
+        Returns:
+            bool: If the removal was sucessful.
         """
-        self.zone.alarmClock.DestroyAlarm([("ID", self._alarm_id)])
-        alarm_id = self._alarm_id
-        try:
-            del Alarm._all_alarms[alarm_id]
-        except KeyError:
-            pass
+        result = self.zone.alarmClock.DestroyAlarm([("ID", self.alarm_id)])
+        alarms = Alarms()
+        alarms.alarms.pop(self.alarm_id, None)
         self._alarm_id = None
+        return result
 
     @property
-    def alarm_id(self):
-        """`str`: The ID of the alarm, or `None`."""
+    def alarm_id(self) -> int | None:
+        """Return the ID of the alarm or None."""
         return self._alarm_id
 
 
-def get_alarms(zone=None):
+def get_alarms(zone: SoCo | None = None) -> set[Alarm]:
     """Get a set of all alarms known to the Sonos system.
 
     Args:
@@ -273,16 +383,34 @@ def get_alarms(zone=None):
 
     Returns:
         set: A set of `Alarm` instances
-
-    Note:
-        Any existing `Alarm` instance will have its attributes updated to those
-        currently stored on the Sonos system.
     """
-    # Get a soco instance to query. It doesn't matter which.
-    if zone is None:
-        zone = discovery.any_soco()
-    response = zone.alarmClock.ListAlarms()
-    alarm_list = response["CurrentAlarmList"]
+    alarms = Alarms()
+    alarms.update(zone)
+    return set(alarms.alarms.values())
+
+
+def remove_alarm_by_id(zone: SoCo, alarm_id: int) -> bool:
+    """Remove an alarm from the Sonos system by its ID.
+
+    Args:
+        zone (`SoCo`): A SoCo instance, which can be any zone that belongs
+            to the Sonos system in which the required alarm is defined.
+        alarm_id (str): The ID of the alarm to be removed.
+
+    Returns:
+        bool: `True` if the alarm is found and removed, `False` otherwise.
+    """
+    alarms = Alarms()
+    alarms.update(zone)
+    alarm = alarms.get(alarm_id)
+    if not alarm:
+        return False
+    return alarm.remove()
+
+
+def parse_alarm_payload(payload: str, zone: SoCo) -> dict[int : dict[str:Any]]:
+    """Parse the XML payload response and return a dict of `Alarm` kwargs."""
+    alarm_list = payload["CurrentAlarmList"]
     tree = XML.fromstring(alarm_list.encode("utf-8"))
 
     # An alarm list looks like this:
@@ -301,67 +429,40 @@ def get_alarms(zone=None):
     #          IncludeLinkedZones="0"/>
     # </Alarms>
 
-    # pylint: disable=protected-access
     alarms = tree.findall("Alarm")
-    result = set()
+    alarm_args = {}
     for alarm in alarms:
         values = alarm.attrib
-        alarm_id = values["ID"]
-        # If an instance already exists for this ID, update and return it.
-        # Otherwise, create a new one and populate its values
-        if Alarm._all_alarms.get(alarm_id):
-            instance = Alarm._all_alarms.get(alarm_id)
-        else:
-            instance = Alarm(None)
-            instance._alarm_id = alarm_id
-            Alarm._all_alarms[instance._alarm_id] = instance
+        alarm_id = int(values["ID"])
 
-        instance.start_time = datetime.strptime(
-            values["StartTime"], "%H:%M:%S"
-        ).time()  # NB StartTime, not
-        # StartLocalTime, which is used by CreateAlarm
-        instance.duration = (
-            None
-            if values["Duration"] == ""
-            else datetime.strptime(values["Duration"], "%H:%M:%S").time()
-        )
-        instance.recurrence = values["Recurrence"]
-        instance.enabled = values["Enabled"] == "1"
-        instance.zone = next(
+        alarm_zone = next(
             (z for z in zone.all_zones if z.uid == values["RoomUUID"]), None
         )
-        # some alarms are not associated to zones -> filter these out
-        if instance.zone is None:
+        if alarm_zone is None:
+            # Some alarms are not associated with a zone, ignore these
             continue
-        instance.program_uri = (
-            None
-            if values["ProgramURI"] == "x-rincon-buzzer:0"
-            else values["ProgramURI"]
-        )
-        instance.program_metadata = values["ProgramMetaData"]
-        instance.play_mode = values["PlayMode"]
-        instance.volume = values["Volume"]
-        instance.include_linked_zones = values["IncludeLinkedZones"] == "1"
 
-        result.add(instance)
-    return result
+        args = {
+            "zone": alarm_zone,
+            # StartTime not StartLocalTime which is used by CreateAlarm
+            "start_time": datetime.strptime(values["StartTime"], "%H:%M:%S").time(),
+            "duration": (
+                None
+                if values["Duration"] == ""
+                else datetime.strptime(values["Duration"], "%H:%M:%S").time()
+            ),
+            "recurrence": values["Recurrence"],
+            "enabled": values["Enabled"] == "1",
+            "program_uri": (
+                None
+                if values["ProgramURI"] == "x-rincon-buzzer:0"
+                else values["ProgramURI"]
+            ),
+            "program_metadata": values["ProgramMetaData"],
+            "play_mode": values["PlayMode"],
+            "volume": values["Volume"],
+            "include_linked_zones": values["IncludeLinkedZones"] == "1",
+        }
 
-
-def remove_alarm_by_id(zone, alarm_id):
-    """Remove an alarm from the Sonos system by its ID.
-
-    Args:
-        zone (`SoCo`): A SoCo instance, which can be any zone that belongs
-            to the Sonos system in which the required alarm is defined.
-        alarm_id (str): The ID of the alarm to be removed.
-
-    Returns:
-        bool: `True` if the alarm is found and removed, `False` otherwise.
-    """
-    alarms = get_alarms(zone)
-    for alarm in alarms:
-        if alarm.alarm_id == alarm_id:
-            alarm.remove()
-            return True
-
-    return False
+        alarm_args[alarm_id] = args
+    return alarm_args

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -235,12 +235,12 @@ class Alarm:
             start_time = datetime.now().time().replace(microsecond=0)
         self.start_time = start_time
         self.duration = duration
-        self._recurrence = recurrence
+        self.recurrence = recurrence
         self.enabled = enabled
         self.program_uri = program_uri
         self.program_metadata = program_metadata
-        self._play_mode = play_mode
-        self._volume = volume
+        self.play_mode = play_mode
+        self.volume = volume
         self.include_linked_zones = include_linked_zones
         self._alarm_id = None
 

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -98,7 +98,7 @@ class Alarms(_SocoSingletonBase):
         self._last_zone_used = None
         self._last_alarm_list_version = None
         self.last_uid = None
-        self.last_id = 0
+        self.last_id = "0"
 
     @property
     def last_alarm_list_version(self):
@@ -108,8 +108,7 @@ class Alarms(_SocoSingletonBase):
     @last_alarm_list_version.setter
     def last_alarm_list_version(self, alarm_list_version):
         """Store alarm list version and store UID/ID values."""
-        self.last_uid, last_id = alarm_list_version.split(":")
-        self.last_id = int(last_id)
+        self.last_uid, self.last_id = alarm_list_version.split(":")
         self._last_alarm_list_version = alarm_list_version
 
     def __iter__(self):
@@ -153,7 +152,7 @@ class Alarms(_SocoSingletonBase):
                         )
                     )
 
-            if int(alarm_list_id) <= self.last_id:
+            if alarm_list_id <= self.last_id:
                 return
 
         self.last_alarm_list_version = current_alarm_list_version
@@ -310,7 +309,7 @@ class Alarm:
         """Save the alarm to the Sonos system.
 
         Returns:
-            int: The alarm ID, or `None` if no alarm was saved.
+            str: The alarm ID, or `None` if no alarm was saved.
 
         Raises:
             ~soco.exceptions.SoCoUPnPException: if the alarm cannot be created
@@ -337,9 +336,9 @@ class Alarm:
         ]
         if self.alarm_id is None:
             response = self.zone.alarmClock.CreateAlarm(args)
-            self._alarm_id = int(response["AssignedID"])
+            self._alarm_id = response["AssignedID"]
             alarms = Alarms()
-            if alarms.last_id == self.alarm_id - 1:
+            if int(alarms.last_id) == int(self.alarm_id) - 1:
                 alarms.last_alarm_list_version = "{}:{}".format(
                     alarms.last_uid, self.alarm_id
                 )
@@ -367,7 +366,7 @@ class Alarm:
 
     @property
     def alarm_id(self):
-        """Return the ID of the alarm or None."""
+        """`str`: The ID of the alarm, or `None`."""
         return self._alarm_id
 
 
@@ -430,7 +429,7 @@ def parse_alarm_payload(payload, zone):
     alarm_args = {}
     for alarm in alarms:
         values = alarm.attrib
-        alarm_id = int(values["ID"])
+        alarm_id = values["ID"]
 
         alarm_zone = next(
             (z for z in zone.all_zones if z.uid == values["RoomUUID"]), None

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -98,7 +98,7 @@ class Alarms(_SocoSingletonBase):
         self._last_zone_used = None
         self._last_alarm_list_version = None
         self.last_uid = None
-        self.last_id = "0"
+        self.last_id = 0
 
     @property
     def last_alarm_list_version(self):
@@ -108,7 +108,8 @@ class Alarms(_SocoSingletonBase):
     @last_alarm_list_version.setter
     def last_alarm_list_version(self, alarm_list_version):
         """Store alarm list version and store UID/ID values."""
-        self.last_uid, self.last_id = alarm_list_version.split(":")
+        self.last_uid, last_id = alarm_list_version.split(":")
+        self.last_id = int(last_id)
         self._last_alarm_list_version = alarm_list_version
 
     def __iter__(self):
@@ -152,7 +153,7 @@ class Alarms(_SocoSingletonBase):
                         )
                     )
 
-            if alarm_list_id <= self.last_id:
+            if int(alarm_list_id) <= self.last_id:
                 return
 
         self.last_alarm_list_version = current_alarm_list_version
@@ -338,7 +339,7 @@ class Alarm:
             response = self.zone.alarmClock.CreateAlarm(args)
             self._alarm_id = response["AssignedID"]
             alarms = Alarms()
-            if int(alarms.last_id) == int(self.alarm_id) - 1:
+            if alarms.last_id == int(self.alarm_id) - 1:
                 alarms.last_alarm_list_version = "{}:{}".format(
                     alarms.last_uid, self.alarm_id
                 )


### PR DESCRIPTION
When using the `soco.alarms` module in tandem with subscription callback events, I found it was difficult to know if the current state of the alarms was accurate. When an alarm is changed and events are sent out (from each speaker), it can take some time for updated alarms to propagate to all speakers. The `zone.alarmClock.ListAlarms()` call returns a `CurrentAlarmListVersion` which can be matched against the same one provided in the event payload, but this does not exist in the current implementation.

While adding support for this value, I found it was easier to think of things in terms of a parent storage class (`Alarms`) which contains all `Alarm` instances instead of using the `weakref` class attribute.

This PR adds new functionality while attempting to preserve existing behavior:
* Adds a new `Alarms` storage class to hold all `Alarm` instances (acts as singleton like `SoCo` instances)
* Parses and stores `CurrentAlarmListVersion` to allow synchronizing with event callbacks
* Throttles unnecessary updates using `CurrentAlarmListVersion`
* Attempts to preserve `Alarm` instances by updating them in place (legacy behavior)
* ~~Adds typing to all methods and attributes~~


Breaking changes:
* ~~`Alarm.alarm_id` is an `int` instead of `str`~~

Non-breaking changes to existing behavior:
* `Alarm.remove()` returns a `bool` to indicate success
