### PR TITLE
Add `sub_crossover` controls

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -236,6 +236,7 @@ class SoCo(_SocoSingletonBase):
         is_soundbar
         is_satellite
         has_satellites
+        sub_crossover
         sub_enabled
         sub_gain
         is_subwoofer
@@ -1071,6 +1072,46 @@ class SoCo(_SocoSingletonBase):
                 ("InstanceID", 0),
                 ("EQType", "SurroundEnable"),
                 ("DesiredValue", int(enable)),
+            ]
+        )
+
+    @property
+    def sub_crossover(self):
+        """int: Reports the current subwoofer crossover frequency in Hz.
+
+        Only supported on Amp devices.
+        """
+        model_name = self.speaker_info["model_name"].lower()
+        if not model_name.endswith("sonos amp"):
+            return None
+
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "SubCrossover")]
+        )
+        return int(response["CurrentValue"])
+
+    @sub_crossover.setter
+    def sub_crossover(self, frequency):
+        """Set the subwoofer crossover frequency. Only supported on Amp devices.
+
+        :param frequency: Desired subwoofer crossover frequency in Hz
+        :type frequency: int
+        """
+        model_name = self.speaker_info["model_name"].lower()
+        if not model_name.endswith("sonos amp"):
+            message = "Subwoofer crossover not supported on this device."
+            raise NotSupportedException(message)
+
+        if not 50 <= frequency <= 110:
+            raise ValueError(
+                "Invalid value, must be integer between 50 and 110 inclusive"
+            )
+
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "SubCrossover"),
+                ("DesiredValue", int(frequency)),
             ]
         )
 


### PR DESCRIPTION
Adds support for subwoofer crossover controls. As of now, I believe this only applies to Amp devices.

Connect:Amp devices have a non-adjustable crossover at 80hz. I assume this will report it properly and that attempts to change will have no effect. Unfortunately I do not have a Connect:Amp (or Amp) to test with.