### PR TITLE
Use venv cache between CI runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "11:00"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v2
 
@@ -29,7 +29,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}-dev
+          python-version: ${{ matrix.python-version }}
 
       - name: Install package dependencies
         run: |

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -60,19 +60,23 @@ jobs:
       - name: Lint with flake8 and pylint
         run: |
           # stop the build if there are Python syntax errors or undefined names
+          . venv/bin/activate
           flake8 soco
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           pylint soco
 
       - name: Test with pytest
         run: |
+          . venv/bin/activate
           pytest --cov-config .coveragerc --cov soco .
 
       - name: Test formatting with Black
         run: |
+          . venv/bin/activate
           black --check soco tests
 
       - name: Test documentation build
         if: matrix.python-version == 3.9
         run: |
+          . venv/bin/activate
           make docs

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
 
@@ -29,11 +29,11 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}-dev
 
       - name: Install package dependencies
         run: |
-          sudo apt-get install graphviz libxml2-dev libxslt-dev python3-dev
+          sudo apt-get install graphviz libxml2-dev libxslt-dev
 
       - name: Restore Python ${{ matrix.python-version }} virtual environment
         id: cache-venv

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}-dev
 

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -11,6 +11,9 @@ on:
       - master
       - 'v0.28.fixes'
 
+env:
+  CACHE_VERSION: 1
+
 jobs:
   SoCo-Check-Jobs:
     name: SoCo Check Jobs (${{ matrix.python-version }})
@@ -21,29 +24,54 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+
+      - name: Install package dependencies
         run: |
           sudo apt-get install graphviz libxml2-dev libxslt-dev python-dev
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements.txt
+
+      - name: Restore Python ${{ matrix.python-version }} virtual environment
+        id: cache-venv
+        uses: actions/cache@v2
+        with:
+          path: venv
+          key: >-
+            ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
+            steps.setup-python.outputs.python-version }}-${{
+            hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
+            steps.setup-python.outputs.python-version }}-
+
+      - name: Create Python ${{ matrix.python-version }} virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          pip install -U pip
           pip install -r requirements-dev.txt
+          pip install -e .
+
       - name: Lint with flake8 and pylint
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 soco
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           pylint soco
+
       - name: Test with pytest
         run: |
           pytest --cov-config .coveragerc --cov soco .
+
       - name: Test formatting with Black
         run: |
           black --check soco tests
+
       - name: Test documentation build
         if: matrix.python-version == 3.9
         run: |

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-python
@@ -37,7 +37,7 @@ jobs:
 
       - name: Restore Python ${{ matrix.python-version }} virtual environment
         id: cache-venv
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: venv
           key: >-

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -54,8 +54,8 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           pip install -U pip
-          pip install -r requirements-dev.txt
           pip install -e .
+          pip install -r requirements-dev.txt
 
       - name: Lint with flake8 and pylint
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ flake8==6.0.0; python_version >= "3.8"
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
+lxml==4.9.2
 pylint==2.13.9; python_version == "3.6"
 pylint==2.17.0; python_version >= "3.7"
 pytest==7.0.1; python_version == "3.6"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 appdirs==1.4.4
-black >= 22.12.0; python_version >= "3.7"
+black==22.12.0; python_version >= "3.7"
 coveralls==3.3.1
-flake8==4.0.1
+flake8==5.0.4; python_version == "3.6"
+flake8==6.0.0; python_version >= "3.7"
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8==4.0.1
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
-pylint==2.14.1
+pylint==2.13.9
 pytest==7.1.2
 pytest-cov==3.0.0
 requests==2.28.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 appdirs==1.4.4
-black==22.12.0; python_version >= "3.7"
+black==23.1.0; python_version >= "3.7"
+build==0.9.0; python_version == "3.6"
+build==0.10.0; python_version >= "3.7"
 build==0.10.0
 coveralls==3.3.1
 flake8==5.0.4; python_version <= "3.7"
@@ -8,12 +10,12 @@ graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
 pylint==2.13.9; python_version == "3.6"
-pylint==2.15.9; python_version >= "3.7"
+pylint==2.17.0; python_version >= "3.7"
 pytest==7.0.1; python_version == "3.6"
