### PR TITLE
Adjust to allow both IPv4 and IPv6 addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ xmltodict
 ifaddr
 appdirs
 lxml
+netaddr

--- a/soco/core.py
+++ b/soco/core.py
@@ -5,6 +5,8 @@ the main entry to the SoCo functionality
 import datetime
 import logging
 import re
+from netaddr.strategy.ipv6 import valid_str as valid_ipv6
+from netaddr.strategy.ipv4 import valid_str as valid_ipv4
 from functools import wraps
 import urllib.parse
 from xml.sax.saxutils import escape
@@ -325,6 +327,9 @@ class SoCo(_SocoSingletonBase):
         # Note: Creation of a SoCo instance should be as cheap and quick as
         # possible. Do not make any network calls here
         super().__init__()
+        if valid_ipv4(ip_address) != True:
+            if valid_ipv6(ip_address) != True:
+                raise ValueError("Not a valid IP address string")
 
         #: The speaker's ip address
         self.ip_address = ip_address

--- a/soco/core.py
+++ b/soco/core.py
@@ -5,7 +5,6 @@ the main entry to the SoCo functionality
 import datetime
 import logging
 import re
-import socket
 from functools import wraps
 import urllib.parse
 from xml.sax.saxutils import escape

--- a/soco/core.py
+++ b/soco/core.py
@@ -5,13 +5,13 @@ the main entry to the SoCo functionality
 import datetime
 import logging
 import re
-from netaddr.strategy.ipv6 import valid_str as valid_ipv6
-from netaddr.strategy.ipv4 import valid_str as valid_ipv4
 from functools import wraps
 import urllib.parse
 from xml.sax.saxutils import escape
 from xml.parsers.expat import ExpatError
 import warnings
+from netaddr.strategy.ipv6 import valid_str as valid_ipv6
+from netaddr.strategy.ipv4 import valid_str as valid_ipv4
 import xmltodict
 
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -327,9 +327,8 @@ class SoCo(_SocoSingletonBase):
         # Note: Creation of a SoCo instance should be as cheap and quick as
         # possible. Do not make any network calls here
         super().__init__()
-        if valid_ipv4(ip_address) != True:
-            if valid_ipv6(ip_address) != True:
-                raise ValueError("Not a valid IP address string")
+        if valid_ipv4(ip_address) is False and valid_ipv6(ip_address) is False:
+            raise ValueError("Not a valid IP address string")
 
         #: The speaker's ip address
         self.ip_address = ip_address

--- a/soco/core.py
+++ b/soco/core.py
@@ -326,12 +326,7 @@ class SoCo(_SocoSingletonBase):
         # Note: Creation of a SoCo instance should be as cheap and quick as
         # possible. Do not make any network calls here
         super().__init__()
-        # Check if ip_address is a valid IPv4 representation.
-        # Sonos does not (yet) support IPv6
-        try:
-            socket.inet_aton(ip_address)
-        except OSError as error:
-            raise ValueError("Not a valid IP address string") from error
+
         #: The speaker's ip address
         self.ip_address = ip_address
         self.speaker_info = {}  # Stores information about the current speaker

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -10,6 +10,7 @@ import struct
 import ipaddress
 import threading
 import ifaddr
+from netaddr.strategy.ipv6 import valid_str as valid_ipv6
 
 from . import config
 from .utils import really_utf8
