### PR TITLE
Added the missing audio format "Dolby Digital Plus 7.1"

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -76,6 +76,7 @@ AUDIO_INPUT_FORMATS = {
     84934716: "Dolby TrueHD 5.1",
     84934718: "Dolby Multichannel PCM 5.1",
     84934721: "DTS 5.1",
+    118489146: "Dolby Digital Plus 7.1",
 }
 
 _LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Hello everyone,
This is my first participation in this repo !
In short: I added the missing audio format "Dolby Digital Plus 7.1".

In detail, I added the Sonos integration in Home Assistant, and while watching a movie, I noticed that "Unknown audio input format: 118489146" was displayed in HA (using the Sonos Arc Ultra with surround speakers):
![image](https://github.com/user-attachments/assets/55baaf61-aad3-4a0b-9fce-154dd8084fcd)

In the Sonos app, the audio format displayed was "Dolby Digital Plus 7.1":
![image](https://github.com/user-attachments/assets/172fac6b-c7ab-41a1-a3a9-080509898ae1)

So I added the missing audio format ID in the audio formats list.

Thank you for your consideration for this PR !
Best regards from Switzerland 🇨🇭 !