### PR TITLE
Explicitly set default timeouts for remaining `requests` calls

### DIFF
--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -9,7 +9,7 @@ import weakref
 
 import requests
 
-from .. import discovery
+from .. import config, discovery
 from ..xml import XML
 
 log = logging.getLogger(__name__)  # pylint: disable=C0103
@@ -75,9 +75,7 @@ class Account:
         device = soco or discovery.any_soco()
         log.debug("Fetching account data from %s", device)
         settings_url = "http://{}:1400/status/accounts".format(device.ip_address)
-        # Remove this as part of PR #925
-        # pylint: disable=W3101
-        result = requests.get(settings_url).content
+        result = requests.get(settings_url, timeout=config.REQUEST_TIMEOUT).content
         log.debug("Account data: %s", result)
         return result
 

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -32,6 +32,7 @@ from xml.sax.saxutils import escape
 
 import requests
 
+from . import config
 from .exceptions import SoCoException
 from .utils import prettify
 from .xml import XML
@@ -287,12 +288,13 @@ class SoapMessage:
         if _LOG.isEnabledFor(logging.DEBUG):
             _LOG.debug("Sending %s, %s", headers, prettify(data))
 
-        # Remove this as part of PR #925
-        # pylint: disable=W3101
+        timeout = self.request_args.pop("timeout", config.REQUEST_TIMEOUT)
+
         response = requests.post(
             self.endpoint,
             headers=headers,
             data=data.encode("utf-8"),
+            timeout=timeout,
             **self.request_args
         )
         _LOG.debug("Received %s, %s", response.headers, response.text)

--- a/tests/test_soap.py
+++ b/tests/test_soap.py
@@ -1,6 +1,7 @@
 """Tests for the soap module."""
 
 
+from soco.config import REQUEST_TIMEOUT
 from soco.soap import SoapMessage
 from soco.xml import XML
 from unittest import mock
@@ -142,6 +143,7 @@ def test_call():
                 "Content-Type": 'text/xml; charset="utf-8"',
                 "user-agent": "sonos",
             },
+            timeout=REQUEST_TIMEOUT,
             data=mock.ANY,
             other_arg=4,
         )


### PR DESCRIPTION
Explicitly add the `timeout` parameter to the remaining `requests` calls.

A current bump to `pylint` (which is not currently pinned) added this check which is making CI runs fail.