### PR TITLE
Adjust timeouts for services and async event handler

### DIFF
--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -68,7 +68,7 @@ import time
 import asyncio
 
 try:
-    from aiohttp import ClientSession, web
+    from aiohttp import ClientSession, ClientTimeout, web
 except ImportError as error:
     print(
         """ImportError: {}:
@@ -206,7 +206,8 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
             if not port:
                 return
             self.address = (ip_address, port)
-            self.session = ClientSession(raise_for_status=True)
+            client_timeout = ClientTimeout(total=10)
+            self.session = ClientSession(raise_for_status=True, timeout=client_timeout)
             self.is_running = True
             log.debug("Event Listener started")
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -429,7 +429,7 @@ class Service:
 
     def send_command(
         self, action, args=None, cache=None, cache_timeout=None, timeout=5, **kwargs
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Send a command to a Sonos device.
 
         Args:

--- a/soco/services.py
+++ b/soco/services.py
@@ -427,7 +427,9 @@ class Service:
         # is set over the network
         return (headers, body)
 
-    def send_command(self, action, args=None, cache=None, cache_timeout=None, **kwargs):
+    def send_command(
+        self, action, args=None, cache=None, cache_timeout=None, timeout=5, **kwargs
+    ):
         """Send a command to a Sonos device.
 
         Args:
@@ -480,7 +482,7 @@ class Service:
             self.base_url + self.control_url,
             headers=headers,
             data=body.encode("utf-8"),
-            timeout=20,
+            timeout=timeout,
         )
 
         log.debug("Received %s, %s", response.headers, response.text)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -243,7 +243,7 @@ def test_send_command(service):
             "http://192.168.1.101:1400/Service/Control",
             headers=mock.ANY,
             data=DUMMY_VALID_ACTION.encode("utf-8"),
-            timeout=20,
+            timeout=5,
         )
         # Now the cache should be primed, so try it again
         fake_post.reset_mock()


### PR DESCRIPTION
This adjusts the `requests` and `aiohttp` timeouts in two places:

1. Reduce the default service call timeout to 5s from 20s, allow passing in a timeout per-call.
2. Set an explicit async event handler timeout instead of using the default of 300s. (https://docs.aiohttp.org/en/stable/client_quickstart.html#aiohttp-client-timeouts)