### PR TITLE
Use LRU caches for `from_didl_string` and `parse_event_xml`

### DIFF
--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -3,7 +3,7 @@ objects from both music library and music service data structures
 
 """
 
-
+from functools import lru_cache
 import logging
 from urllib.parse import urlparse
 
@@ -19,6 +19,7 @@ _LOG.addHandler(logging.NullHandler())
 _LOG.debug("%s imported", __name__)
 
 
+@lru_cache
 def from_didl_string(string):
     """Convert a unicode xml string to a list of `DIDLObjects <DidlObject>`.
 

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -19,7 +19,7 @@ _LOG.addHandler(logging.NullHandler())
 _LOG.debug("%s imported", __name__)
 
 
-@lru_cache
+@lru_cache()
 def from_didl_string(string):
     """Convert a unicode xml string to a list of `DIDLObjects <DidlObject>`.
 

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -9,6 +9,7 @@
 
 
 import atexit
+from functools import lru_cache
 import logging
 import socket
 import time
@@ -26,6 +27,7 @@ log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 # pylint: disable=too-many-branches
+@lru_cache()
 def parse_event_xml(xml_event):
     """Parse the body of a UPnP event.
 


### PR DESCRIPTION
The `from_didl_string()` function is regularly called with the same input data when processing subscription events. By caching the results with `lru_cache`, we can avoid some processing overhead and also allow equality comparisons downstream for metadata as identical `DidlObject` instances are re-sent.

This uses the default size of 128 entries.