### PR TITLE
Add support for Spotify podcast episodes/shows to ShareLinkPlugin

### DIFF
--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -82,7 +82,9 @@ class SpotifyShare(ShareClass):
     """Spotify share class."""
 
     def canonical_uri(self, uri):
-        match = re.search(r"spotify.*[:/](album|episode|playlist|show|track)[:/](\w+)", uri)
+        match = re.search(
+            r"spotify.*[:/](album|episode|playlist|show|track)[:/](\w+)", uri
+        )
         if match:
             return "spotify:" + match.group(1) + ":" + match.group(2)
 

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -41,10 +41,20 @@ class ShareClass:
                 "key": "00040000",
                 "class": "object.container.album.musicAlbum",
             },
+            "episode": {
+                "prefix": "",
+                "key": "00032020",
+                "class": "object.item.audioItem.musicTrack",
+            },
             "track": {
                 "prefix": "",
                 "key": "00032020",
                 "class": "object.item.audioItem.musicTrack",
+            },
+            "show": {
+                "prefix": "x-rincon-cpcontainer:1006206c",
+                "key": "1006206c",
+                "class": "object.container.playlistContainer",
             },
             "song": {
                 "prefix": "",
@@ -72,7 +82,7 @@ class SpotifyShare(ShareClass):
     """Spotify share class."""
 
     def canonical_uri(self, uri):
-        match = re.search(r"spotify.*[:/](album|track|playlist)[:/](\w+)", uri)
+        match = re.search(r"spotify.*[:/](album|episode|playlist|show|track)[:/](\w+)", uri)
         if match:
             return "spotify:" + match.group(1) + ":" + match.group(2)
 


### PR DESCRIPTION
Adds support for enqueuing podcast episodes and shows (i.e.., all episodes from a show) from Spotify URLs using `ShareLinkPlugin`. Although this does not seem supported from the Spotify music service interface in the native Sonos app, using base containers/classes seem to work fine.