### PR TITLE
Rework ZoneGroupState cache strategy

### DIFF
--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -453,6 +453,8 @@ class SubscriptionBase:
             # Autorenew just before expiry, say at 85% of self.timeout seconds
             interval = self.timeout * 85 / 100
             self._auto_renew_start(interval)
+            if service.service_type == "ZoneGroupTopology":
+                service.soco.zone_group_state.extend_cache(self.timeout)
 
         # Lock out EventNotifyHandler during registration.
         # If events_twisted is used, this lock should always be
@@ -523,6 +525,8 @@ class SubscriptionBase:
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
             )
+            if self.service.service_type == "ZoneGroupTopology":
+                self.service.soco.zone_group_state.extend_cache(self.timeout)
 
         return self._request(
             "SUBSCRIBE",
@@ -653,6 +657,8 @@ class SubscriptionBase:
         # an attempt to unsubscribe fails
         self._has_been_unsubscribed = True
         self._timestamp = None
+        if self.service.service_type == "ZoneGroupTopology":
+            self.service.soco.zone_group_state.clear_cache()
         # Cancel any auto renew
         self._auto_renew_cancel()
         if msg:

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -436,6 +436,8 @@ class SubscriptionBase:
                 self.timeout = None
             else:
                 self.timeout = int(timeout.lstrip("Second-"))
+            if service.service_type == "ZoneGroupTopology":
+                service.soco.zone_group_state.extend_cache(self.timeout)
             self._timestamp = time.time()
             self.is_subscribed = True
             log.debug(
@@ -453,8 +455,6 @@ class SubscriptionBase:
             # Autorenew just before expiry, say at 85% of self.timeout seconds
             interval = self.timeout * 85 / 100
             self._auto_renew_start(interval)
-            if service.service_type == "ZoneGroupTopology":
-                service.soco.zone_group_state.extend_cache(self.timeout)
 
         # Lock out EventNotifyHandler during registration.
         # If events_twisted is used, this lock should always be
@@ -518,6 +518,8 @@ class SubscriptionBase:
                 self.timeout = None
             else:
                 self.timeout = int(timeout.lstrip("Second-"))
+            if self.service.service_type == "ZoneGroupTopology":
+                self.service.soco.zone_group_state.extend_cache(self.timeout)
             self._timestamp = time.time()
             self.is_subscribed = True
             log.debug(
@@ -525,8 +527,6 @@ class SubscriptionBase:
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
             )
-            if self.service.service_type == "ZoneGroupTopology":
-                self.service.soco.zone_group_state.extend_cache(self.timeout)
 
         return self._request(
             "SUBSCRIBE",


### PR DESCRIPTION
A followup to the ZoneGroupState caching added in https://github.com/SoCo/SoCo/pull/913.

The last `ZoneGroupState` payload received for a Sonos system can be used indefinitely as long as a `ZoneGroupTopology` subscription remains active. With long-lived subscriptions, idle devices will have periods of time where no ZoneGroupState payload is published and the ZGS cache will expire long before the subscription needs to be renewed. This will require a poll to request a fresh payload and on large systems, this will fail (see https://github.com/SoCo/SoCo/pull/937).

This change ties the cache timeout from a default timeout of 60s since the last payload arrival to the lifetime of an active `ZoneGroupTopology` subscription.