### PR TITLE
Add configurable timeout for network requests

### DIFF
--- a/soco/config.py
+++ b/soco/config.py
@@ -67,7 +67,12 @@ See also:
 """
 
 REQUEST_TIMEOUT = 20.0
-"""The timeout to be used when sending commands to a Sonos device.
+"""The timeout in seconds to be used when sending commands to a Sonos device.
 
-If this is set to 'None', the call will wait indefinitely.
+Can be a float, an int, or None. If set to 'None', calls can potentially
+wait indefinitely.
+
+This variable can be set dynamically during program execution to adjust the
+timeout in use. It can also be overridden for specific calls by using the
+'timeout' kwarg.
 """

--- a/soco/config.py
+++ b/soco/config.py
@@ -67,12 +67,14 @@ See also:
 """
 
 REQUEST_TIMEOUT = 20.0
-"""The timeout in seconds to be used when sending commands to a Sonos device.
+"""The timeout (in seconds) to be used when sending commands to a Sonos device.
 
-Can be a float, an int, or None. If set to 'None', calls can potentially
-wait indefinitely.
+A value for REQUEST_TIMEOUT *must* be set. It can be a float, an int, or None.
+If set to 'None', calls can potentially wait indefinitely. (The default of 20.0s
+is a long time for network operations, but it's been determined empirically to
+be a reasonable upper limit for most circumstances.)
 
-This variable can be set dynamically during program execution to adjust the
-timeout in use. It can also be overridden for specific calls by using the
-'timeout' kwarg.
+REQUEST_TIMEOUT can be set dynamically during program execution to adjust the
+timeout at runtime. It can also be overridden for specific calls by using the
+'timeout' kwarg in the relevant calling functions.
 """

--- a/soco/config.py
+++ b/soco/config.py
@@ -65,3 +65,9 @@ The default of None means the :mod:`soco.events` module will be used.
 See also:
     The :mod:`soco.events` and :mod:`soco.events_twisted` modules.
 """
+
+REQUEST_TIMEOUT = 20.0
+"""The timeout to be used when sending commands to a Sonos device.
+
+If this is set to 'None', the call will wait indefinitely.
+"""

--- a/soco/services.py
+++ b/soco/services.py
@@ -463,10 +463,12 @@ class Service:
             `requests.exceptions.HTTPError`: if an http error occurs.
 
         """
-        # Determine the timeout for the request; if 'timeout' is not
-        # set as a kwarg by the caller, use the value from
-        # config.REQUEST_TIMEOUT instead.
+        # Determine the timeout for the request: use the value of
+        # config.REQUEST_TIMEOUT unless overridden by 'timeout'
+        # being provided as a kwarg by the caller, in which case
+        # use this and remove it from kwargs.
         timeout = kwargs.pop("timeout", config.REQUEST_TIMEOUT)
+        log.debug("Request timeout set to %s", timeout)
 
         if args is None:
             args = self.compose_args(action, kwargs)

--- a/soco/services.py
+++ b/soco/services.py
@@ -428,7 +428,7 @@ class Service:
         return (headers, body)
 
     def send_command(
-        self, action, args=None, cache=None, cache_timeout=None, timeout=20, **kwargs
+        self, action, args=None, cache=None, cache_timeout=None, **kwargs
     ):  # pylint: disable=too-many-arguments
         """Send a command to a Sonos device.
 
@@ -465,6 +465,16 @@ class Service:
             `requests.exceptions.HTTPError`: if an http error occurs.
 
         """
+        # Determine the timeout for the request; if 'timeout' is not
+        # set as a kwarg by the caller, use the value from
+        # config.REQUEST_TIMEOUT instead.
+        try:
+            timeout = kwargs.pop("timeout")
+            log.debug("Using timeout set by caller")
+        except KeyError:
+            timeout = config.REQUEST_TIMEOUT
+            log.debug("Using timeout from config.REQUEST_TIMEOUT")
+
         if args is None:
             args = self.compose_args(action, kwargs)
         if cache is None:

--- a/soco/services.py
+++ b/soco/services.py
@@ -466,12 +466,7 @@ class Service:
         # Determine the timeout for the request; if 'timeout' is not
         # set as a kwarg by the caller, use the value from
         # config.REQUEST_TIMEOUT instead.
-        try:
-            timeout = kwargs.pop("timeout")
-            log.debug("Using timeout set by caller")
-        except KeyError:
-            timeout = config.REQUEST_TIMEOUT
-            log.debug("Using timeout from config.REQUEST_TIMEOUT")
+        timeout = kwargs.pop("timeout", config.REQUEST_TIMEOUT)
 
         if args is None:
             args = self.compose_args(action, kwargs)
@@ -481,6 +476,7 @@ class Service:
         if result is not None:
             log.debug("Cache hit")
             return result
+
         # Cache miss, so go ahead and make a network call
         headers, body = self.build_command(action, args)
         log.debug("Sending %s %s to %s", action, args, self.soco.ip_address)

--- a/soco/services.py
+++ b/soco/services.py
@@ -427,9 +427,7 @@ class Service:
         # is set over the network
         return (headers, body)
 
-    def send_command(
-        self, action, args=None, cache=None, cache_timeout=None, **kwargs
-    ):  # pylint: disable=too-many-arguments
+    def send_command(self, action, args=None, cache=None, cache_timeout=None, **kwargs):
         """Send a command to a Sonos device.
 
         Args:


### PR DESCRIPTION
This is a possible approach to address the suggestion in the discussion around #876.

1. It moves the default timeout for requests to `config.py` in variable `config.REQUEST_TIMEOUT`. The default is set to 20.0s, as is currently the case. A value of `None` will establish an infinite timeout.
2. The value of `config.REQUEST_TIMEOUT` can be set dynamically at runtime.
3. It still permits the use of the `timeout` kwarg by callers, which will override the value in `config.REQUEST_TIMEOUT`.