### PR TITLE
Attempt to refresh expired music service tokens (fixes#890)

### DIFF
--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -235,7 +235,6 @@ class MusicServiceSoapClient:
                     ".//xmlns:privateKey", {"xmlns": self.namespace}
                 ).text
 
-                # If we didn't find the tokens, raise
                 if auth_token is None or private_key is None:
                     auth_token = exc.detail.findtext(".//authToken")
                     private_key = exc.detail.findtext(".//privateKey")


### PR DESCRIPTION
This will try to find first the token and the key into the namespace
and fallback to `findtext()` if nothing has been found.