### PR TITLE
Add convenience wrappers for surround_level properties

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1372,12 +1372,12 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def surround_level(self):
-        """Convenience wrapper for surround_volume_tv getter to match raw Sonos API."""
+        """Convenience getter for surround_volume_tv to match raw Sonos API."""
         return self.surround_volume_tv
 
     @surround_level.setter
     def surround_level(self, relative_volume):
-        """Convenience wrapper for surround_volume_tv setter to match raw Sonos API."""
+        """Convenience setter for surround_volume_tv to match raw Sonos API."""
         self.surround_volume_tv = relative_volume
 
     @property
@@ -1411,12 +1411,12 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def music_surround_level(self):
-        """Convenience wrapper for surround_volume_music getter to match raw Sonos API."""
+        """Convenience getter for surround_volume_music to match raw Sonos API."""
         return self.surround_volume_music
 
     @music_surround_level.setter
     def music_surround_level(self, relative_volume):
-        """Convenience wrapper for surround_volume_music setter to match raw Sonos API."""
+        """Convenience setter for surround_volume_music to match raw Sonos API."""
         self.surround_volume_music = relative_volume
 
     @property

--- a/soco/core.py
+++ b/soco/core.py
@@ -1371,6 +1371,16 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
+    def surround_level(self):
+        """Convenience wrapper for surround_volume_tv getter to match raw Sonos API."""
+        return self.surround_volume_tv
+
+    @surround_level.setter
+    def surround_level(self, relative_volume):
+        """Convenience wrapper for surround_volume_tv setter to match raw Sonos API."""
+        self.surround_volume_tv = relative_volume
+
+    @property
     def surround_volume_music(self):
         """Return the relative volume for surround speakers in music mode,
         in the range -15 to +15.
@@ -1398,6 +1408,16 @@ class SoCo(_SocoSingletonBase):
                 ("DesiredValue", relative_volume),
             ]
         )
+
+    @property
+    def music_surround_level(self):
+        """Convenience wrapper for surround_volume_music getter to match raw Sonos API."""
+        return self.surround_volume_music
+
+    @music_surround_level.setter
+    def music_surround_level(self, relative_volume):
+        """Convenience wrapper for surround_volume_music setter to match raw Sonos API."""
+        self.surround_volume_music = relative_volume
 
     @property
     def dialog_level(self):

--- a/soco/core.py
+++ b/soco/core.py
@@ -1342,6 +1342,16 @@ class SoCo(_SocoSingletonBase):
         )
 
     @property
+    def surround_mode(self):
+        """Convenience surround_full_volume_enabled getter to match raw Sonos API."""
+        return self.surround_full_volume_enabled
+
+    @surround_mode.setter
+    def surround_mode(self, value):
+        """Convenience surround_full_volume_enabled setter to match raw Sonos API."""
+        self.surround_full_volume_enabled = value
+
+    @property
     def surround_volume_tv(self):
         """Get the relative volume for surround speakers in TV
         playback mode. Ranges from -15 to +15."""


### PR DESCRIPTION
Adds wrappers to the TV & music `surround_volume` properties to allow direct mapping to the native subscription event payload names.

A similar solution was previously implemented in https://github.com/SoCo/SoCo/pull/874.