### PR TITLE
Move mocked soco to conftest.py

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from unittest import mock
 import pytest
 import requests_mock
 
+from conftest import IP_ADDR
 from soco import SoCo
 from soco.data_structures import to_didl_string
 from soco.exceptions import (
@@ -12,35 +13,6 @@ from soco.exceptions import (
 )
 from soco.groups import ZoneGroup
 from soco.xml import XML
-
-IP_ADDR = "192.168.1.101"
-
-
-@pytest.fixture()
-def moco():
-    """A mock soco with fake services and hardcoded is_coordinator.
-
-    Allows calls to services to be tracked. Should not cause any network
-    access
-    """
-    services = (
-        "AVTransport",
-        "RenderingControl",
-        "DeviceProperties",
-        "ContentDirectory",
-        "ZoneGroupTopology",
-        "GroupRenderingControl",
-    )
-    patchers = [mock.patch("soco.core.{}".format(service)) for service in services]
-    for patch in patchers:
-        patch.start()
-    with mock.patch(
-        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
-    ) as is_coord:
-        is_coord = True  # noqa: F841
-        yield SoCo(IP_ADDR)
-    for patch in reversed(patchers):
-        patch.stop()
 
 
 @pytest.fixture()

--- a/tests/test_music_library.py
+++ b/tests/test_music_library.py
@@ -1,36 +1,4 @@
-from unittest import mock
-import pytest
-
-from soco import SoCo
 from soco.exceptions import SoCoUPnPException
-
-IP_ADDR = "192.168.1.101"
-
-
-@pytest.fixture()
-def moco():
-    """A mock soco with fake services and hardcoded is_coordinator.
-
-    Allows calls to services to be tracked. Should not cause any network
-    access
-    """
-    services = (
-        "AVTransport",
-        "RenderingControl",
-        "DeviceProperties",
-        "ContentDirectory",
-        "ZoneGroupTopology",
-    )
-    patchers = [mock.patch("soco.core.{}".format(service)) for service in services]
-    for patch in patchers:
-        patch.start()
-    with mock.patch(
-        "soco.SoCo.is_coordinator", new_callable=mock.PropertyMock
-    ) as is_coord:
-        is_coord = True  # noqa: F841
-        yield SoCo(IP_ADDR)
-    for patch in reversed(patchers):
-        patch.stop()
 
 
 class TestMusicLibrary:


### PR DESCRIPTION
Moves the redundant declarations of the `moco` fixture into `conftest.py`.

This was done in to prepare for a future test module which also needed the `moco` fixture.