### PR TITLE
Remove unnecessary `loginToken` during music service auth (fixes #891)

### DIFF
--- a/examples/play_local_files/play_local_files.py
+++ b/examples/play_local_files/play_local_files.py
@@ -164,7 +164,7 @@ def main():
         add_random_file_from_present_folder(args.ip, args.port, zone)
         # Remember the http server runs in its own daemonized thread, so it is
         # necessary to keep the main thread alive. So sleep for 3 years.
-        time.sleep(10 ** 8)
+        time.sleep(10**8)
     except KeyboardInterrupt:
         server.stop()
 

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -93,8 +93,7 @@ class MusicServiceSoapClient:
             "User-Agent": (
                 "Linux UPnP/1.0 Sonos/29.3-87071 (ICRU_iPhone7,1); "
                 "iOS/Version 8.2 (Build 12D508)"
-            )
-            # "Linux UPnP/1.0 Sonos/26.99-12345",
+            ),
         }
         self._device = device or discovery.any_soco()
         self._device_id = self._device.systemProperties.GetString(
@@ -129,21 +128,15 @@ class MusicServiceSoapClient:
         if music_service.auth_type in ("DeviceLink", "AppLink"):
             # Add context
             context = XML.Element("context")
-            # Add timezone offset e.g. "+01:00"
-            timezone = XML.SubElement(context, "timezone")
-            offset = (
-                time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
-            ) * -1
-            hours, minutes = offset / 3600, (offset % 3600) / 60
-            timezone.text = "{:0=+3.0f}:{:0>2.0f}".format(hours, minutes)
             credentials_header.append(context)
 
-            login_token = XML.Element("loginToken")
             # If no existing authentication is known, we do not add 'token' and 'key'
             # elements and the only operation the service can perform is to authenticate
             if self.token_store.has_token(
                 self.music_service.service_id, self._device.household_id
             ):
+                login_token = XML.Element("loginToken")
+
                 # Fill in from saved tokens
                 token_pair = self.token_store.load_token_pair(
                     self.music_service.service_id, self._device.household_id
@@ -153,9 +146,9 @@ class MusicServiceSoapClient:
                 token.text = token_pair[0]
                 key.text = token_pair[1]
 
-            household_id = XML.SubElement(login_token, "householdId")
-            household_id.text = self._household_id
-            credentials_header.append(login_token)
+                household_id = XML.SubElement(login_token, "householdId")
+                household_id.text = self._household_id
+                credentials_header.append(login_token)
 
         # TODO Implement UserID with user provided account, since we can't get the
         # accounts from the device anymore

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -29,7 +29,6 @@ Known problems:
 import logging
 from urllib.parse import quote as quote_url
 import json
-import time
 import requests
 from xmltodict import parse
 


### PR DESCRIPTION
According to the [Sonos documentation](https://developer.sonos.com/reference/sonos-music-api/getdevicelinkcode/), the `loginToken` section is not required during the `POST` to get the `regUrl` and the `linkCode`.

Here is the working payload for `DeviceLink`:

```xml
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:s="http://www.sonos.com/Services/1.1">
  <soap:Header>
    <s:credentials>
      <s:deviceId>XXX</s:deviceId>
      <s:deviceProvider>Sonos</s:deviceProvider>
    </s:credentials>
  </soap:Header>
  <soap:Body>
    <s:getDeviceLinkCode>
      <s:householdId>XXX</s:householdId>
    </s:getDeviceLinkCode>
  </soap:Body>
</soap:Envelope>
```

And for `AppLink`:

```xml
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:s="http://www.sonos.com/Services/1.1">
  <soap:Header>
    <s:credentials>
      <s:deviceId>XXXX</s:deviceId>
      <s:deviceProvider>Sonos</s:deviceProvider>
    </s:credentials>
  </soap:Header>
  <soap:Body>
    <s:getAppLink>
      <s:householdId>XXXX</s:householdId>
    </s:getAppLink>
  </soap:Body>
</soap:Envelope>
```

Tested with Amazon Music, Spotify, Plex, Deezer and Tidal.
