### PR TITLE
Add a 'SnapshotGroupVolume' operation before reading/changing group volume

### DIFF
--- a/soco/groups.py
+++ b/soco/groups.py
@@ -133,6 +133,7 @@ class ZoneGroup:
 
         An integer between 0 and 100.
         """
+        self.coordinator.groupRenderingControl.SnapshotGroupVolume([("InstanceID", 0)])
         response = self.coordinator.groupRenderingControl.GetGroupVolume(
             [("InstanceID", 0)]
         )
@@ -142,6 +143,7 @@ class ZoneGroup:
     def volume(self, group_volume):
         group_volume = int(group_volume)
         group_volume = max(0, min(group_volume, 100))  # Coerce in range
+        self.coordinator.groupRenderingControl.SnapshotGroupVolume([("InstanceID", 0)])
         self.coordinator.groupRenderingControl.SetGroupVolume(
             [("InstanceID", 0), ("DesiredVolume", group_volume)]
         )
@@ -192,6 +194,7 @@ class ZoneGroup:
         """
         relative_group_volume = int(relative_group_volume)
         # Sonos automatically handles out-of-range values.
+        self.coordinator.groupRenderingControl.SnapshotGroupVolume([("InstanceID", 0)])
         resp = self.coordinator.groupRenderingControl.SetRelativeGroupVolume(
             [("InstanceID", 0), ("Adjustment", relative_group_volume)]
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1546,10 +1546,16 @@ class TestZoneGroupTopology:
         c = moco_zgs.group.coordinator
         c.groupRenderingControl.GetGroupVolume.return_value = {"CurrentVolume": 50}
         assert g.volume == 50
+        c.groupRenderingControl.SnapshotGroupVolume.assert_called_with(
+            [("InstanceID", 0)]
+        )
         c.groupRenderingControl.GetGroupVolume.assert_called_once_with(
             [("InstanceID", 0)]
         )
         g.volume = 75
+        c.groupRenderingControl.SnapshotGroupVolume.assert_called_with(
+            [("InstanceID", 0)]
+        )
         c.groupRenderingControl.SetGroupVolume.assert_called_once_with(
             [("InstanceID", 0), ("DesiredVolume", 75)]
         )
@@ -1574,6 +1580,9 @@ class TestZoneGroupTopology:
             "NewVolume": "75"
         }
         new_volume = g.set_relative_volume(25)
+        c.groupRenderingControl.SnapshotGroupVolume.assert_called_with(
+            [("InstanceID", 0)]
+        )
         c.groupRenderingControl.SetRelativeGroupVolume.assert_called_once_with(
             [("InstanceID", 0), ("Adjustment", 25)]
         )


### PR DESCRIPTION
This PR fixes #887.