### PR TITLE
Allow standard multicast discovery to select by household_id

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -22,6 +22,7 @@ def discover(
     timeout=5,
     include_invisible=False,
     interface_addr=None,
+    household_id="Sonos",
     allow_network_scan=False,
     **network_scan_kwargs
 ):
@@ -52,6 +53,9 @@ def discover(
             the system default interface(s) for UDP multicast messages will be
             used. This is probably what you want to happen. Defaults to
             `None`.
+        household_id (str): Supply a Sonos Household ID to restrict discovery
+            to a specific household. Useful in multi-household networks. In
+            the default case the first player to respond will be used.
         allow_network_scan (bool, optional): If normal discovery fails, fall
             back to a scan of the attached network(s) to detect Sonos
             devices.
@@ -188,7 +192,7 @@ def discover(
             for _sock in response:
                 data, addr = _sock.recvfrom(1024)
                 _LOG.debug('Received discovery response from %s: "%s"', addr, data)
-                if b"Sonos" in data:
+                if really_utf8(household_id) in data:
                     # Now we have an IP, we can build a SoCo instance and query
                     # that player for the topology to find the other players.
                     # It is much more efficient to rely upon the Zone
@@ -203,10 +207,17 @@ def discover(
 
     if allow_network_scan:
         _LOG.debug("Falling back to network scan discovery")
-        return scan_network(
-            include_invisible=include_invisible,
-            **network_scan_kwargs,
-        )
+        if household_id == "Sonos":
+            return scan_network(
+                include_invisible=include_invisible,
+                **network_scan_kwargs,
+            )
+        else:
+            return scan_network_by_household_id(
+                household_id,
+                include_invisible=include_invisible,
+                **network_scan_kwargs,
+            )
 
 
 def any_soco(allow_network_scan=False, **network_scan_kwargs):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -442,7 +442,7 @@ def scan_network_by_household_id(
     network_scan_kwargs["multi_household"] = True
     zones = scan_network(include_invisible=include_invisible, **network_scan_kwargs)
     if zones:
-        zones = {zone for zone in zones if zone.household_id == household_id}
+        zones = {zone for zone in zones if household_id in zone.household_id}
     _LOG.debug("Returning zones: %s", zones)
     return zones
 


### PR DESCRIPTION
This resurrects and updates PR #644. It's a neat idea and avoids the requirement to use network scan discovery when multiple Sonos households are present on the network.

The PR adds an optional `household_id` parameter to `discover()`. If set, `discover()` will wait for a multicast discovery response that comes from a player in the selected household. If `allow_network_scan` is `True`, it will also use the selected household ID to filter responses.

Credit to @twosky2000 for the idea and initial implementation.