### PR TITLE
Pin black version

### DIFF
--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -43,9 +43,7 @@ jobs:
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
         if: >-
-          ${{ matrix.python-version == '3.8' ||
-              matrix.python-version == '3.9' ||
-              startsWith(matrix.python-version, '3.1') }}
+          ${{ startsWith(matrix.python-version, '3.1') }}
         run: |
           black --check soco tests
       - name: Test documentation build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@
     ]
 
 [tool.black]
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
+target-version = ["py38"]
 
 [tool.setuptools]
     packages = ["soco", "soco.plugins", "soco.music_services"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,14 @@
         "pylint",
         "coveralls",
         "pytest-cov<2.6.0",
-        "wheel", "black >= 22.12.0; python_version >= \"3.7\"",
+        "wheel", "black >= 24.4.0; python_version >= \"3.10\"",
         "requests-mock",
         "twine",
         "importlib-metadata<5; python_version == \"3.7\""
     ]
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py37"]
 
 [tool.setuptools]
     packages = ["soco", "soco.plugins", "soco.music_services"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@
         "importlib-metadata<5; python_version == \"3.7\""
     ]
 
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
+
 [tool.setuptools]
     packages = ["soco", "soco.plugins", "soco.music_services"]
     include-package-data = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylint
 coveralls
 pytest-cov<2.6.0
 wheel
-black == 25.1.0; python_version >= "3.8"
+black == 24.8.0; python_version >= "3.8"
 requests-mock
 twine
 importlib-metadata<5; python_version == "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylint
 coveralls
 pytest-cov<2.6.0
 wheel
-black == 24.8.0; python_version >= "3.8"
+black >= 24.4.0; python_version >= "3.10"
 requests-mock
 twine
 importlib-metadata<5; python_version == "3.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylint
 coveralls
 pytest-cov<2.6.0
 wheel
-black >= 24.4.0; python_version >= "3.8"
+black == 25.1.0; python_version >= "3.8"
 requests-mock
 twine
 importlib-metadata<5; python_version == "3.7"


### PR DESCRIPTION
The failures in #996 seems to be cause by black using python 3.14 formatting.

Pinning black to 24.8.0 provides compatibility across the python version 3.8-3.14.
Pin the black formatting to 3.8