### PR TITLE
Support dict type in single result parsing

### DIFF
--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -60,7 +60,6 @@ Class overview:
 from urllib.parse import quote as quote_url
 
 import logging
-from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
 
@@ -98,7 +97,7 @@ def parse_response(service, response, search_type):
 
     Args:
         service (MusicService): The music service that produced the response
-        response (OrderedDict): The response from the soap client call
+        response (dict): The response from the soap client call
         search_type (str): A string that indicates the search type that the
             response is from
 
@@ -274,7 +273,7 @@ class MusicServiceItem(MetadataDictBase):
         Args:
             music_service (MusicService): The music service that content_dict
                 originated from
-            content_dict (OrderedDict): The data to instantiate the music
+            content_dict (dict): The data to instantiate the music
                 service item from
 
         Returns:

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -136,7 +136,7 @@ def parse_response(service, response, search_type):
         result_type_proper = result_type[0].upper() + result_type[1:]
         raw_items = response.get(result_type, [])
         # If there is only 1 result, it is not put in an array
-        if isinstance(raw_items, OrderedDict):
+        if isinstance(raw_items, dict):
             raw_items = [raw_items]
 
         for raw_item in raw_items:

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -206,6 +206,19 @@ def test_parse_response(response, correct):
         assert result.music_service is music_service
 
 
+def test_parse_response_plain_dict_fields():
+    """Test that a single result returned as a plain dict (issue #988) parses
+    fields correctly, not just the count and class."""
+    music_service = Mock()
+    music_service.desc = "DESC"
+    results = data_structures.parse_response(music_service, RESPONSES[2], "albums")
+    assert len(results) == 1
+    item = results[0]
+    assert item.title == "Single Result Track"
+    assert item.item_id == "0fffffff" + "track/amazon123"
+    assert item.music_service is music_service
+
+
 def test_parse_response_bad_type():
     """Test parse reponse bad code"""
     with pytest.raises(ValueError) as exp:

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -118,6 +118,33 @@ RESPONSES.append(
         ]
     )
 )
+# Test case for issue #988: single result returned as plain dict (e.g., Amazon Music)
+RESPONSES.append(
+    {
+        "searchResult": {
+            "index": "0",
+            "count": "1",
+            "total": "1",
+            "mediaMetadata": {
+                "id": "track/amazon123",
+                "title": "Single Result Track",
+                "itemType": "track",
+                "mimeType": "audio/mp4",
+                "trackMetadata": {
+                    "albumArtURI": "http://example.com/art.jpg",
+                    "artistId": "artist/456",
+                    "artist": "Test Artist",
+                    "album": "Test Album",
+                    "duration": "300",
+                    "canPlay": "true",
+                    "canSkip": "true",
+                    "canAddToFavorites": "true",
+                    "trackNumber": "1",
+                },
+            },
+        }
+    }
+)
 PARSE_RESULTS = (
     {
         "number_of_results": 2,
@@ -127,6 +154,12 @@ PARSE_RESULTS = (
     {
         "number_of_results": 1,
         "type": "getMetadataResult",
+        "class_key": "MediaMetadataTrack",
+    },
+    # Test case for issue #988: single result as plain dict
+    {
+        "number_of_results": 1,
+        "type": "searchResult",
         "class_key": "MediaMetadataTrack",
     },
 )


### PR DESCRIPTION
This commit updates the `parse_response` function in `soco/music_services/data_structures.py` to handle single results returned as plain dictionaries instead of only `OrderedDict`. This change was necessary to accommodate services like Amazon Music, which return a single result as a plain dictionary. Additionally, a test case was added to `tests/test_music_service_data_structures.py` to ensure this behavior is correctly handled, addressing issue #988. This update ensures that the music service integration can correctly parse and handle single results from various music services, improving compatibility and reliability.