### PR TITLE
Pass kwargs for ShareLink/Plex queue methods

### DIFF
--- a/soco/plugins/plex.py
+++ b/soco/plugins/plex.py
@@ -110,7 +110,7 @@ class PlexPlugin(SoCoPlugin):
         self.soco.play_from_queue(position - 1)
 
     def add_to_queue(
-        self, plex_media, position=0, as_next=False
+        self, plex_media, position=0, as_next=False, **kwargs
     ):  # pylint: disable=too-many-locals
         """Add the provided media to the speaker's playback queue.
 
@@ -204,7 +204,8 @@ class PlexPlugin(SoCoPlugin):
                 ("EnqueuedURIMetaData", metadata),
                 ("DesiredFirstTrackNumberEnqueued", position),
                 ("EnqueueAsNext", int(as_next)),
-            ]
+            ],
+            **kwargs
         )
         qnumber = response["FirstTrackNumberEnqueued"]
         return int(qnumber)

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -213,7 +213,7 @@ class ShareLinkPlugin(SoCoPlugin):
 
         return False
 
-    def add_share_link_to_queue(self, uri, position=0, as_next=False):
+    def add_share_link_to_queue(self, uri, position=0, as_next=False, **kwargs):
         """Add a Spotify/Tidal/... item to the queue.
 
         This is similar to soco.add_uri_to_queue() but will work with
@@ -265,7 +265,8 @@ class ShareLinkPlugin(SoCoPlugin):
                             ("EnqueuedURIMetaData", metadata),
                             ("DesiredFirstTrackNumberEnqueued", position),
                             ("EnqueueAsNext", int(as_next)),
-                        ]
+                        ],
+                        **kwargs
                     )
 
                     qnumber = response["FirstTrackNumberEnqueued"]


### PR DESCRIPTION
Allow passing `**kwargs` to the underlying service call for the ShareLink `add_share_link_to_queue()` and Plex `add_to_queue()` plugin methods. My primary reason is to allow differing `timeout` arguments for different services. Spotify, for example, seems to need a longer timeout when adding playlists with many tracks.