### PR TITLE
Add Arc Ultra support

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -2988,6 +2988,7 @@ SOURCES = {
 SOUNDBARS = (
     "arc",
     "arc sl",
+    "arc ultra",
     "beam",
     "playbase",
     "playbar",


### PR DESCRIPTION
The new Arc Ultra devices identify themselves as "Sonos Arc Ultra". This adds support for the soundbar-related controls.