### PR TITLE
Check metadata title for URI hints before discarding

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1956,10 +1956,29 @@ class SoCo(_SocoSingletonBase):
         # used if needed by the client to restart a given URI
         track["metadata"] = metadata
 
+        def _string_has_uri_components(string):
+            """Returns True if the string contains common URI components."""
+            if string.endswith(".m3u8"):
+                return True
+            try:
+                result = urllib.parse.urlparse(string)
+                return all([result.path, result.query])
+            except ValueError:
+                return False
+
         def _title_in_uri(title):
-            return title and (
-                title in track["uri"] or title in urllib.parse.unquote(track["uri"])
-            )
+            """Returns True if the title contains URI components
+            and the track title is repeated inside the track URI.
+
+            Used to avoid using invalid values in title metadata.
+            """
+            if not title:
+                return False
+
+            if not _string_has_uri_components(title):
+                return False
+
+            return title in track["uri"] or title in urllib.parse.unquote(track["uri"])
 
         def _parse_radio_metadata(metadata):
             """Try to parse trackinfo from radio metadata."""

--- a/soco/core.py
+++ b/soco/core.py
@@ -50,7 +50,12 @@ from .services import (
     AudioIn,
     GroupRenderingControl,
 )
-from .utils import really_utf8, camel_to_underscore, deprecated
+from .utils import (
+    camel_to_underscore,
+    deprecated,
+    really_utf8,
+    string_has_uri_components,
+)
 from .xml import XML
 
 AUDIO_INPUT_FORMATS = {
@@ -1956,16 +1961,6 @@ class SoCo(_SocoSingletonBase):
         # used if needed by the client to restart a given URI
         track["metadata"] = metadata
 
-        def _string_has_uri_components(string):
-            """Returns True if the string contains common URI components."""
-            if string.endswith(".m3u8"):
-                return True
-            try:
-                result = urllib.parse.urlparse(string)
-                return all([result.path, result.query])
-            except ValueError:
-                return False
-
         def _title_in_uri(title):
             """Returns True if the title contains URI components
             and the track title is repeated inside the track URI.
@@ -1975,7 +1970,7 @@ class SoCo(_SocoSingletonBase):
             if not title:
                 return False
 
-            if not _string_has_uri_components(title):
+            if not string_has_uri_components(title):
                 return False
 
             return title in track["uri"] or title in urllib.parse.unquote(track["uri"])

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -7,7 +7,7 @@
 import functools
 import re
 import warnings
-from urllib.parse import quote as quote_url
+from urllib.parse import quote as quote_url, urlparse
 
 from .xml import XML
 
@@ -201,3 +201,14 @@ def url_escape_path(path):
 def first_cap(string):
     """Return upper cased first character"""
     return string[0].upper() + string[1:]
+
+
+def string_has_uri_components(string):
+    """Returns True if the string contains common URI components."""
+    if string.endswith(".m3u8"):
+        return True
+    try:
+        result = urlparse(string)
+        return all([result.path, result.query])
+    except ValueError:
+        return False

--- a/tests/data/media_metadata_payloads/bbc.json
+++ b/tests/data/media_metadata_payloads/bbc.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "Track": "1",
+        "TrackDuration": "0:00:00",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_two.m3u8</res><r:streamContent></r:streamContent><dc:title>bbc_radio_two.m3u8</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>",
+        "TrackURI": "hls-radio://http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_two.m3u8",
+        "RelTime": "0:02:35",
+        "AbsTime": "NOT_IMPLEMENTED",
+        "RelCount": "2147483647",
+        "AbsCount": "2147483647"
+    },
+    "result": {
+        "title": "",
+        "artist": "",
+        "album": "",
+        "album_art": "",
+        "position": "0:02:35",
+        "playlist_position": "1",
+        "duration": "0:00:00",
+        "uri": "hls-radio://http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_two.m3u8",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_two.m3u8</res><r:streamContent></r:streamContent><dc:title>bbc_radio_two.m3u8</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>"
+    }
+}

--- a/tests/data/media_metadata_payloads/cifs.json
+++ b/tests/data/media_metadata_payloads/cifs.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "AbsCount" : "2147483647",
+        "AbsTime" : "NOT_IMPLEMENTED",
+        "RelCount" : "2147483647",
+        "RelTime" : "0:00:04",
+        "Track" : "1",
+        "TrackDuration" : "0:03:12",
+        "TrackMetaData" : "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"x-file-cifs:*:audio/mpeg:*\" duration=\"0:03:12\">x-file-cifs://192.168.1.3/sonos/music/Tired.mp3</res><r:streamContent></r:streamContent><upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2f192.168.1.3%2fsonos%2fmusic%2fTired.mp3&amp;v=265</upnp:albumArtURI><dc:title>Tired</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:creator>Alan Walker, Gavin James</dc:creator><upnp:album>Tired</upnp:album><upnp:originalTrackNumber>1</upnp:originalTrackNumber><r:albumArtist>Alan Walker, Gavin James</r:albumArtist></item></DIDL-Lite>",
+        "TrackURI" : "x-file-cifs://192.168.1.3/sonos/music/Tired.mp3"
+    },
+    "result": {
+        "title": "Tired",
+        "artist": "Alan Walker, Gavin James",
+        "album": "Tired",
+        "album_art": "http://192.168.1.101:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.1.3%2fsonos%2fmusic%2fTired.mp3&v=265",
+        "position": "0:00:04",
+        "playlist_position": "1",
+        "duration": "0:03:12",
+        "uri": "x-file-cifs://192.168.1.3/sonos/music/Tired.mp3",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"x-file-cifs:*:audio/mpeg:*\" duration=\"0:03:12\">x-file-cifs://192.168.1.3/sonos/music/Tired.mp3</res><r:streamContent></r:streamContent><upnp:albumArtURI>/getaa?u=x-file-cifs%3a%2f%2f192.168.1.3%2fsonos%2fmusic%2fTired.mp3&amp;v=265</upnp:albumArtURI><dc:title>Tired</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:creator>Alan Walker, Gavin James</dc:creator><upnp:album>Tired</upnp:album><upnp:originalTrackNumber>1</upnp:originalTrackNumber><r:albumArtist>Alan Walker, Gavin James</r:albumArtist></item></DIDL-Lite>"
+    }
+}

--- a/tests/data/media_metadata_payloads/pandora.json
+++ b/tests/data/media_metadata_payloads/pandora.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "Track": "1",
+        "TrackDuration": "0:02:00",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\"><res protocolInfo=\"http-get:*:audio/mp3:*\" duration=\"0:02:00\">x-sonos-http:VC1%3A%3AST%3A%3AST%3A1234567890123456789%3A%3ATR%3A12345678%3A%3A0%3A%3ARINCON_000123456789012341400%3A1234567890.mp3?sid=236&amp;flags=32768&amp;sn=1</res><upnp:albumArtURI>https://cont-1.p-cdn.us/images/09/33/95/c6/0123456789012345789/_500W_500H.jpg</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:title>Hit the Road Jack</dc:title><dc:creator>Ray Charles</dc:creator><upnp:album>True Genius</upnp:album><r:trackGain>-0.340000</r:trackGain><r:tiid>VC1::ST::ST:1234567890123456789::TR:12345678::0::RINCON_000123456789012341400:1234567890</r:tiid><r:rating><r:type>NONE</r:type><r:connotation>NEUTRAL</r:connotation></r:rating><r:policies mask=\"0x320008\" flags=\"0x20008\"/></item></DIDL-Lite>",
+        "TrackURI": "x-sonos-http:VC1%3A%3AST%3A%3AST%3A1234567890123456789%3A%3ATR%3A12345678%3A%3A0%3A%3ARINCON_000123456789012341400%3A1234567890.mp3?sid=236&flags=32768&sn=1",
+        "RelTime": "0:01:01",
+        "AbsTime": "NOT_IMPLEMENTED",
+        "RelCount": "2147483647",
+        "AbsCount": "2147483647"
+    },
+    "result": {
+        "title": "Hit the Road Jack",
+        "artist": "Ray Charles",
+        "album": "True Genius",
+        "album_art": "https://cont-1.p-cdn.us/images/09/33/95/c6/0123456789012345789/_500W_500H.jpg",
+        "position": "0:01:01",
+        "playlist_position": "1",
+        "duration": "0:02:00",
+        "uri": "x-sonos-http:VC1%3A%3AST%3A%3AST%3A1234567890123456789%3A%3ATR%3A12345678%3A%3A0%3A%3ARINCON_000123456789012341400%3A1234567890.mp3?sid=236&flags=32768&sn=1",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\"><res protocolInfo=\"http-get:*:audio/mp3:*\" duration=\"0:02:00\">x-sonos-http:VC1%3A%3AST%3A%3AST%3A1234567890123456789%3A%3ATR%3A12345678%3A%3A0%3A%3ARINCON_000123456789012341400%3A1234567890.mp3?sid=236&amp;flags=32768&amp;sn=1</res><upnp:albumArtURI>https://cont-1.p-cdn.us/images/09/33/95/c6/0123456789012345789/_500W_500H.jpg</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:title>Hit the Road Jack</dc:title><dc:creator>Ray Charles</dc:creator><upnp:album>True Genius</upnp:album><r:trackGain>-0.340000</r:trackGain><r:tiid>VC1::ST::ST:1234567890123456789::TR:12345678::0::RINCON_000123456789012341400:1234567890</r:tiid><r:rating><r:type>NONE</r:type><r:connotation>NEUTRAL</r:connotation></r:rating><r:policies mask=\"0x320008\" flags=\"0x20008\"/></item></DIDL-Lite>"
+    }
+}

--- a/tests/data/media_metadata_payloads/sonos_radio.json
+++ b/tests/data/media_metadata_payloads/sonos_radio.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "Track": "1",
+        "TrackDuration": "0:00:00",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\"><res protocolInfo=\"http-get:*:audio/mp4:*\">x-sonos-http:sonos%3a00000000000000000000000000000000%3a00%3a0000000000000%3ahead%3a0000%3a%3atra.0000000%3adefault%3aSD.mp4?sid=303&amp;flags=0&amp;sn=8</res><upnp:albumArtURI>https://sonosradio.imgix.net/placeholders/00000000000000000000000000000000_bg_09.png?w=200&amp;auto=format,compress?w=200&amp;mark-scale=93&amp;mark-align=center,middle&amp;mark=https%3A%2F%2Fapi.napster.com%2Fimageserver%2Fv2%2Falbums%2Falb.00000%2Fimages%2F600x600.jpg&amp;auto=format,compress</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:title>I&apos;m Not In Love</dc:title><dc:creator>10cc</dc:creator><r:trackGain>4.000000</r:trackGain><r:tiid>00000000000000000000000000000000:00:0000000000000:head:0000::tra.0000000:default:SD:6</r:tiid></item></DIDL-Lite>",
+        "TrackURI": "x-sonos-http:sonos%3a00000000000000000000000000000000%3a00%3a0000000000000%3ahead%3a0000%3a%3atra.0000000%3adefault%3aSD.mp4?sid=303&flags=0&sn=8",
+        "RelTime": "0:00:06",
+        "AbsTime": "NOT_IMPLEMENTED",
+        "RelCount": "2147483647",
+        "AbsCount": "2147483647"
+    },
+    "result": {
+        "title": "I'm Not In Love",
+        "artist": "10cc",
+        "album": "",
+        "album_art": "https://sonosradio.imgix.net/placeholders/00000000000000000000000000000000_bg_09.png?w=200&auto=format,compress?w=200&mark-scale=93&mark-align=center,middle&mark=https%3A%2F%2Fapi.napster.com%2Fimageserver%2Fv2%2Falbums%2Falb.00000%2Fimages%2F600x600.jpg&auto=format,compress",
+        "position": "0:00:06",
+        "playlist_position": "1",
+        "duration": "0:00:00",
+        "uri": "x-sonos-http:sonos%3a00000000000000000000000000000000%3a00%3a0000000000000%3ahead%3a0000%3a%3atra.0000000%3adefault%3aSD.mp4?sid=303&flags=0&sn=8",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\"><res protocolInfo=\"http-get:*:audio/mp4:*\">x-sonos-http:sonos%3a00000000000000000000000000000000%3a00%3a0000000000000%3ahead%3a0000%3a%3atra.0000000%3adefault%3aSD.mp4?sid=303&amp;flags=0&amp;sn=8</res><upnp:albumArtURI>https://sonosradio.imgix.net/placeholders/00000000000000000000000000000000_bg_09.png?w=200&amp;auto=format,compress?w=200&amp;mark-scale=93&amp;mark-align=center,middle&amp;mark=https%3A%2F%2Fapi.napster.com%2Fimageserver%2Fv2%2Falbums%2Falb.00000%2Fimages%2F600x600.jpg&amp;auto=format,compress</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><dc:title>I&apos;m Not In Love</dc:title><dc:creator>10cc</dc:creator><r:trackGain>4.000000</r:trackGain><r:tiid>00000000000000000000000000000000:00:0000000000000:head:0000::tra.0000000:default:SD:6</r:tiid></item></DIDL-Lite>"
+    }
+}

--- a/tests/data/media_metadata_payloads/tunein.json
+++ b/tests/data/media_metadata_payloads/tunein.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "Track": "1",
+        "TrackDuration": "0:00:00",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM </r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>",
+        "TrackURI": "hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&maxServers=2&partnertok=somesuperlongtoken&rj-ttl=5&DIST=TuneIn&rj-tok=000000000000000000000_0000",
+        "RelTime": "0:04:14",
+        "AbsTime": "NOT_IMPLEMENTED",
+        "RelCount": "2147483647",
+        "AbsCount": "2147483647"
+    },
+    "result": {
+        "title": "text=\"Spot Block End\" amgTrackId=\"1234567\"",
+        "artist": "",
+        "album": "",
+        "album_art": "",
+        "position": "0:04:14",
+        "playlist_position": "1",
+        "duration": "0:00:00",
+        "uri": "hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&maxServers=2&partnertok=somesuperlongtoken&rj-ttl=5&DIST=TuneIn&rj-tok=000000000000000000000_0000",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM </r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>"
+    }
+}

--- a/tests/test_metadata_parsing.py
+++ b/tests/test_metadata_parsing.py
@@ -1,0 +1,16 @@
+"""Tests for the media metadata parsing."""
+from conftest import DataLoader
+
+DATA_LOADER = DataLoader("media_metadata_payloads")
+MEDIA_TEST_SOURCES = ("bbc", "cifs", "pandora", "sonos_radio", "tunein")
+
+
+def test_metadata_parsing(moco):
+    for media_source in MEDIA_TEST_SOURCES:
+        metadata_info = DATA_LOADER.load_json("{}.json".format(media_source))
+        moco.avTransport.GetPositionInfo.return_value = metadata_info["input"]
+        assert moco.get_current_track_info() == metadata_info["result"]
+        moco.avTransport.GetPositionInfo.assert_called_once_with(
+            [("InstanceID", 0), ("Channel", "Master")]
+        )
+        moco.avTransport.reset_mock()


### PR DESCRIPTION
A change in #896 caused certain titles (most obviously from CIFS shares) to be incorrectly discarded as they were contained in the track URI. This was naive as even single-word strings would trigger the discard behavior. This PR adds an additional hurdle which requires the track to contain some URI components before it is discarded, such as path and query arguments or an `.m3u8` extension.

I've also added tests to validate expected processing of metadata from a variety of sources. This should help ensure we're going all we can to get correct results and also prevent future regressions.

Note: This includes the commit from #904 in order to pass tests. Once that PR is merged this can be rebased to simplify the changes.

Fixes: #903