### PR TITLE
Fix python iteration error

### DIFF
--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -355,7 +355,7 @@ class Subscription(SubscriptionBase):
         agent = BrowserLikeRedirectAgent(Agent(reactor))
 
         if headers:
-            for k in headers.keys():
+            for k in list(headers.keys()):
                 header = headers[k]
                 del headers[k]
                 if isinstance(header, (list,)):


### PR DESCRIPTION
This minor change fixes an iteration error I've encountered since upgrading to python 3.8. Without this fix, I get:

`builtins.RuntimeError: dictionary keys changed during iteration`