### PR TITLE
Add boot count attribute to zones

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -237,6 +237,7 @@ class SoCo(_SocoSingletonBase):
         create_stereo_pair
         separate_stereo_pair
         get_battery_info
+        boot_seqnum
 
     .. warning::
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -293,6 +293,7 @@ class SoCo(_SocoSingletonBase):
 
         # Some private attributes
         self._all_zones = set()
+        self._boot_seqnum = None
         self._groups = set()
         self._is_bridge = None
         self._is_coordinator = False
@@ -311,6 +312,12 @@ class SoCo(_SocoSingletonBase):
 
     def __repr__(self):
         return '{}("{}")'.format(self.__class__.__name__, self.ip_address)
+
+    @property
+    def boot_seqnum(self):
+        """int: The boot sequence number."""
+        self._parse_zone_group_state()
+        return int(self._boot_seqnum)
 
     @property
     def player_name(self):
@@ -1186,6 +1193,7 @@ class SoCo(_SocoSingletonBase):
             # the zone is as yet unseen.
             zone._uid = member_attribs["UUID"]
             zone._player_name = member_attribs["ZoneName"]
+            zone._boot_seqnum = member_attribs["BootSeq"]
             # add the zone to the set of all members, and to the set
             # of visible members if appropriate
             is_visible = member_attribs.get("Invisible") != "1"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1447,6 +1447,9 @@ class TestZoneGroupTopology:
     def test_soco_is_coordinator(self, moco_zgs):
         assert moco_zgs.is_coordinator
 
+    def test_boot_seqnum(self, moco_zgs):
+        assert moco_zgs.boot_seqnum == 162
+
     def test_all_groups(self, moco_zgs):
         groups = moco_zgs.all_groups
         assert len(groups) == 3


### PR DESCRIPTION
Having the boot sequence number on a zone can be useful for determining when a given zone has lost power or is otherwise rebooted. This information is available from SSDP & Zeroconf discovery broadcasts, but this is the only way I've been able to find it in direct queries to the speaker.