### PR TITLE
Use Github Action to upload to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,36 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: PyPI
+
+on:
+  release:
+    types: [published]
+
+env:
+  DEFAULT_PYTHON: 3.9
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON }}
+
+    - name: Install dependencies and build
+      run: |
+        pip install -U pip
+        pip install setuptools wheel
+        python setup.py sdist bdist_wheel
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This is a Github Actions workflow to automatically publish tagged releases to PyPI as described [here](https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries).

This will require a repository owner to:

1. Create a new token on PyPI under "Account Settings > API tokens"
2. Set it as `PYPI_TOKEN` in the repository's encrypted secrets

More details about the encrypted secrets here: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets.