### PR TITLE
Mark `events_asyncio` handler as not running during stop

### DIFF
--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -281,6 +281,7 @@ class EventListener(EventListenerBase):
 
     async def async_stop(self):
         """Stop the listener."""
+        self.is_running = False
         if self.site:
             await self.site.stop()
             self.site = None


### PR DESCRIPTION
The `events_asyncio` event handler did not explicitly mark `self.is_running = False` during listener shutdown. This would cause attempts to restart the listener to fail after it was previously stopped:

```python
Traceback (most recent call last):
  ...
    sub = await soco.zoneGroupTopology.subscribe()
  File "/usr/local/lib/python3.10/site-packages/soco/events_asyncio.py", line 373, in _async_wrap_subscribe
    await subscribe(requested_timeout, auto_renew)
  File "/usr/local/lib/python3.10/site-packages/soco/events_asyncio.py", line 506, in _async_make_request
    response = await self.event_listener.session.request(
  AttributeError: 'NoneType' object has no attribute 'request'
```

If the `is_running` attribute is false, this guard to avoid starting an already-running listener is incorrectly enforced:
https://github.com/SoCo/SoCo/blob/17dfe4d383771910d73938a2305933c4341a23df/soco/events_asyncio.py#L371-L373

This leads to a subscription attempt before the `session` attribute has been initialized with a new `aiohttp.ClientSession` instance here:
https://github.com/SoCo/SoCo/blob/17dfe4d383771910d73938a2305933c4341a23df/soco/events_asyncio.py#L219

(which we'd never reach anyway because of this guard before it in `async_start()` here):
https://github.com/SoCo/SoCo/blob/17dfe4d383771910d73938a2305933c4341a23df/soco/events_asyncio.py#L205-L206