### PR TITLE
Check for empty token refresh to avoid exceptions

### DIFF
--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -230,10 +230,14 @@ class MusicServiceSoapClient:
                 # </detail>
                 auth_token = exc.detail.find(
                     ".//xmlns:authToken", {"xmlns": self.namespace}
-                ).text
+                )
+                if auth_token:
+                    auth_token = auth_token.text
                 private_key = exc.detail.find(
                     ".//xmlns:privateKey", {"xmlns": self.namespace}
-                ).text
+                )
+                if private_key:
+                    private_key = private_key.text
 
                 if auth_token is None or private_key is None:
                     auth_token = exc.detail.findtext(".//authToken")

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -231,12 +231,12 @@ class MusicServiceSoapClient:
                 auth_token = exc.detail.find(
                     ".//xmlns:authToken", {"xmlns": self.namespace}
                 )
-                if auth_token:
+                if auth_token is not None:
                     auth_token = auth_token.text
                 private_key = exc.detail.find(
                     ".//xmlns:privateKey", {"xmlns": self.namespace}
                 )
-                if private_key:
+                if private_key is not None:
                     private_key = private_key.text
 
                 if auth_token is None or private_key is None:


### PR DESCRIPTION
Minor followup to #893 which prevents exceptions if the `.find()` calls do not succeed and return `None`.

Example traceback this PR addresses:
```python
>>> my_music_service.search("artists", "M83")
Traceback (most recent call last):
  File "/src/SoCo/soco/music_services/music_service.py", line 199, in call
    result_elt = message.call()
  File "/src/SoCo/soco/soap.py", line 309, in call
    raise SoapFault(faultcode, faultstring, faultdetail)
soco.soap.SoapFault: Client.TokenRefreshRequired: Token has expired

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/src/SoCo/soco/music_services/music_service.py", line 916, in search
    response = self.soap_client.call(
  File "/src/SoCo/soco/music_services/music_service.py", line 233, in call
    auth_token = exc.detail.find(
AttributeError: 'NoneType' object has no attribute 'text'
```