### PR TITLE
Fix: Restore queue from snapshot when uri attribute is missing -  mp3 playing via http

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -291,7 +291,16 @@ class Snapshot:
             # Now loop around all the queue entries adding them
             for queue_group in self.queue:
                 for queue_item in queue_group:
-                    self.device.add_uri_to_queue(queue_item.uri)
+                    uri = None
+                    # Get Uri from Item if availiable
+                    if hasattr(queue_item, 'uri') and queue_item.uri:
+                        uri = queue_item.uri
+                    # Get Uri from Item.resources if availiable
+                    elif hasattr(queue_item, 'resources') and len(queue_item.resources) > 0 and hasattr(queue_item.resources[0],'uri'):
+                        uri = queue_item.resources[0].uri
+                    # Add uri to queue if found
+                    if uri:
+                        self.device.add_uri_to_queue(uri)
 
     def __enter__(self):
         self.snapshot()

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -296,7 +296,11 @@ class Snapshot:
                     if hasattr(queue_item, 'uri') and queue_item.uri:
                         uri = queue_item.uri
                     # Get Uri from Item.resources if availiable
-                    elif hasattr(queue_item, 'resources') and len(queue_item.resources) > 0 and hasattr(queue_item.resources[0],'uri'):
+                    elif (
+                        hasattr(queue_item, 'resources') and
+                        len(queue_item.resources) > 0 and
+                        hasattr(queue_item.resources[0], 'uri')
+                    ):
                         uri = queue_item.resources[0].uri
                     # Add uri to queue if found
                     if uri:

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -291,20 +291,7 @@ class Snapshot:
             # Now loop around all the queue entries adding them
             for queue_group in self.queue:
                 for queue_item in queue_group:
-                    uri = None
-                    # Get Uri from Item if availiable
-                    if hasattr(queue_item, 'uri') and queue_item.uri:
-                        uri = queue_item.uri
-                    # Get Uri from Item.resources if availiable
-                    elif (
-                        hasattr(queue_item, 'resources') and
-                        len(queue_item.resources) > 0 and
-                        hasattr(queue_item.resources[0], 'uri')
-                    ):
-                        uri = queue_item.resources[0].uri
-                    # Add uri to queue if found
-                    if uri:
-                        self.device.add_uri_to_queue(uri)
+                    self.device.add_uri_to_queue(queue_item.get_uri())
 
     def __enter__(self):
         self.snapshot()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,63 @@
+"""Tests for the snapshot module."""
+
+from unittest.mock import MagicMock, call
+
+from soco.data_structures import DidlMusicTrack, DidlResource
+from soco.snapshot import Snapshot
+
+
+def make_track(uri, protocol_info="http-get:*:audio/mpeg:*"):
+    """Create a DidlMusicTrack with a resource URI, as returned by get_queue."""
+    resource = DidlResource(uri=uri, protocol_info=protocol_info)
+    return DidlMusicTrack(
+        title="Test Track",
+        parent_id="Q:0",
+        item_id="Q:0/1",
+        resources=[resource],
+    )
+
+
+def test_restore_queue_calls_add_uri_to_queue(moco):
+    """_restore_queue adds each queue item's URI via add_uri_to_queue."""
+    track1 = make_track("x-file-cifs://nas/music/a.mp3")
+    track2 = make_track("http://192.168.1.50/music/b.mp3")
+
+    snap = Snapshot(moco, snapshot_queue=True)
+    snap.queue = [[track1, track2]]
+
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+
+    moco.add_uri_to_queue.assert_has_calls(
+        [
+            call("x-file-cifs://nas/music/a.mp3"),
+            call("http://192.168.1.50/music/b.mp3"),
+        ]
+    )
+
+
+def test_restore_queue_http_uri(moco):
+    """Tracks added via HTTP (e.g. WebDAV) are correctly restored (issue #983).
+
+    DidlMusicTrack has no direct .uri attribute; the URI lives in resources[0].
+    get_uri() must be used instead.
+    """
+    http_track = make_track("http://192.168.1.50/share/song.mp3")
+    assert not hasattr(http_track, "uri"), "DidlMusicTrack should not have .uri"
+    assert http_track.get_uri() == "http://192.168.1.50/share/song.mp3"
+
+    snap = Snapshot(moco, snapshot_queue=True)
+    snap.queue = [[http_track]]
+
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+
+    moco.add_uri_to_queue.assert_called_once_with("http://192.168.1.50/share/song.mp3")
+
+
+def test_restore_queue_skipped_when_none(moco):
+    """_restore_queue does nothing when queue was not snapshotted."""
+    snap = Snapshot(moco, snapshot_queue=False)
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+    moco.add_uri_to_queue.assert_not_called()


### PR DESCRIPTION
When playing files directly via HTTP (from a WebDAV share), restoring the queue from a snapshot fails with the following error:

File "site-packages/soco/snapshot.py", line 294, in _restore_queue
    self.device.add_uri_to_queue(queue_item.uri)
                                                     ^^^^^^^^^^^^
AttributeError: 'DidlMusicTrack' object has no attribute 'uri'

[I added the files to the queue by using add_uri_to_queue("http://...")]

This pull request addresses the issue by attempting to retrieve the URI from the item's resources if the uri attribute is not directly available. This ensures compatibility with tracks added from sources like HTTP.