### PR TITLE
Update pylint config, remove unnecessary pragmas

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,13 +1,33 @@
 [MESSAGES CONTROL]
 
-# locally disable too-many-lines is only possible if the disable statement is
-# put into the first line, which is not good practice
-# see https://github.com/SoCo/SoCo/issues/127
-# duplicate code check disabled whilst refactoring of wimp plugin is in
-# progress
-disable=too-many-lines,locally-disabled,duplicate-code,too-few-public-methods,
-    bad-option-value,no-else-return,cyclic-import,too-many-public-methods,
-    bad-continuation, consider-using-f-string
+disable=
+# Reasons disabled:
+#  consider-using-f-string - str.format sometimes more readable
+#  cyclic-import - doesn't test if both import on load
+#  duplicate-code - unavoidable
+#  format - handled by black
+#  locally-disabled - it spams too much
+#  too-many-* - can harm readability
+#  too-few-* - can harm readability
+    bad-continuation,
+    bad-option-value,
+    consider-using-f-string,
+    cyclic-import,
+    duplicate-code,
+    format,
+    locally-disabled,
+    no-else-return,
+    too-few-public-methods,
+    too-many-ancestors,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-lines,
+    too-many-locals,
+    too-many-public-methods,
+    too-many-return-statements,
+    too-many-statements,
+    too-many-boolean-expressions
 
 
 [REPORTS]

--- a/soco/alarms.py
+++ b/soco/alarms.py
@@ -188,8 +188,6 @@ class Alarm:
     system. An alarm is not automatically saved. Call `save()` to do that.
     """
 
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         zone,

--- a/soco/core.py
+++ b/soco/core.py
@@ -132,7 +132,7 @@ class _ArgsSingleton(type):
         return cls._instances[key][args]
 
 
-class _SocoSingletonBase(  # pylint: disable=too-few-public-methods,no-init
+class _SocoSingletonBase(  # pylint: disable=no-init
     _ArgsSingleton("ArgsSingletonMeta", (object,), {})
 ):
 
@@ -177,7 +177,7 @@ def only_on_soundbars(function):
     return inner_function
 
 
-# pylint: disable=R0904,too-many-instance-attributes
+# pylint: disable=R0904
 class SoCo(_SocoSingletonBase):
 
     """A simple class for controlling a Sonos speaker.
@@ -759,7 +759,6 @@ class SoCo(_SocoSingletonBase):
         self.avTransport.Play([("InstanceID", 0), ("Speed", 1)])
 
     @only_on_master
-    # pylint: disable=too-many-arguments
     def play_uri(self, uri="", meta="", title="", start=True, force_radio=False):
         """Play a URI.
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1,4 +1,4 @@
-# pylint: disable=star-args, too-many-arguments, fixme, import-outside-toplevel
+# pylint: disable=star-args, fixme, import-outside-toplevel
 
 # Disable while we have Python 2.x compatability
 # pylint: disable=useless-object-inheritance,bad-mcs-classmethod-argument
@@ -170,7 +170,6 @@ class DidlResource:
 
     # Adapted from a class taken from the Python Brisa project - MIT licence.
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         uri,
@@ -534,7 +533,6 @@ class DidlObject(metaclass=DidlMetaClass):
             # way.
             setattr(self, key, value)
 
-    # pylint: disable=too-many-locals, too-many-branches
     @classmethod
     def from_element(cls, element):  # pylint: disable=R0914
         """Create an instance of this class from an ElementTree xml Element.

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -17,8 +17,6 @@ from .utils import really_utf8
 
 _LOG = logging.getLogger(__name__)
 
