### PR TITLE
Add `mic_enabled` property to the SoCo class

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -233,6 +233,7 @@ class SoCo(_SocoSingletonBase):
         trueplay
         status_light
         buttons_enabled
+        mic_enabled
 
     ..  rubric:: Playlists and Favorites
     ..  autosummary::
@@ -334,6 +335,8 @@ class SoCo(_SocoSingletonBase):
         self._has_satellites = False
         self._channel = None
         self._is_soundbar = None
+        self._voice_config_state = None
+        self._mic_enabled = None
         self._player_name = None
         self._uid = None
         self._household_id = None
@@ -1440,6 +1443,13 @@ class SoCo(_SocoSingletonBase):
             zone._uid = member_attribs["UUID"]
             zone._player_name = member_attribs["ZoneName"]
             zone._boot_seqnum = member_attribs["BootSeq"]
+            voice_config_state = member_attribs.get("VoiceConfigState")
+            if voice_config_state:
+                zone._voice_config_state = int(voice_config_state)
+                if zone._voice_config_state > 0:
+                    zone._mic_enabled = bool(int(member_attribs["MicEnabled"]))
+                else:
+                    zone._mic_enabled = None
             zone._channel_map = member_attribs.get("ChannelMapSet")
             zone._ht_sat_chan_map = member_attribs.get("HTSatChanMapSet")
             if zone._channel_map:
@@ -1780,6 +1790,17 @@ class SoCo(_SocoSingletonBase):
                 ("DesiredButtonLockState", lock_state),
             ]
         )
+
+    @property
+    def mic_enabled(self):
+        """bool: Is the device's microphone enabled?
+
+        .. note:: Returns None if the device does not have a microphone
+            or if a voice service is not configured.
+
+        """
+        self._parse_zone_group_state()
+        return self._mic_enabled
 
     def get_current_track_info(self):
         """Get information about the currently playing track.

--- a/soco/core.py
+++ b/soco/core.py
@@ -1379,7 +1379,7 @@ class SoCo(_SocoSingletonBase):
         except SoCoUPnPException as error:
             raise NotSupportedException from error
 
-    def _parse_zone_group_state(self):
+    def _parse_zone_group_state(self):  # pylint: disable=too-many-statements
         """The Zone Group State contains a lot of useful information.
 
         Retrieve and parse it, and populate the relevant properties.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,7 +146,7 @@ ZGS = (
               Orientation="0"
               RoomCalibrationState="4"
               SecureRegState="3"
-              VoiceConfigState="0"
+              VoiceConfigState="2"
               MicEnabled="0"
               AirPlayEnabled="0"
               IdleState="1"
@@ -175,8 +175,8 @@ ZGS = (
               Orientation="0"
               RoomCalibrationState="4"
               SecureRegState="3"
-              VoiceConfigState="0"
-              MicEnabled="0"
+              VoiceConfigState="2"
+              MicEnabled="1"
               AirPlayEnabled="0"
               IdleState="0"
               MoreInfo=""/>
@@ -1578,6 +1578,15 @@ class TestZoneGroupTopology:
             [("InstanceID", 0), ("Adjustment", 25)]
         )
         assert new_volume == 75
+
+    def test_mic_enabled(self, moco_zgs):
+        for zone in moco_zgs.all_zones:
+            if zone.uid == "RINCON_000E58A53FAE01400":
+                assert zone.mic_enabled is False
+            elif zone.uid == "RINCON_000E5884455C01400":
+                assert zone.mic_enabled is True
+            else:
+                assert zone.mic_enabled is None
 
 
 def test_only_on_master_true(moco_only_on_master):


### PR DESCRIPTION
Adds a new read-only boolean property which reports the current state of the device's microphone. For devices without a microphone or where a voice service has not yet been configured, the return value will be `None`.

Modified the `ZoneGroupState` XML in the tests to mark two speakers as voice-enabled in order to allow testing this new feature. Should have no effect on existing tests.