### PR TITLE
Arc Ultra Soundbar SpeechEnhanceEnabled property

### DIFF
--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import SoCoException, UnknownSoCoException
 __author__ = "The SoCo-Team <python-soco@googlegroups.com>"
 # Please increment the version number and add the suffix "-dev" after
 # a release, to make it possible to identify in-development code
-__version__ = "0.31.0-dev"
+__version__ =  "0.30.9"
 __website__ = "https://github.com/SoCo/SoCo"
 __license__ = "MIT License"
 

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import SoCoException, UnknownSoCoException
 __author__ = "The SoCo-Team <python-soco@googlegroups.com>"
 # Please increment the version number and add the suffix "-dev" after
 # a release, to make it possible to identify in-development code
-__version__ =  "0.30.9"
+__version__ =  "0.31.0-dev"
 __website__ = "https://github.com/SoCo/SoCo"
 __license__ = "MIT License"
 

--- a/soco/__init__.py
+++ b/soco/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import SoCoException, UnknownSoCoException
 __author__ = "The SoCo-Team <python-soco@googlegroups.com>"
 # Please increment the version number and add the suffix "-dev" after
 # a release, to make it possible to identify in-development code
-__version__ =  "0.31.0-dev"
+__version__ = "0.31.0-dev"
 __website__ = "https://github.com/SoCo/SoCo"
 __license__ = "MIT License"
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -1492,7 +1492,7 @@ class SoCo(_SocoSingletonBase):
 
         True if on, False if off, None if not supported.
         """
-        if not self.is_soundbar:
+        if not self.is_arc_ultra_soundbar:
             return None
 
         response = self.renderingControl.GetEQ(

--- a/soco/core.py
+++ b/soco/core.py
@@ -1479,6 +1479,39 @@ class SoCo(_SocoSingletonBase):
         self.dialog_mode = dialog_level
 
     @property
+    def speech_enhance_enabled(self):
+        """bool: The speaker's dialog mode.
+
+        True if on, False if off, None if not supported.
+        """
+        if not self.is_soundbar:
+            return None
+
+        response = self.renderingControl.GetEQ(
+            [("InstanceID", 0), ("EQType", "SpeechEnhanceEnabled")]
+        )
+        return bool(int(response["CurrentValue"]))
+
+    @speech_enhance_enabled.setter
+    @only_on_soundbars
+    def speech_enhance_enabled(self, speech_mode):
+        """Switch on/off the speaker's dialog mode.
+
+        :param dialog_mode: Enable or disable dialog mode
+        :type dialog_mode: bool
+        :raises NotSupportedException: If the device does not support
+        dialog mode.
+        """
+        self.renderingControl.SetEQ(
+            [
+                ("InstanceID", 0),
+                ("EQType", "SpeechEnhanceEnabled"),
+                ("DesiredValue", int(speech_mode)),
+            ]
+        )
+
+
+    @property
     def trueplay(self):
         """bool: Whether Trueplay is enabled on this device.
         True if on, False if off.

--- a/soco/core.py
+++ b/soco/core.py
@@ -557,6 +557,14 @@ class SoCo(_SocoSingletonBase):
         return self._is_soundbar
 
     @property
+    def is_arc_ultra_soundbar(self):
+        """bool: Is this zone an arc ultra sound bar?"""
+        if not self.speaker_info:
+            self.get_speaker_info()
+
+        return self.speaker_info["model_name"].lower().endswith(ARC_ULTRA_PRODUCT_NAME)
+
+    @property
     def play_mode(self):
         """str: The queue's play mode.
 
@@ -1480,7 +1488,7 @@ class SoCo(_SocoSingletonBase):
 
     @property
     def speech_enhance_enabled(self):
-        """bool: The speaker's dialog mode.
+        """bool: The speaker's speech enhancement mode.
 
         True if on, False if off, None if not supported.
         """
@@ -1495,13 +1503,17 @@ class SoCo(_SocoSingletonBase):
     @speech_enhance_enabled.setter
     @only_on_soundbars
     def speech_enhance_enabled(self, speech_mode):
-        """Switch on/off the speaker's dialog mode.
+        """Switch on/off the arc ultra soundbar speech enhancement.
 
-        :param dialog_mode: Enable or disable dialog mode
-        :type dialog_mode: bool
+        :param speech_mode: Enable or disable dialog mode
+        :type speech_mode: bool
         :raises NotSupportedException: If the device does not support