-# pylint: disable=too-many-locals, too-many-branches, too-many-statements
-
 
 def discover(
     timeout=5,
@@ -272,7 +270,6 @@ def by_name(name, allow_network_scan=False, **network_scan_kwargs):
     return None
 
 
-# pylint: disable=too-many-arguments
 def scan_network(
     include_invisible=False,
     multi_household=False,

--- a/soco/events.py
+++ b/soco/events.py
@@ -370,7 +370,7 @@ class Subscription(SubscriptionBase):
         """Cancels the auto_renew thread"""
         self._auto_renew_thread_flag.set()
 
-    # pylint: disable=no-self-use, too-many-arguments
+    # pylint: disable=no-self-use
     def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -155,7 +155,7 @@ class EventNotifyHandler(EventNotifyHandlerBase):
         log.debug("Event %s received for %s service at %s", seq, service_id, timestamp)
 
 
-class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-attributes
+class EventListener(EventListenerBase):
     """The Event Listener.
 
     Runs an http server which is an endpoint for ``NOTIFY``
@@ -475,7 +475,7 @@ class Subscription(SubscriptionBase):
             self._auto_renew_task.cancel()
             self._auto_renew_task = None
 
-    # pylint: disable=no-self-use, too-many-branches, too-many-arguments
+    # pylint: disable=no-self-use
     def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -26,7 +26,6 @@ from .xml import XML
 log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-# pylint: disable=too-many-branches
 @lru_cache()
 def parse_event_xml(xml_event):
     """Parse the body of a UPnP event.
@@ -159,8 +158,6 @@ class Event:
 
     """
 
-    # pylint: disable=too-few-public-methods, too-many-arguments
-
     def __init__(self, sid, seq, service, timestamp, variables=None):
         # Initialisation has to be done like this, because __setattr__ is
         # overridden, and will not allow direct setting of attributes
@@ -189,8 +186,6 @@ class EventNotifyHandlerBase:
     """Base class for `soco.events.EventNotifyHandler` and
     `soco.events_twisted.EventNotifyHandler`.
     """
-
-    # pylint: disable=too-many-public-methods
 
     def handle_notification(self, headers, content):
         """Handle a ``NOTIFY`` request by building an `Event` object and
@@ -338,8 +333,6 @@ class SubscriptionBase:
     """Base class for `soco.events.Subscription` and
     `soco.events_twisted.Subscription`
     """
-
-    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, service, event_queue=None):
         """
@@ -621,7 +614,7 @@ class SubscriptionBase:
         """
         raise NotImplementedError
 
-    # pylint: disable=missing-docstring, too-many-arguments
+    # pylint: disable=missing-docstring
     def _request(self, method, url, headers, success, unconditional=None):
         """Send a HTTP request
 

--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -335,7 +335,7 @@ class Subscription(SubscriptionBase):
             self._auto_renew_loop.stop()
             self._auto_renew_loop = None
 
-    # pylint: disable=no-self-use, too-many-branches, too-many-arguments
+    # pylint: disable=no-self-use
     def _request(self, method, url, headers, success, unconditional=None):
         """Sends an HTTP request.
 

--- a/soco/ms_data_structures.py
+++ b/soco/ms_data_structures.py
@@ -1,4 +1,4 @@
-# pylint: disable = star-args, too-many-arguments, unsupported-membership-test
+# pylint: disable = star-args, unsupported-membership-test
 # pylint: disable = not-an-iterable
 
 # Disable while we have Python 2.x compatability

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -179,8 +179,6 @@ class MusicLibrary:
         args = tuple(["radio_shows"] + list(args))
         return self.get_music_library_information(*args, **kwargs)
 
-        # pylint: disable=too-many-locals, too-many-arguments, too-many-branches
-
     def get_music_library_information(
         self,
         search_type,

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -15,7 +15,6 @@ from ..xml import XML
 log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-# pylint: disable=too-many-instance-attributes
 class Account:
 
     """An account for a Music Service.

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -1,5 +1,5 @@
 # Disable while we have Python 2.x compatability
-# pylint: disable=useless-object-inheritance, too-many-arguments
+# pylint: disable=useless-object-inheritance
 
 """Data structures for music service items
 
@@ -232,7 +232,7 @@ class MusicServiceItem(MetadataDictBase):
     def __init__(
         self,
         item_id,
-        desc,  # pylint: disable=too-many-arguments
+        desc,
         resources,
         uri,
         metadata_dict,

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -42,7 +42,7 @@ from ..xml import XML
 log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-# pylint: disable=too-many-instance-attributes, protected-access
+# pylint: disable=protected-access
 class MusicServiceSoapClient:
 
     """A SOAP client for accessing Music Services.
@@ -54,7 +54,7 @@ class MusicServiceSoapClient:
 
     def __init__(
         self, endpoint, timeout, music_service, token_store, device=None
-    ):  # pylint: disable=too-many-arguments
+    ):
         """
         Args:
             endpoint (str): The SOAP endpoint. A url.
@@ -341,7 +341,6 @@ class MusicServiceSoapClient:
         self._cached_soap_header = None
 
 
-# pylint: disable=too-many-instance-attributes
 class MusicService:
 
     """The MusicService class provides access to third party music services.

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -52,9 +52,7 @@ class MusicServiceSoapClient:
     yourself.
     """
 
-    def __init__(
-        self, endpoint, timeout, music_service, token_store, device=None
-    ):
+    def __init__(self, endpoint, timeout, music_service, token_store, device=None):
         """
         Args:
             endpoint (str): The SOAP endpoint. A url.

--- a/soco/plugins/plex.py
+++ b/soco/plugins/plex.py
@@ -109,9 +109,7 @@ class PlexPlugin(SoCoPlugin):
         position = self.add_to_queue(plex_media)
         self.soco.play_from_queue(position - 1)
 
-    def add_to_queue(
-        self, plex_media, position=0, as_next=False
-    ):  # pylint: disable=too-many-locals
+    def add_to_queue(self, plex_media, position=0, as_next=False):
         """Add the provided media to the speaker's playback queue.
 
         Args:

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -1,4 +1,4 @@
-# pylint: disable=star-args,too-many-locals
+# pylint: disable=star-args
 
 """Plugin for the Wimp music service (Service ID 20)"""
 

--- a/soco/services.py
+++ b/soco/services.py
@@ -95,7 +95,6 @@ class Vartype(namedtuple("VartypeBase", "datatype, default, list, range")):
         return self.datatype
 
 
-# pylint: disable=too-many-instance-attributes
 class Service:
     """A class representing a UPnP service.
 
@@ -695,7 +694,6 @@ class Service:
             )
         """
 
-        # pylint: disable=too-many-locals
         # pylint: disable=invalid-name
         ns = "{urn:schemas-upnp-org:service-1-0}"
         # get the scpd body as bytes, and feed directly to elementtree

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-instance-attributes
-
 # Disable while we have Python 2.x compatability
 # pylint: disable=useless-object-inheritance
 
@@ -155,7 +153,6 @@ class Snapshot:
         # return if device is a coordinator (helps usage)
         return self.is_coordinator
 
-    # pylint: disable=too-many-branches
     def restore(self, fade=False):
         """Restore the state of a device to that which was previously saved.
 

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -93,8 +93,6 @@ class SoapFault(SoCoException):
 #   </s:Body>
 # </s:Envelope>
 
-# pylint: disable=too-many-instance-attributes, too-many-arguments
-
 
 class SoapMessage:
 

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -136,7 +136,7 @@ class deprecated:
     """
 
     # pylint really doesn't like decorators!
-    # pylint: disable=invalid-name, too-few-public-methods
+    # pylint: disable=invalid-name
     # pylint: disable=missing-docstring
 
     def __init__(


### PR DESCRIPTION
This updates the pylint configuration to disable more `too-many-*` checks and add comments with reasoning.

Also removes any existing pragmas in the codebase which match these new global disables.