### PR TITLE
Use a requests.Session for http requests

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -295,6 +295,8 @@ class SoCo(_SocoSingletonBase):
 
         self.music_library = MusicLibrary(self)
 
+        self.session = requests.Session()
+
         # Some private attributes
         self._all_zones = set()
         self._boot_seqnum = None
@@ -1738,7 +1740,7 @@ class SoCo(_SocoSingletonBase):
         if self.speaker_info and refresh is False:
             return self.speaker_info
         else:
-            response = requests.get(
+            response = self.session.get(
                 "http://" + self.ip_address + ":1400/xml/device_description.xml",
                 timeout=timeout,
             )
@@ -2566,7 +2568,7 @@ class SoCo(_SocoSingletonBase):
 
         # Retrieve information from the speaker's status URL
         try:
-            response = requests.get(
+            response = self.session.get(
                 "http://" + self.ip_address + ":1400/status/batterystatus",
                 timeout=timeout,
             )

--- a/soco/events.py
+++ b/soco/events.py
@@ -248,6 +248,7 @@ class Subscription(SubscriptionBase):
                 created and used.
         """
         super().__init__(service, event_queue)
+        self.session = requests.Session()
         # Used to keep track of the auto_renew thread
         self._auto_renew_thread = None
         self._auto_renew_thread_flag = threading.Event()
@@ -389,7 +390,7 @@ class Subscription(SubscriptionBase):
         """
         response = None
         try:
-            response = requests.request(method, url, headers=headers, timeout=3)
+            response = self.session.request(method, url, headers=headers, timeout=3)
         except requests.exceptions.RequestException:
             # Ignore timeout for unsubscribe since we are leaving anyway.
             if method != "UNSUBSCRIBE":

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -7,8 +7,6 @@
 import logging
 import weakref
 
-import requests
-
 from .. import discovery
 from ..xml import XML
 
@@ -76,7 +74,7 @@ class Account:
         device = soco or discovery.any_soco()
         log.debug("Fetching account data from %s", device)
         settings_url = "http://{}:1400/status/accounts".format(device.ip_address)
-        result = requests.get(settings_url).content
+        result = soco.session.get(settings_url).content
         log.debug("Account data: %s", result)
         return result
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -36,8 +36,6 @@ import logging
 from collections import namedtuple
 from xml.sax.saxutils import escape
 
-import requests
-
 from .cache import Cache
 from . import events
 from . import config
@@ -476,7 +474,7 @@ class Service:
         log.debug("Sending %s %s to %s", action, args, self.soco.ip_address)
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
-        response = requests.post(
+        response = self.soco.session.post(
             self.base_url + self.control_url,
             headers=headers,
             data=body.encode("utf-8"),
@@ -692,7 +690,9 @@ class Service:
         ns = "{urn:schemas-upnp-org:service-1-0}"
         # get the scpd body as bytes, and feed directly to elementtree
         # which likes to receive bytes
-        scpd_body = requests.get(self.base_url + self.scpd_url, timeout=10).content
+        scpd_body = self.soco.session.get(
+            self.base_url + self.scpd_url, timeout=10
+        ).content
         tree = XML.fromstring(scpd_body)
         # parse the state variables to get the relevant variable types
         vartypes = {}
@@ -752,7 +752,9 @@ class Service:
 
         # pylint: disable=invalid-name
         ns = "{urn:schemas-upnp-org:service-1-0}"
-        scpd_body = requests.get(self.base_url + self.scpd_url, timeout=10).text
+        scpd_body = self.soco.session.get(
+            self.base_url + self.scpd_url, timeout=10
+        ).text
         tree = XML.fromstring(scpd_body.encode("utf-8"))
         # parse the state variables to get the relevant variable types
         statevars = tree.findall("{}stateVariable".format(ns))


### PR DESCRIPTION
- Avoids constant reconnects to the devices

```
[pid   232] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.106.49")}, 16) = -1 EINPROGRESS (Operation in progress)
[pid   231] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.106.49")}, 16) = -1 EINPROGRESS (Operation in progress)
[pid   229] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.107.181")}, 16) = -1 EINPROGRESS (Operation in progress)
[pid   227] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.107.181")}, 16) = -1 EINPROGRESS (Operation in progress)
[pid   222] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.107.230")}, 16) = -1 EINPROGRESS (Operation in progress)
[pid   220] connect(353, {sa_family=AF_INET, sin_port=htons(1400), sin_addr=inet_addr("192.168.107.230")}, 16) = -1 EINPROGRESS (Operation in progress)```
```

- Reduces command latency

