### PR TITLE
Parse hyphens in track metadata

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -1961,6 +1961,8 @@ class SoCo(_SocoSingletonBase):
                 or ""
             )
 
+            index = trackinfo.find(" - ")
+
             if "TYPE=SNG|" in trackinfo:
                 # Examples from services:
                 #  Apple Music radio:
@@ -1974,9 +1976,9 @@ class SoCo(_SocoSingletonBase):
                     radio_track["artist"] = tags["ARTIST"]
                 if tags.get("ALBUM"):
                     radio_track["album"] = tags["ALBUM"]
-            elif (index := trackinfo.find(" - ")) > -1:
+            elif index > -1:
                 radio_track["artist"] = trackinfo[:index].strip()
-                radio_track["title"] = trackinfo[index + 3 :].strip()                    
+                radio_track["title"] = trackinfo[index + 3 :].strip()                  
             else:
                 # Might find some kind of title anyway in metadata
                 title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")

--- a/soco/core.py
+++ b/soco/core.py
@@ -1977,7 +1977,7 @@ class SoCo(_SocoSingletonBase):
                     radio_track["album"] = tags["ALBUM"]
             elif index > -1:
                 radio_track["artist"] = trackinfo[:index].strip()
-                radio_track["title"] = trackinfo[index + 3 :].strip()            
+                radio_track["title"] = trackinfo[index + 3 :].strip()
             else:
                 # Might find some kind of title anyway in metadata
                 title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")

--- a/soco/core.py
+++ b/soco/core.py
@@ -1960,12 +1960,8 @@ class SoCo(_SocoSingletonBase):
                 )
                 or ""
             )
-            index = trackinfo.find(" - ")
 
-            if index > -1:
-                radio_track["artist"] = trackinfo[:index].strip()
-                radio_track["title"] = trackinfo[index + 3 :].strip()
-            elif "TYPE=SNG|" in trackinfo:
+            if "TYPE=SNG|" in trackinfo:
                 # Examples from services:
                 #  Apple Music radio:
                 #   "TYPE=SNG|TITLE Couleurs|ARTIST M83|ALBUM Saturdays = Youth"
@@ -1978,6 +1974,9 @@ class SoCo(_SocoSingletonBase):
                     radio_track["artist"] = tags["ARTIST"]
                 if tags.get("ALBUM"):
                     radio_track["album"] = tags["ALBUM"]
+            elif (index := trackinfo.find(" - ")) > -1:
+                radio_track["artist"] = trackinfo[:index].strip()
+                radio_track["title"] = trackinfo[index + 3 :].strip()                    
             else:
                 # Might find some kind of title anyway in metadata
                 title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")

--- a/soco/core.py
+++ b/soco/core.py
@@ -1978,7 +1978,7 @@ class SoCo(_SocoSingletonBase):
                     radio_track["album"] = tags["ALBUM"]
             elif index > -1:
                 radio_track["artist"] = trackinfo[:index].strip()
-                radio_track["title"] = trackinfo[index + 3 :].strip()                  
+                radio_track["title"] = trackinfo[index + 3 :].strip()               
             else:
                 # Might find some kind of title anyway in metadata
                 title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")

--- a/soco/core.py
+++ b/soco/core.py
@@ -1960,8 +1960,8 @@ class SoCo(_SocoSingletonBase):
                 )
                 or ""
             )
-
             index = trackinfo.find(" - ")
+
             if "TYPE=SNG|" in trackinfo:
                 # Examples from services:
                 #  Apple Music radio:

--- a/soco/core.py
+++ b/soco/core.py
@@ -1962,7 +1962,6 @@ class SoCo(_SocoSingletonBase):
             )
 
             index = trackinfo.find(" - ")
-
             if "TYPE=SNG|" in trackinfo:
                 # Examples from services:
                 #  Apple Music radio:
@@ -1978,7 +1977,7 @@ class SoCo(_SocoSingletonBase):
                     radio_track["album"] = tags["ALBUM"]
             elif index > -1:
                 radio_track["artist"] = trackinfo[:index].strip()
-                radio_track["title"] = trackinfo[index + 3 :].strip()               
+                radio_track["title"] = trackinfo[index + 3 :].strip()            
             else:
                 # Might find some kind of title anyway in metadata
                 title = metadata.findtext(".//{http://purl.org/dc/elements/1.1/}title")

--- a/tests/data/media_metadata_payloads/tunein.json
+++ b/tests/data/media_metadata_payloads/tunein.json
@@ -2,7 +2,7 @@
     "input": {
         "Track": "1",
         "TrackDuration": "0:00:00",
-        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM </r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>",
+        "TrackMetaData": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM greatest - hits</r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>",
         "TrackURI": "hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&maxServers=2&partnertok=somesuperlongtoken&rj-ttl=5&DIST=TuneIn&rj-tok=000000000000000000000_0000",
         "RelTime": "0:04:14",
         "AbsTime": "NOT_IMPLEMENTED",
@@ -12,12 +12,12 @@
     "result": {
         "title": "text=\"Spot Block End\" amgTrackId=\"1234567\"",
         "artist": "",
-        "album": "",
+        "album": "greatest - hits",
         "album_art": "",
         "position": "0:04:14",
         "playlist_position": "1",
         "duration": "0:00:00",
         "uri": "hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&maxServers=2&partnertok=somesuperlongtoken&rj-ttl=5&DIST=TuneIn&rj-tok=000000000000000000000_0000",
-        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM </r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>"
+        "metadata": "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"><item id=\"-1\" parentID=\"-1\" restricted=\"true\"><res protocolInfo=\"sonos.com-hls-radio:*:audio/mpegurl:*\">hls-radio://http://n30a-e2.revma.ihrhls.com/zc000/hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</res><r:streamContent>TYPE=SNG|TITLE text=&quot;Spot Block End&quot; amgTrackId=&quot;1234567&quot;|ARTIST |ALBUM greatest - hits</r:streamContent><dc:title>hls.m3u8?TGT=TuneIn&amp;maxServers=2&amp;partnertok=somesuperlongtoken&amp;rj-ttl=5&amp;DIST=TuneIn&amp;rj-tok=000000000000000000000_0000</dc:title><upnp:class>object.item</upnp:class></item></DIDL-Lite>"
     }
 }


### PR DESCRIPTION
When a radio station provides track metadata using TYPE=SNG in the stream_content and the album name contains a hyphen the track title, artist and album would not be parsed correctly.

The fix is to check for TYPE=SNG first; rather than the presence of a hyphen.

Reference HA issue:  https://github.com/home-assistant/core/issues/136474