### PR TITLE
Fix error when radio title is missing

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1854,7 +1854,9 @@ class SoCo(_SocoSingletonBase):
                     ".//{http://purl.org/dc/" "elements/1.1/}title"
                 )
                 # Avoid using URIs as the title
-                if title in track["uri"] or title in urllib.parse.unquote(track["uri"]):
+                if title and (
+                    title in track["uri"] or title in urllib.parse.unquote(track["uri"])
+                ):
                     radio_track["title"] = trackinfo
                 else:
                     radio_track["title"] = title


### PR DESCRIPTION
This fixes an assumption that there will always be a `title` element when parsing radio-like stations (e.g., anything without a specific duration).

Example traceback:
```
    track_info = self.soco.get_current_track_info()
  File "/usr/local/lib/python3.9/site-packages/soco/core.py", line 1813, in get_current_track_info
    track.update(_parse_radio_metadata(metadata))
  File "/usr/local/lib/python3.9/site-packages/soco/core.py", line 1803, in _parse_radio_metadata
    if title in track["uri"] or title in urllib.parse.unquote(track["uri"]):
TypeError: 'in <string>' requires string as left operand, not NoneType
```