### PR TITLE
Clean up subscription if unsubscription request fails

### DIFF
--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -452,6 +452,7 @@ class Subscription(SubscriptionBase):
                 return
             await unsub
         except Exception as exc:  # pylint: disable=broad-except
+            self._cancel_subscription(exc)
             if strict:
                 raise
             self._log_exception(exc)

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -661,7 +661,7 @@ class SubscriptionBase:
         # Cancel any auto renew
         self._auto_renew_cancel()
         if msg:
-            log.info(msg)
+            log.debug(msg)
 
     @property
     def time_left(self):


### PR DESCRIPTION
If an unsubscription request fails, the `Subscription` object is not properly cleaned up. This can lead to dangling failed subscriptions which conflict with attempts to recreate new subscriptions.

The call to `_cancel_subscription` is currently called in request failure scenarios for both subscriptions and renewals, but not after unsubscription request failures:

https://github.com/SoCo/SoCo/blob/5602d2880af8a3daa9158a2982fca8130d41b13f/soco/events_asyncio.py#L367-L368

https://github.com/SoCo/SoCo/blob/5602d2880af8a3daa9158a2982fca8130d41b13f/soco/events_asyncio.py#L418-L419