### PR TITLE
Report "Dolby Multichannel PCM 5.1" input format

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -73,6 +73,7 @@ AUDIO_INPUT_FORMATS = {
     84934658: "Multichannel PCM 5.1",
     84934713: "Dolby 5.1",
     84934714: "Dolby Digital Plus 5.1",
+    84934718: "Dolby Multichannel PCM 5.1",
     84934721: "DTS 5.1",
 }
 


### PR DESCRIPTION
This PR adds the "Dolby Multichannel PCM 5.1" to the list of input formats SoCo can report on. 

Tested on a Beam Gen 2, input source was the Disney Plus. 