### PR TITLE
Add Python 3.12-dev to the test matrix

### DIFF
--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install graphviz
+          sudo apt-get install graphviz libxml2-dev libxslt-dev python-dev
           python -m pip install --upgrade pip
           pip install -e .
           pip install -r requirements.txt


### PR DESCRIPTION
- Add Python "3.12.-dev" to the test matrix
- Add `libxml2-dev libxslt-dev python-dev` to the Linux package install list to install libxml successfully under 3.12-dev