### PR TITLE
Increase 'scan_network' default timeout

### DIFF
--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -274,7 +274,7 @@ def scan_network(
     include_invisible=False,
     multi_household=False,
     max_threads=256,
-    scan_timeout=0.1,
+    scan_timeout=0.5,
     min_netmask=24,
     networks_to_scan=None,
 ):


### PR DESCRIPTION
On my networks I'm repeatedly finding that the default timeout of 0.1s when scanning the network for Sonos devices is too short to detect all devices reliably. Increasing the default timeout to 0.5s makes it significantly more reliable.

This only applies to the fallback `scan_network()` discovery method, not to any other network operations.