@@ -70,14 +71,18 @@ def discover(
 
         Create and return a socket with appropriate options set for multicast.
         """
+        if valid_ipv6(interface_addr):
+            _protocol = socket.AF_INET6
+        else:
+            _protocol = socket.AF_INET
 
-        _sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        _sock = socket.socket(_protocol, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         # UPnP v1.0 requires a TTL of 4
         _sock.setsockopt(
             socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("B", 4)
         )
         _sock.setsockopt(
-            socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(interface_addr)
+            socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_pton(_protocol, interface_addr)
         )
         return _sock
 
@@ -96,7 +101,10 @@ def discover(
 
     if interface_addr is not None:  # Use the specified interface, if any
         try:
-            _ = socket.inet_aton(interface_addr)
+            if valid_ipv6(interface_addr):
+                _ = socket.inet_pton(AF_INET6, interface_addr)
+            else:
+                _ = socket.inet_pton(AF_INET, interface_addr)
         except OSError as e:
             raise ValueError(
                 "{} is not a valid IP address string".format(interface_addr)
@@ -106,7 +114,7 @@ def discover(
             "Sending discovery packets on specified interface %s", interface_addr
         )
     else:  # Use all qualified, discovered network interfaces
-        addresses = _find_ipv4_addresses()
+        addresses = _find_ip_addresses()
         if len(addresses) == 0:
             _LOG.debug("No interfaces available for discovery")
             return None
@@ -661,32 +669,41 @@ def _find_ipv4_networks(min_netmask):
     return ipv4_net_list
 
 
-def _find_ipv4_addresses():
-    """Discover and return all the host's IPv4 addresses.
+def _find_ip_addresses():
+    """Discover and return all the host's IPv4 and IPv6 addresses.
 
     Helper function to return a set of IPv4 addresses associated
     with the network interfaces of this host. Loopback and link
     local addresses are excluded.
 
     Returns:
-        set: A set of IPv4 addresses (dotted decimal strings). Empty
+        set: A set of IPv4, IPv6 addresses (dotted decimal strings). Empty
         set if there are no addresses found.
     """
 
-    ipv4_addresses = set()
+    ip_addresses = set()
     for adapter in ifaddr.get_adapters():
         for ifaddr_network in adapter.ips:
             try:
                 ipaddress.IPv4Network(ifaddr_network.ip)
-            except ValueError:
-                # Not an IPv4 address
-                continue
-            ipv4_network = ipaddress.ip_network(ifaddr_network.ip)
-            if not ipv4_network.is_loopback and not ipv4_network.is_link_local:
-                ipv4_addresses.add(ifaddr_network.ip)
 
-    _LOG.debug("Set of attached IPs: %s", str(ipv4_addresses))
-    return ipv4_addresses
+                ipv4_network = ipaddress.ip_network(ifaddr_network.ip)
+                if not ipv4_network.is_loopback and not ipv4_network.is_link_local:
+                    ip_addresses.add(ifaddr_network.ip)
+            except ValueError:
+                try:
+                    ipaddress.IPv6Network(ifaddr_network.ip)
+
+                    ipv6_network = ipaddress.ip_network(ifaddr_network.ip)
+                    if not ipv6_network.is_loopback and not ipv6_network.is_link_local:
+                        ip_addresses.add(ifaddr_network.ip)
+                except ValueError:
+                    # Not an IPv6 address
+                    continue
+
+
+    _LOG.debug("Set of attached IPs: %s", str(ip_addresses))
+    return ip_addresses
 
 
 def _check_ip_and_port(ip_address, port, timeout):

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -82,7 +82,9 @@ def discover(
             socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("B", 4)
         )
         _sock.setsockopt(
-            socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_pton(_protocol, interface_addr)
+            socket.IPPROTO_IP,
+            socket.IP_MULTICAST_IF,
+            socket.inet_pton(_protocol, interface_addr),
         )
         return _sock
 
@@ -700,7 +702,6 @@ def _find_ip_addresses():
                 except ValueError:
                     # Not an IPv6 address
                     continue
-
 
     _LOG.debug("Set of attached IPs: %s", str(ip_addresses))
     return ip_addresses

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -679,7 +679,7 @@ def _find_ip_addresses():
     local addresses are excluded.
 
     Returns:
-        set: A set of IPv4, IPv6 addresses (dotted decimal strings). Empty
+        set: A set of IPv4, IPv6 addresses. Empty
         set if there are no addresses found.
     """
 

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -104,9 +104,9 @@ def discover(
     if interface_addr is not None:  # Use the specified interface, if any
         try:
             if valid_ipv6(interface_addr):
-                _ = socket.inet_pton(AF_INET6, interface_addr)
+                _ = socket.inet_pton(socket.AF_INET6, interface_addr)
             else:
-                _ = socket.inet_pton(AF_INET, interface_addr)
+                _ = socket.inet_pton(socket.AF_INET, interface_addr)
         except OSError as e:
             raise ValueError(
                 "{} is not a valid IP address string".format(interface_addr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from soco import SoCo
 
 IP_ADDR = "192.168.1.101"
+IP6_ADDR = "2001:db8:3333:4444:5555:6666:7777:8888"
 THISDIR = path.dirname(path.abspath(__file__))
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -385,6 +385,13 @@ class TestSoco:
         with pytest.raises(ValueError):
             _ = SoCo(bad_ip_addr)
 
+    @pytest.mark.parametrize(
+        "bad_ip_addr", ["not_ip", "2001:db8:3333:4444:5555:6666:7777:8888!"]
+    )
+    def test_soco_bad_ipv6(self, bad_ip_addr):
+        with pytest.raises(ValueError):
+            _ = SoCo(bad_ip_addr)
+
     def test_soco_init(self, moco):
         assert moco.ip_address == IP_ADDR
         assert moco.speaker_info == {}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -101,7 +101,10 @@ class TestDiscover:
         # Now test include_visible parameter. include_invisible=True should
         # result in calling SoCo.all_zones etc
         # Reset gethostbyname, to always return the same value
-        monkeypatch.setattr("socket.gethostbyname", Mock(return_value="2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"))
+        monkeypatch.setattr(
+            "socket.gethostbyname",
+            Mock(return_value="2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
+        )
         config.SOCO_CLASS.return_value = Mock(all_zones="ALL", visible_zones="VISIBLE")
         assert discover(include_invisible=True) == "ALL"
         assert discover(include_invisible=False) == "VISIBLE"
@@ -113,6 +116,7 @@ class TestDiscover:
         discover(timeout=1)
         # Check no SoCo instance created
         config.SOCO_CLASS.assert_not_called
+
 
 def test_by_name():
     """Test the by_name method"""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,6 +5,8 @@ import ifaddr
 
 from collections import OrderedDict
 
+from conftest import IP_ADDR, IP6_ADDR
+
 from unittest.mock import patch, MagicMock as Mock, call
 
 from soco import discover
@@ -19,7 +21,6 @@ from soco.discovery import (
     scan_network,
 )
 
-IP_ADDR = "192.168.1.101"
 TIMEOUT = 5
 
 
@@ -75,7 +76,7 @@ class TestDiscover:
         sock = socket.socket.return_value
         sock.recvfrom.return_value = (
             b"SERVER: Linux UPnP/1.0 Sonos/26.1-76230 (ZPS3)",
-            [IP_ADDR],
+            [IP6_ADDR],
         )  # (data, # address)
         # Return a couple of IP addresses from _find_ip_addresses()
         monkeypatch.setattr(
@@ -96,7 +97,7 @@ class TestDiscover:
         # select called with the relevant timeout
         select.select.assert_called_with([sock], [], [], min(TIMEOUT, 0.1))
         # SoCo should be created with the IP address received
-        config.SOCO_CLASS.assert_called_with(IP_ADDR)
+        config.SOCO_CLASS.assert_called_with(IP6_ADDR)
 
         # Now test include_visible parameter. include_invisible=True should
         # result in calling SoCo.all_zones etc


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/139617

- Adds a net_addr dependency, I haven't looked into if its actually necessary or if its better to just do the try-catch parsing approach/make wrappers
- Adjust discovery to work on IPv6, adding a simulated test case
- Does not address other areas in the code
- Swaps to inet_pton() in various places

Not tested with a real device.

I have a busy work week; so feel free to take over this PR/branch if there's other areas that should be addressed and you don't feel like waiting ~6-7 days.