### PR TITLE
Add more detail on Dolby Atmos input formats

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -76,7 +76,7 @@ AUDIO_INPUT_FORMATS = {
     84934658: "Multichannel PCM 5.1",
     84934713: "Dolby 5.1",
     84934714: "Dolby Digital Plus 5.1",
-    84934721: "DTS 5.1"
+    84934721: "DTS 5.1",
 }
 
 # XML to zone attribute mappings for ZoneGroupState contents

--- a/soco/core.py
+++ b/soco/core.py
@@ -64,16 +64,19 @@ AUDIO_INPUT_FORMATS = {
     18: "Dolby 5.1",
     21: "No input",
     22: "No audio",
-    59: "Dolby Atmos",
-    63: "Dolby Atmos",
+    59: "Dolby Atmos (DD+)",
+    61: "Dolby Atmos (TrueHD)",
+    63: "Dolby Atmos (MAT 2.0)",
     33554434: "PCM 2.0",
     33554454: "PCM 2.0 no audio",
     33554488: "Dolby 2.0",
     33554490: "Dolby Digital Plus 2.0",
+    33554492: "Dolby TrueHD 2.0",
     33554494: "Dolby Multichannel PCM 2.0",
     84934658: "Multichannel PCM 5.1",
     84934713: "Dolby 5.1",
     84934714: "Dolby Digital Plus 5.1",
+    84934721: "DTS 5.1"
 }
 
 # XML to zone attribute mappings for ZoneGroupState contents


### PR DESCRIPTION
I felt like the different Atmos codecs could use a little more specificity, but open to everyone's opinion!

Also added Dolby TrueHD 2.0 and DTS 5.1.