-        dialog mode.
+        speech enhancement.
         """
+        if not self.is_arc_ultra_soundbar:
+            raise NotSupportedException(
+                "The device is not a arc ultra soundbar and doesn't support speech_enhance_enabled."
+            )        
         self.renderingControl.SetEQ(
             [
                 ("InstanceID", 0),
@@ -3030,6 +3042,8 @@ SOUNDBARS = (
     "ray",
     "sonos amp",
 )
+
+ARC_ULTRA_PRODUCT_NAME = "arc ultra"
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo

--- a/soco/core.py
+++ b/soco/core.py
@@ -1511,7 +1511,7 @@ class SoCo(_SocoSingletonBase):
         """
         if not self.is_arc_ultra_soundbar:
             raise NotSupportedException(
-                "The device is not a arc ultra soundbar and doesn't support speech_enhance_enabled."
+                "The device not a arc ultra and doesn't support speech_enhance_enabled."
             )
         self.renderingControl.SetEQ(
             [

--- a/soco/core.py
+++ b/soco/core.py
@@ -1512,7 +1512,7 @@ class SoCo(_SocoSingletonBase):
         if not self.is_arc_ultra_soundbar:
             raise NotSupportedException(
                 "The device is not a arc ultra soundbar and doesn't support speech_enhance_enabled."
-            )        
+            )
         self.renderingControl.SetEQ(
             [
                 ("InstanceID", 0),
@@ -1520,7 +1520,6 @@ class SoCo(_SocoSingletonBase):
                 ("DesiredValue", int(speech_mode)),
             ]
         )
-
 
     @property
     def trueplay(self):

--- a/soco/core.py
+++ b/soco/core.py
@@ -1501,7 +1501,6 @@ class SoCo(_SocoSingletonBase):
         return bool(int(response["CurrentValue"]))
 
     @speech_enhance_enabled.setter
-    @only_on_soundbars
     def speech_enhance_enabled(self, speech_mode):
         """Switch on/off the arc ultra soundbar speech enhancement.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -519,7 +519,6 @@ class TestSoco:
     @mock.patch("soco.core.requests")
     def test_soco_speech_enhance_mode(self, mocr, moco_zgs):
         moco_zgs.renderingControl.GetEQ.reset_mock()
-
         response = mock.MagicMock()
         mocr.get.return_value = response
         response.content = self.device_description

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -551,7 +551,6 @@ class TestSoco:
         )
 
 
-
 class TestAVTransport:
     @pytest.mark.parametrize(
         "playmode",
@@ -1323,7 +1322,6 @@ class TestRenderingControl:
         moco.renderingControl.SetEQ.assert_called_once_with(
             [("InstanceID", 0), ("EQType", "AudioDelay"), ("DesiredValue", 1)]
         )
-
 
     def test_soco_fixed_volume(self, moco):
         moco.renderingControl.GetSupportsOutputFixed.return_value = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1283,6 +1283,7 @@ class TestRenderingControl:
                 moco.trueplay = True
 
     def test_soco_soundbar_audio_input_format(self, moco):
+        moco._is_soundbar = True
         moco.deviceProperties.GetZoneInfo.return_value = {"HTAudioIn": "0"}
         assert moco.soundbar_audio_input_format_code == 0
         assert moco.soundbar_audio_input_format == "No input connected"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -523,19 +523,15 @@ class TestSoco:
         mocr.get.return_value = response
         response.content = self.device_description
 
-        # Data is available only when a soundbar. Test nout a soundbar first
+        # Data is available only when an arc ultra soundbar. Test not a soundbar first
         moco_zgs._is_soundbar = False
         assert moco_zgs.speech_enhance_enabled is None
         assert moco_zgs.renderingControl.GetEQ.call_count == 0
         with pytest.raises(NotSupportedException):
             moco_zgs.speech_enhance_enabled = 1
-        moco_zgs._is_soundbar = True
-        # Setting should raise because its not an arc ultra soundbar
-        with pytest.raises(NotSupportedException):
-            moco_zgs.speech_enhance_enabled = 1
 
-        # Data should be available when a soundbar
-        moco_zgs.speaker_info["model_name"] = ARC_ULTRA_PRODUCT_NAME
+        # Data should be available when an arc ultra soundbar
+        moco_zgs.speaker_info["model_name"] = "speaker prefix " + ARC_ULTRA_PRODUCT_NAME
         moco_zgs.renderingControl.GetEQ.return_value = {"CurrentValue": "1"}
         assert moco_zgs.speech_enhance_enabled == 1
         moco_zgs.renderingControl.GetEQ.assert_called_once_with(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1288,6 +1288,33 @@ class TestRenderingControl:
             [("InstanceID", 0), ("EQType", "AudioDelay"), ("DesiredValue", 1)]
         )
 
+    def test_soco_speech_enhance_mode(self, moco):
+            moco.renderingControl.GetEQ.reset_mock()
+            moco._is_soundbar = False
+            assert moco.speech_enhance_enabled is None
+            assert moco.renderingControl.GetEQ.call_count == 0
+
+            with pytest.raises(NotSupportedException):
+                moco.speech_enhance_enabled = 1
+
+            moco._is_soundbar = True
+
+            moco.renderingControl.GetEQ.return_value = {"CurrentValue": "1"}
+            assert moco.speech_enhance_enabled == 1
+            moco.renderingControl.GetEQ.assert_called_once_with(
+                [("InstanceID", 0), ("EQType", "SpeechEnhanceEnabled")]
+            )
+
+            moco.renderingControl.GetEQ.return_value = {"CurrentValue": "0"}
+            assert moco.speech_enhance_enabled == 0
+
+            moco.renderingControl.SetEQ.reset_mock()
+            moco.speech_enhance_enabled = 1
+            moco.renderingControl.SetEQ.assert_called_once_with(
+                [("InstanceID", 0), ("EQType", "SpeechEnhanceEnabled"), ("DesiredValue", 1)]
+            )
+
+
     def test_soco_fixed_volume(self, moco):
         moco.renderingControl.GetSupportsOutputFixed.return_value = {
             "CurrentSupportsFixed": "1"


### PR DESCRIPTION
In the Arc Ultra Soundbar, Sonos has changed the interface for enabling / disabling dialog mode.

SpeechEnhanceEnabled property (new for SoCo) is used to enable / disable dialog mode
DialogLevel (existing) is a multistate property with values 1,2,3,4 to control the dialog level (Low, Medium, High, Max)

For other model soundbars DialogLevel is used to turn on / off dialog mode and does not use SpeechEnhanceEnabled 

https://github.com/home-assistant/core/issues/142881