### PR TITLE
Detect Sonos Radio as radio source

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -2875,6 +2875,7 @@ SOURCES = {
     r"^x-sonosapi-stream:": MUSIC_SRC_RADIO,
     r"^x-sonosapi-radio:": MUSIC_SRC_RADIO,
     r"^x-sonosapi-hls:": MUSIC_SRC_RADIO,
+    r"^x-sonos-http:sonos": MUSIC_SRC_RADIO,
     r"^aac:": MUSIC_SRC_RADIO,
     r"^hls-radio:": MUSIC_SRC_RADIO,
     r"^https?:": MUSIC_SRC_WEB_FILE,


### PR DESCRIPTION
This adds an entry for Sonos Radio URIs to properly categorize playing streams as radio for `music_source` related features.