### PR TITLE
Attempt to fix flake8 runs on 3.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ wheel
 black >= 20.0b0
 requests-mock
 twine
-importlib-metadata<5; python_version == "3.6"
+importlib-metadata<5; python_version == "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ wheel
 black >= 20.0b0
 requests-mock
 twine
+importlib-metadata<5; python_version == "3.6"


### PR DESCRIPTION
This attempts to fix the CI by pinning a `flake8` dependency to an older version on py37.