-pytest==7.1.2; python_version >= "3.7"
+pytest==7.2.2; python_version >= "3.7"
 pytest-cov==3.0.0
 requests==2.27.1; python_version == "3.6"
-requests==2.28.0; python_version >= "3.7"
+requests==2.28.2; python_version >= "3.7"
 requests-mock==1.9.3
 sphinx==4.3.2; python_version <= "3.7"
 sphinx==4.5.0; python_version >= "3.8"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==21.7b0
+black==21.7b0; python_version >= "3.6"
 coveralls==3.2.0
 flake8==3.9.2
 graphviz==0.17
@@ -7,7 +7,8 @@ importlib-metadata<5; python_version == "3.7"
 pylint==2.9.5
 pytest==6.2.4
 pytest-cov==2.12.1
-requests==2.26.0
+requests==2.25.1; python_version == "3.5"
+requests==2.26.0; python_version >= "3.6"
 requests-mock==1.9.3
 sphinx==4.5.0
 sphinx-rtd-theme==0.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,17 @@
-black==21.7b0; python_version >= "3.6"
-coveralls==3.2.0
-flake8==3.9.2
-graphviz==0.17; python_version >= "3.6"
+black==21.12b0; python_version >= "3.6"
+coveralls==3.3.1
+flake8==4.0.1
+graphviz==0.19.1; python_version >= "3.6"
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
 pylint; python_version == "3.5"
-pylint==2.9.5; python_version >= "3.6"
+pylint==2.12.1; python_version >= "3.6"
 pytest; python_version == "3.5"
-pytest==6.2.4; python_version >= "3.6"
+pytest==6.2.5; python_version >= "3.6"
 pytest-cov==2.12.1
 requests==2.25.1; python_version == "3.5"
-requests==2.26.0; python_version >= "3.6"
+requests==2.27.1; python_version >= "3.6"
 requests-mock==1.9.3
 sphinx==4.5.0
-sphinx-rtd-theme==0.5.2
+sphinx-rtd-theme==1.0.0
 xmltodict==0.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==21.7b0; python_version >= "3.6"
 coveralls==3.2.0
 flake8==3.9.2
-graphviz==0.17
+graphviz==0.17; python_version >= "3.6"
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
 pylint==2.9.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,10 +5,13 @@ flake8==4.0.1
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
-pylint==2.13.9
-pytest==7.1.2
+pylint==2.13.9; python_version == "3.6"
+pylint==2.14.1; python_version >= "3.7"
+pytest==7.0.1; python_version == "3.6"
+pytest==7.1.2; python_version >= "3.7"
 pytest-cov==3.0.0
-requests==2.28.0
+requests==2.27.1; python_version == "3.6"
+requests==2.28.0; python_version >= "3.7"
 requests-mock==1.9.3
 sphinx==4.5.0
 sphinx-rtd-theme==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,13 @@
-black==21.12b0; python_version >= "3.6"
+black==21.12b0
 coveralls==3.3.1
-flake8==3.9.2; python_version == "3.5"
-flake8==4.0.1; python_version >= "3.6"
-graphviz==0.19.1; python_version >= "3.6"
+flake8==4.0.1
+graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
-pylint; python_version == "3.5"
-pylint==2.12.1; python_version >= "3.6"
-pytest; python_version == "3.5"
-pytest==6.2.5; python_version >= "3.6"
+pylint==2.12.1
+pytest==6.2.5
 pytest-cov==2.12.1
-requests==2.25.1; python_version == "3.5"
-requests==2.27.1; python_version >= "3.6"
+requests==2.27.1
 requests-mock==1.9.3
 sphinx==4.5.0
 sphinx-rtd-theme==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,14 @@
-sphinx == 4.5.0
-sphinx_rtd_theme
-pytest >= 2.5
-graphviz
-flake8
-pylint
-coveralls
-pytest-cov<2.6.0
-wheel
-black >= 20.0b0
-requests-mock
-twine
+black==21.7b0
+coveralls==3.2.0
+flake8==3.9.2
+graphviz==0.17
+ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
+pylint==2.9.5
+pytest==6.2.4
+pytest-cov==2.12.1
+requests==2.26.0
+requests-mock==1.9.3
+sphinx==4.5.0
+sphinx-rtd-theme==0.5.2
+xmltodict==0.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black==21.12b0; python_version >= "3.6"
 coveralls==3.3.1
