### PR TITLE
Use matrix in CI config

### DIFF
--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -12,16 +12,19 @@ on:
       - 'v0.23.fixes'
 
 jobs:
-  SoCo-Check-Jobs-Py_3-10:
-
+  SoCo-Check-Jobs:
+    name: SoCo Check Jobs (${{ matrix.python-version }})
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.0-beta.4
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get install graphviz
@@ -39,154 +42,10 @@ jobs:
         run: |
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
+        if: matrix.python-version != 3.5
         run: |
           black --check soco tests
       - name: Test documentation build
+        if: matrix.python-version == 3.9
         run: |
           make docs
-
-  SoCo-Check-Jobs-Py_3-9:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        sudo apt-get install graphviz
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8 and pylint
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 soco
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        pylint soco
-    - name: Test with pytest
-      run: |
-        pytest --cov-config .coveragerc --cov soco .
-    - name: Test formatting with Black
-      run: |
-        black --check soco tests
-    - name: Test documentation build
-      run: |
-        make docs
-
-  SoCo-Check-Jobs-Py_3-8:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8 and pylint
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 soco
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        pylint soco
-    - name: Test with pytest
-      run: |
-        pytest --cov-config .coveragerc --cov soco .
-    - name: Test formatting with Black
-      run: |
-        black --check soco tests
-
-  SoCo-Check-Jobs-Py_3-7:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8 and pylint
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 soco
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        pylint soco
-    - name: Test with pytest
-      run: |
-        pytest --cov-config .coveragerc --cov soco .
-    - name: Test formatting with Black
-      run: |
-        black --check soco tests
-
-  SoCo-Check-Jobs-Py_3-6:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8 and pylint
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 soco
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        pylint soco
-    - name: Test with pytest
-      run: |
-        pytest --cov-config .coveragerc --cov soco .
-    - name: Test formatting with Black
-      run: |
-        black --check soco tests
-
-  SoCo-Check-Jobs-Py_3-5:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.5
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8 and pylint
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 soco
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        pylint soco
-    - name: Test with pytest
-      run: |
-        pytest --cov-config .coveragerc --cov soco .


### PR DESCRIPTION
Instead of duplicating the test configs, loop through using a matrix and specific job exceptions.

Bumps the 3.10 version to the latest available, and also disables building docs on 3.10 as https://github.com/sphinx-doc/sphinx/issues/9505 is an open issue causing CI failures.