### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -42,7 +42,6 @@ jobs:
         run: |
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
-        if: matrix.python-version != 3.5
         run: |
           black --check soco tests
       - name: Test documentation build

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ would be appreciated.**
 Installation
 ------------
 
-SoCo requires Python 3.7 or newer.
+SoCo requires Python 3.6 or newer.
 
 Use pip:
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ would be appreciated.**
 Installation
 ------------
 
-SoCo requires Python 3.5 or newer.
+SoCo requires Python 3.6 or newer.
 
 Use pip:
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ would be appreciated.**
 Installation
 ------------
 
-SoCo requires Python 3.6 or newer.
+SoCo requires Python 3.7 or newer.
 
 Use pip:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ pylint
 coveralls
 pytest-cov<2.6.0
 wheel
-black >= 20.0b0; python_version >= "3.6" and implementation_name == "cpython"
+black >= 20.0b0
 requests-mock
 twine

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ CLASSIFIERS = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -60,7 +61,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-PYTHON_REQUIRES = ">=3.7"
+PYTHON_REQUIRES = ">=3.6"
 
 with open("README.rst", encoding="utf-8") as file:
     LONG_DESCRIPTION = file.read()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ CLASSIFIERS = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -61,7 +60,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-PYTHON_REQUIRES = ">=3.6"
+PYTHON_REQUIRES = ">=3.7"
 
 with open("README.rst", encoding="utf-8") as file:
     LONG_DESCRIPTION = file.read()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ CLASSIFIERS = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -62,7 +61,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-PYTHON_REQUIRES = ">=3.5"
+PYTHON_REQUIRES = ">=3.6"
 
 with open("README.rst", encoding="utf-8") as file:
     LONG_DESCRIPTION = file.read()


### PR DESCRIPTION
Python 3.5 has been considered EOL since September 2020 and `requests` (a primary dependency) has dropped support as of [2.26.0](https://docs.python-requests.org/en/latest/community/updates/#id1). This removes a workaround for handling `black` in the CI.

Dropping support for 3.5 will allow use of some newer features, probably most visible being [f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings).