### PR TITLE
Rename `surround_ambient_enabled` to `surround_full_volume_enabled`

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -255,7 +255,7 @@ class SoCo(_SocoSingletonBase):
         night_mode
         dialog_mode
         surround_enabled
-        surround_ambient_enabled
+        surround_full_volume_enabled
         surround_volume_tv
         surround_volume_music
         soundbar_audio_input_format
@@ -1264,11 +1264,11 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
-    def surround_ambient_enabled(self):
-        """Return True if surround ambient mode is enabled for surround music
+    def surround_full_volume_enabled(self):
+        """Return True if surround full volume is enabled for surround music
         playback.
 
-        If False, playback on surround speakers uses full volume.
+        If False, playback on surround speakers uses ambient volume.
 
         Note: does not apply to TV playback.
         """
@@ -1278,12 +1278,14 @@ class SoCo(_SocoSingletonBase):
         response = self.renderingControl.GetEQ(
             [("InstanceID", 0), ("EQType", "SurroundMode")]
         )
-        return not int(response["CurrentValue"])
+        return int(response["CurrentValue"])
 
-    @surround_ambient_enabled.setter
+    @surround_full_volume_enabled.setter
     @only_on_soundbars
-    def surround_ambient_enabled(self, value):
-        """Toggle surround music playback mode. True = ambient mode.
+    def surround_full_volume_enabled(self, value):
+        """Toggle surround music playback mode.
+
+        True = full volume, False = ambient mode.
 
         Note: this does not apply to TV playback.
         """
@@ -1291,7 +1293,7 @@ class SoCo(_SocoSingletonBase):
             [
                 ("InstanceID", 0),
                 ("EQType", "SurroundMode"),
-                ("DesiredValue", int(not value)),
+                ("DesiredValue", int(value)),
             ]
         )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1359,7 +1359,7 @@ class TestRenderingControl:
         "prop,variable,type,min,max",
         [
             ("surround_enabled", "SurroundEnable", bool, None, None),
-            ("surround_ambient_enabled", "SurroundMode", bool, None, None),
+            ("surround_full_volume_enabled", "SurroundMode", bool, None, None),
             ("surround_volume_tv", "SurroundLevel", int, -15, 15),
             ("surround_volume_music", "MusicSurroundLevel", int, -15, 15),
         ],
@@ -1375,9 +1375,6 @@ class TestRenderingControl:
         def _assert_seteq_call(prop, variable, value, type):
             desired_value = value
             setattr(moco, prop, value)
-
-            if variable == "SurroundMode":  # negate desired value for surround mode
-                desired_value = not value
 
             moco.renderingControl.SetEQ.assert_any_call(
                 [


### PR DESCRIPTION
Reverses the boolean value to make it consistent with the eventing based value for easier integration for downstream users.

Example event (`surround_mode` is the variable in question, here shown in "full mode"):
```
{
   "audio_delay" : "0",
   "audio_delay_left_rear" : "1",
   "audio_delay_right_rear" : "1",
   "bass" : "0",
   "dialog_level" : "0",
   "headphone_connected" : "0",
   "height_channel_level" : "0",
   "loudness" : {
      "Master" : "1"
   },
   "music_surround_level" : "6",
   "mute" : {
      "LF" : "0",
      "Master" : "0",
      "RF" : "0"
   },
   "night_mode" : "0",
   "output_fixed" : "0",
   "preset_name_list" : "FactoryDefaults",
   "sonar_calibration_available" : "0",
   "sonar_enabled" : "0",
   "speaker_size" : "9",
   "sub_crossover" : "0",
   "sub_enabled" : "1",
   "sub_gain" : "0",
   "sub_polarity" : "0",
   "surround_enabled" : "1",
   "surround_level" : "3",
   "surround_mode" : "1",
   "treble" : "0",
   "volume" : {
      "LF" : "100",
      "Master" : "18",
      "RF" : "100"
   }
}
```

The name of the property is just a suggestion, maybe there's a better name for this?