### PR TITLE
Revert service call timeout reduction

### DIFF
--- a/soco/services.py
+++ b/soco/services.py
@@ -428,7 +428,7 @@ class Service:
         return (headers, body)
 
     def send_command(
-        self, action, args=None, cache=None, cache_timeout=None, timeout=5, **kwargs
+        self, action, args=None, cache=None, cache_timeout=None, timeout=20, **kwargs
     ):  # pylint: disable=too-many-arguments
         """Send a command to a Sonos device.
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -243,7 +243,7 @@ def test_send_command(service):
             "http://192.168.1.101:1400/Service/Control",
             headers=mock.ANY,
             data=DUMMY_VALID_ACTION.encode("utf-8"),
-            timeout=5,
+            timeout=20,
         )
         # Now the cache should be primed, so try it again
         fake_post.reset_mock()


### PR DESCRIPTION
I've received several reports from users that previously working service calls are now timing out. This coincides with the reduction of timeout from 20s to 5s in #868. This PR retains the ability to set a timeout per-call but reverts the default timeout to 20s.