-flake8==4.0.1
+flake8==3.9.2; python_version == "3.5"
+flake8==4.0.1; python_version >= "3.6"
 graphviz==0.19.1; python_version >= "3.6"
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,14 @@
-black==21.12b0
+appdirs==1.4.4
+black==22.3.0
 coveralls==3.3.1
 flake8==4.0.1
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
-pylint==2.12.1
-pytest==6.2.5
-pytest-cov==2.12.1
-requests==2.27.1
+pylint==2.14.1
+pytest==7.1.2
+pytest-cov==3.0.0
+requests==2.28.0
 requests-mock==1.9.3
 sphinx==4.5.0
 sphinx-rtd-theme==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,8 @@ ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
 pylint; python_version == "3.5"
 pylint==2.9.5; python_version >= "3.6"
-pytest==6.2.4
+pytest; python_version == "3.5"
+pytest==6.2.4; python_version >= "3.6"
 pytest-cov==2.12.1
 requests==2.25.1; python_version == "3.5"
 requests==2.26.0; python_version >= "3.6"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ appdirs==1.4.4
 black==23.1.0; python_version >= "3.7"
 build==0.9.0; python_version == "3.6"
 build==0.10.0; python_version >= "3.7"
-build==0.10.0
 coveralls==3.3.1
 flake8==5.0.4; python_version <= "3.7"
 flake8==6.0.0; python_version >= "3.8"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,8 @@ flake8==3.9.2
 graphviz==0.17; python_version >= "3.6"
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
-pylint==2.9.5
+pylint; python_version == "3.5"
+pylint==2.9.5; python_version >= "3.6"
 pytest==6.2.4
 pytest-cov==2.12.1
 requests==2.25.1; python_version == "3.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
 pylint==2.13.9; python_version == "3.6"
-pylint==2.14.1; python_version >= "3.7"
+pylint==2.15.9; python_version >= "3.7"
 pytest==7.0.1; python_version == "3.6"
 pytest==7.1.2; python_version >= "3.7"
 pytest-cov==3.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 appdirs==1.4.4
 black==22.12.0; python_version >= "3.7"
 coveralls==3.3.1
-flake8==5.0.4; python_version == "3.6"
-flake8==6.0.0; python_version >= "3.7"
+flake8==5.0.4; python_version <= "3.7"
+flake8==6.0.0; python_version >= "3.8"
 graphviz==0.19.1
 ifaddr==0.1.7
 importlib-metadata<5; python_version == "3.7"
@@ -14,6 +14,7 @@ pytest-cov==3.0.0
 requests==2.27.1; python_version == "3.6"
 requests==2.28.0; python_version >= "3.7"
 requests-mock==1.9.3
-sphinx==4.5.0
+sphinx==4.3.2; python_version <= "3.7"
+sphinx==4.5.0; python_version >= "3.8"
 sphinx-rtd-theme==1.0.0
 xmltodict==0.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ minversion = 2.5
 norecursedirs=venv* .git .hg build doc *.egg-info
 
 [flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 # Ingore errors relating to naming conventions.  Will be picked up by pylint
 # Ignore W504 line break after binary operator
 ignore = N801,N802,N804,N805,N806,W504


### PR DESCRIPTION
This will use the `actions/cache` action to store and load a venv cache between runs using the same dependencies. In order to do this, each entry in `requirements-dev.txt` must be explicitly pinned as a hash of that file is used to determine if a cache should be reused.

Since the dependencies must be pinned, I've also added a Dependabot config to automatically keep those libraries up to date.

Both `twine` and `wheel` have been removed as hard dependencies. An alternative to using `twine` to upload from a local dev environment is to use Github Actions to do this for us. The PR for that feature is here: #856.

~~This may be dependent on dropping Python 3.5 support as several of the dependencies have already dropped support. This is proposed in #855.~~

This does _not_ affect the standard `requirements.txt` file and no pinning is necessary there. This will only affect development environments & CI runs.