### PR TITLE
Address new pylint issue

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -526,7 +526,7 @@ class SoCo(_SocoSingletonBase):
     def play_mode(self, playmode):
         """Set the speaker's mode."""
         playmode = playmode.upper()
-        if playmode not in PLAY_MODES.keys():
+        if playmode not in PLAY_MODES:
             raise KeyError("'%s' is not a valid play mode" % playmode)
 
         self.avTransport.SetPlayMode([("InstanceID", 0), ("NewPlayMode", playmode)])


### PR DESCRIPTION
Addresses an unrelated CI issue uncovered in https://github.com/SoCo/SoCo/pull/871.

Since `pylint` is not pinned to a specific version, a newer release has marked previously accepted code with a warning. CI pinning is included with https://github.com/SoCo/SoCo/pull/857 (and improved with https://github.com/SoCo/SoCo/pull/855) which would avoid shifting test requirements in the future.