### PR TITLE
Add audio_delay property for TV dialog sync.

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -223,6 +223,7 @@ class SoCo(_SocoSingletonBase):
         treble
         loudness
         balance
+        audio_delay
         night_mode
         dialog_mode
         supports_fixed_volume
@@ -1123,6 +1124,45 @@ class SoCo(_SocoSingletonBase):
         )
         self.renderingControl.SetVolume(
             [("InstanceID", 0), ("Channel", "RF"), ("DesiredVolume", right)]
+        )
+
+    @property
+    def audio_delay(self):
+        """int: The TV Dialog Sync audio delay.
+
+        Returns the current value or None if not supported.
+        """
+        if not self.is_soundbar:
+            return None
+
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "AudioDelay")]
+        )
+        return int(response["CurrentValue"])
+
+    @audio_delay.setter
+    def audio_delay(self, delay):
+        """Control the delay added to incoming audio sources. Also called
+        TV Dialog Sync in Home Theater settings.
+
+        :param delay: Delay to apply to audio in the range of 0 to 5
+        :type delay: int
+        :raises NotSupportedException: If device does not support audio delay.
+        :raises ValueError: If provided delay is not an acceptable value.
+        """
+        if not self.is_soundbar:
+            message = "This device does not support audio delay"
+            raise NotSupportedException(message)
+
+        if not 0 <= delay <= 5:
+            raise ValueError("invalid value, must be integer between 0 and 5 inclusive")
+
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "AudioDelay"),
+                ("DesiredValue", int(delay)),
+            ]
         )
 
     @property

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1278,6 +1278,18 @@ class TestRenderingControl:
         assert moco.soundbar_audio_input_format_code is None
         assert moco.soundbar_audio_input_format is None
 
+    def test_soco_audio_delay(self, moco):
+        moco._is_soundbar = True
+        moco.renderingControl.GetEQ.return_value = {"CurrentValue": "2"}
+        assert moco.audio_delay == 2
+        moco.renderingControl.GetEQ.assert_called_once_with(
+            [("InstanceID", 0), ("EQType", "AudioDelay")]
+        )
+        moco.audio_delay = 1
+        moco.renderingControl.SetEQ.assert_called_once_with(
+            [("InstanceID", 0), ("EQType", "AudioDelay"), ("DesiredValue", 1)]
+        )
+
     def test_soco_fixed_volume(self, moco):
         moco.renderingControl.GetSupportsOutputFixed.return_value = {
             "CurrentSupportsFixed": "1"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1279,7 +1279,18 @@ class TestRenderingControl:
         assert moco.soundbar_audio_input_format is None
 
     def test_soco_audio_delay(self, moco):
+        moco._is_soundbar = False
+        assert moco.audio_delay == None
+        assert not moco.renderingControl.GetEQ.called
+
+        with pytest.raises(NotSupportedException):
+            moco.audio_delay = 1
+
         moco._is_soundbar = True
+
+        with pytest.raises(ValueError):
+            moco.audio_delay = 6
+
         moco.renderingControl.GetEQ.return_value = {"CurrentValue": "2"}
         assert moco.audio_delay == 2
         moco.renderingControl.GetEQ.assert_called_once_with(


### PR DESCRIPTION
Adds controls to the TV Dialog Sync audio delay exposed for home theater devices.

![image](https://user-images.githubusercontent.com/1203111/147724472-407c28a7-801c-48c8-ac28-6c483e6011d1.png)

Oddly, this value doesn't seem to update in the native Sonos app even when navigating away and back. However its value is correctly reflected in realtime from `renderingControl` subscription events as `audio_delay`.