### PR TITLE
Add missing audio format TrueHD 7.1

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -79,6 +79,7 @@ AUDIO_INPUT_FORMATS = {
     84934721: "DTS 5.1",
     118489090: "Multichannel PCM 7.1",
     118489146: "Dolby Digital Plus 7.1",
+    118489148: "Dolby TrueHD 7.1",
 }
 
 _LOG = logging.getLogger(__name__)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1316,6 +1316,10 @@ class TestRenderingControl:
 
         moco.deviceProperties.GetZoneInfo.assert_called_with()
 
+        moco.deviceProperties.GetZoneInfo.return_value = {"HTAudioIn": "118489148"}
+        assert moco.soundbar_audio_input_format_code == 118489148
+        assert moco.soundbar_audio_input_format == "Dolby TrueHD 7.1"
+
         moco.deviceProperties.GetZoneInfo.return_value = {"HTAudioIn": "12345"}
         assert "Unknown audio input format: 12345" in moco.soundbar_audio_input_format
 


### PR DESCRIPTION
Add this missing audio format. Add a test for the new audio format.

Will help close this issue:
https://github.com/home-assistant/core/issues/162045
