### PR TITLE
Fix misnamed isort config param

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ all_files = 1
 universal = 1
 
 [isort]
-combine-star = 1
+combine_star = 1
 balanced_wrapping = 1
 default_section = FIRSTPARTY
 indent = '    '


### PR DESCRIPTION
When testing `isort` I noticed the `combine_star` config param had a typo: https://pycqa.github.io/isort/docs/configuration/options#combine-star.