### PR TITLE
Unconditionally enable `has_subwoofer` on Amp devices

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -510,7 +510,14 @@ class SoCo(_SocoSingletonBase):
 
         Only provides reliable results when called on the soundbar
         or subwoofer devices if configured in a home theater setup.
+
+        Sonos Amp devices support a directly-connected 3rd party subwoofer
+        connected over RCA. This property is always enabled for those devices.
         """
+        model_name = self.speaker_info["model_name"].lower()
+        if model_name.endswith("sonos amp"):
+            return True
+
         self.zone_group_state.poll(self)
         channel_map = self._channel_map or self._ht_sat_chan_map
         if not channel_map:


### PR DESCRIPTION
External 3rd party subwoofers can be used on Amp devices by using an RCA cable. Details here: https://support.sonos.com/en-us/article/use-a-third-party-subwoofer-with-amp-or-connect-amp.

This change unconditionally enables the `has_subwoofer` property for Amp devices as it's not clear how to detect this with current API methods. This enables the various subwoofer controls which are guarded by that property.