### PR TITLE
Add sub & surround properties and controls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,12 @@ SoCo supports the following controls amongst others:
 -  Get or set alarms
 -  Get or set sleep timers
 
+-  Enable or disable surround speakers or subwoofer
+-  Get information regarding a home theater setup:
+
+   - If surround speakers or a subwoofer are paired
+   - Which audio channel a given speaker handles
+
 -  Get or set the speaker’s bass and treble EQ
 -  Toggle the speaker’s loudness compensation, night mode and dialog mode
 -  Toggle the white status light on the unit

--- a/soco/core.py
+++ b/soco/core.py
@@ -449,7 +449,7 @@ class SoCo(_SocoSingletonBase):
         if not self._ht_sat_chan_map:
             return False
 
-        if ":SW" in self._ht_sat_chan_map:
+        if ":SW" in self._ht_sat_chan_map:  # pylint: disable=unsupported-membership-test
             return True
         return False
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -193,8 +193,10 @@ class SoCo(_SocoSingletonBase):
         is_bridge
         is_coordinator
         is_soundbar
+        surround_enabled
         is_satellite
         has_satellites
+        sub_enabled
         is_subwoofer
         has_subwoofer
         channel

--- a/soco/core.py
+++ b/soco/core.py
@@ -449,7 +449,7 @@ class SoCo(_SocoSingletonBase):
         if not self._ht_sat_chan_map:
             return False
 
-        if ":SW" in self._ht_sat_chan_map:  # pylint: disable=unsupported-membership-test
+        if ":SW" in self._ht_sat_chan_map:  # pylint: disable=E1135
             return True
         return False
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -435,7 +435,7 @@ class SoCo(_SocoSingletonBase):
     def is_subwoofer(self):
         """bool: Is this zone a subwoofer?"""
         self._parse_zone_group_state()
-        if zone._surround_location == "SW":
+        if self._surround_location == "SW":
             return True
         return False
 


### PR DESCRIPTION
Implements new properties (`is_satellite`, `has_satellites`, `is_subwoofer`, `has_subwoofer`, `channel`) for home theater and sub-paired configurations. These are populated from the Zone group state cache.

Also adds `surround_enabled` and `sub_enabled` properties to obtain & control the respective "_Surround Audio > Surrounds_" and "_Sub Audio > Sub_" toggle switches.

~~Note: This PR was created without direct access to a sub, so a bit of testing would be appreciated.~~

Sub controls have been confirmed working by a user with a subwoofer.