### PR TITLE
Adjust metadata title discard logic

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -54,7 +54,6 @@ from .utils import (
     camel_to_underscore,
     deprecated,
     really_utf8,
-    string_has_uri_components,
 )
 from .xml import XML
 
@@ -2010,7 +2009,7 @@ class SoCo(_SocoSingletonBase):
             if not title:
                 return False
 
-            if not string_has_uri_components(title):
+            if self.music_source_from_uri(track["uri"]) == MUSIC_SRC_LIBRARY:
                 return False
 
             return title in track["uri"] or title in urllib.parse.unquote(track["uri"])

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -7,7 +7,7 @@
 import functools
 import re
 import warnings
-from urllib.parse import quote as quote_url, urlparse
+from urllib.parse import quote as quote_url
 
 from .xml import XML
 
@@ -201,14 +201,3 @@ def url_escape_path(path):
 def first_cap(string):
     """Return upper cased first character"""
     return string[0].upper() + string[1:]
-
-
-def string_has_uri_components(string):
-    """Returns True if the string contains common URI components."""
-    if string.endswith(".m3u8"):
-        return True
-    try:
-        result = urlparse(string)
-        return all([result.path, result.query])
-    except ValueError:
-        return False

--- a/tests/data/media_metadata_payloads/tunein_2.json
+++ b/tests/data/media_metadata_payloads/tunein_2.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "Track": "1",
+        "TrackDuration": "0:00:00",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"aac:*:application/octet-stream:*\">aac://http://lyd.nrk.no/nrk_radio_mp3_aac_h</res><r:streamContent>Martin Solveig + Ina Wroldsen med Places</r:streamContent><dc:title>nrk_radio_mp3_aac_h</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>",
+        "TrackURI": "aac://http://lyd.nrk.no/nrk_radio_mp3_aac_h",
+        "RelTime": "0:00:00",
+        "AbsTime": "NOT_IMPLEMENTED",
+        "RelCount": "2147483647",
+        "AbsCount": "2147483647"
+    },
+    "result": {
+        "title": "Martin Solveig + Ina Wroldsen med Places",
+        "artist": "",
+        "album": "",
+        "album_art": "",
+        "position": "0:00:00",
+        "playlist_position": "1",
+        "duration": "0:00:00",
+        "uri": "aac://http://lyd.nrk.no/nrk_radio_mp3_aac_h",
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"aac:*:application/octet-stream:*\">aac://http://lyd.nrk.no/nrk_radio_mp3_aac_h</res><r:streamContent>Martin Solveig + Ina Wroldsen med Places</r:streamContent><dc:title>nrk_radio_mp3_aac_h</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>"
+    }
+}

--- a/tests/test_metadata_parsing.py
+++ b/tests/test_metadata_parsing.py
@@ -2,7 +2,7 @@
 from conftest import DataLoader
 
 DATA_LOADER = DataLoader("media_metadata_payloads")
-MEDIA_TEST_SOURCES = ("bbc", "cifs", "pandora", "sonos_radio", "tunein")
+MEDIA_TEST_SOURCES = ("bbc", "cifs", "pandora", "sonos_radio", "tunein", "tunein_2")
 
 
 def test_metadata_parsing(moco):


### PR DESCRIPTION
Based on a new report, the logic added in #906 now seems overly specific. This adds an exception for CIFS tracks instead of validating the title as a URI fragment. All previous metadata processing results are unchanged and a newly added example now provides "correct" results.