### PR TITLE
events_asyncio: defer EventListener teardown so resubscribes reuse the running server

### DIFF
--- a/examples/events_asyncio_verify_listener_fix.py
+++ b/examples/events_asyncio_verify_listener_fix.py
@@ -1,0 +1,164 @@
+"""Live-network verification of the events_asyncio EventListener fix.
+
+Exercises the deferred-stop refcounting path against a real Sonos zone
+and asserts the structural invariants that the fix guarantees:
+
+  1. After ``subscription.unsubscribe()``, ``stop_listening`` schedules a
+     deferred stop. The listener's runtime resources (``site``, ``sock``,
+     ``runner``, ``session``) remain alive during the grace window.
+
+  2. A resubscribe within the grace window cancels the deferred stop and
+     resumes the listener — the site/sock object identity is preserved
+     and the "Event Listener resumed (deferred stop cancelled)" debug log
+     fires. No teardown/rebuild churn.
+
+  3. After a final unsubscribe with no resubscribe, the deferred stop
+     runs once the grace window expires; listener resources are released
+     and ``is_running`` returns to ``False``.
+
+The test uses ``renderingControl`` rather than ``avTransport`` so it
+does not interfere with consumer applications that may have an
+``avTransport`` subscription active against the same zone (e.g. a
+"now playing" orchestrator).
+
+Pass a zone name (any zone on your local network) via ``--zone`` or set
+``SOCO_ZONE``. Discovery uses SSDP, so the host must be on the same
+LAN/VLAN as the Sonos players.
+
+Usage:
+
+    python examples/events_asyncio_verify_listener_fix.py --zone "Office"
+    SOCO_ZONE="Living Room" python examples/events_asyncio_verify_listener_fix.py
+
+Exit code 0 on PASS, non-zero on FAIL.
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+import soco
+from soco import config as soco_config
+from soco import events_asyncio
+
+# Must be set BEFORE any subscription is created so SoCo uses the asyncio
+# event module rather than the threaded one.
+soco_config.EVENTS_MODULE = events_asyncio
+
+
+# Keep the test fast — production default is 5.0s.
+SHORT_GRACE = 0.5
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify events_asyncio EventListener fix against a live Sonos zone."
+    )
+    parser.add_argument(
+        "--zone",
+        default=os.environ.get("SOCO_ZONE"),
+        help="Sonos zone name to bind against (default: $SOCO_ZONE).",
+    )
+    parser.add_argument(
+        "--discover-timeout",
+        type=float,
+        default=3.0,
+        help="SSDP discovery timeout in seconds (default: 3.0).",
+    )
+    return parser.parse_args()
+
+
+async def main(zone_name: str | None, discover_timeout: float) -> int:
+    if not zone_name:
+        print("ERROR: --zone (or $SOCO_ZONE) is required", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    # Silence aiohttp's chatter; keep soco at DEBUG so the
+    # "resumed (deferred stop cancelled)" line is visible.
+    logging.getLogger("aiohttp").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    # Shorten the grace window so the test runs quickly.
+    events_asyncio.event_listener._stop_grace_seconds = SHORT_GRACE
+
+    # Capture log records emitted by soco.events_asyncio so we can assert
+    # on the structural log lines the patch emits.
+    captured: list[str] = []
+
+    class _RecordCapture(logging.Handler):
+        def emit(self, record):
+            captured.append(record.getMessage())
+
+    logging.getLogger("soco.events_asyncio").addHandler(_RecordCapture())
+
+    zones = soco.discover(timeout=discover_timeout) or set()
+    zone = next((z for z in zones if z.player_name == zone_name), None)
+    if zone is None:
+        print(
+            f"ERROR: zone {zone_name!r} not found via SSDP. "
+            f"Visible zones: {[z.player_name for z in zones] or 'none'}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Using zone: {zone.player_name} @ {zone.ip_address}")
+
+    listener = events_asyncio.event_listener
+
+    print("\n--- Phase 1: initial subscribe ---")
+    sub = await zone.renderingControl.subscribe(auto_renew=False)
+    sub.callback = lambda ev: None
+    site1 = listener.site
+    sock1 = listener.sock
+    print(f"sid={sub.sid} site={id(site1):x} sock={id(sock1):x}")
+    assert listener.is_running, "listener should be running after subscribe"
+    assert site1 is not None and sock1 is not None
+
+    print("\n--- Phase 2: unsubscribe + immediate resubscribe (inside grace) ---")
+    await sub.unsubscribe()
+    pending = listener._stop_grace_task
+    print(
+        f"deferred task: {pending} "
+        f"done={pending.done() if pending else 'n/a'}"
+    )
+    assert pending is not None and not pending.done(), (
+        "stop_listening should have scheduled a deferred stop"
+    )
+    # Resources must still be alive during grace.
+    assert listener.site is site1, "site should not be replaced during grace"
+    assert listener.sock is sock1, "sock should not be replaced during grace"
+
+    sub2 = await zone.renderingControl.subscribe(auto_renew=False)
+    sub2.callback = lambda ev: None
+    print(f"sid={sub2.sid} site={id(listener.site):x} sock={id(listener.sock):x}")
+    assert listener.site is site1, "site identity must be preserved on resume"
+    assert listener.sock is sock1, "sock identity must be preserved on resume"
+    assert listener.is_running, "listener should be running after resume"
+    assert any("resumed (deferred stop cancelled)" in m for m in captured), (
+        "expected the 'resumed (deferred stop cancelled)' log line"
+    )
+    print("PASS: resubscribe inside grace reused the running listener")
+
+    print("\n--- Phase 3: final unsubscribe, wait past grace, expect teardown ---")
+    captured.clear()
+    await sub2.unsubscribe()
+    pending2 = listener._stop_grace_task
+    assert pending2 is not None and not pending2.done()
+    await asyncio.sleep(SHORT_GRACE + 0.3)
+    assert not listener.is_running, "listener should have stopped after grace"
+    assert listener.site is None, "site should be cleared"
+    assert listener.sock is None, "sock should be cleared"
+    print("PASS: deferred stop fired after grace expired")
+
+    print("\nALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    sys.exit(asyncio.run(main(args.zone, args.discover_timeout)))

--- a/examples/events_asyncio_verify_listener_fix.py
+++ b/examples/events_asyncio_verify_listener_fix.py
@@ -16,7 +16,7 @@ and asserts the structural invariants that the fix guarantees:
      runs once the grace window expires; listener resources are released
      and ``is_running`` returns to ``False``.
 
-The test uses ``renderingControl`` rather than ``avTransport`` so it
+This script uses ``renderingControl`` rather than ``avTransport`` so it
 does not interfere with consumer applications that may have an
 ``avTransport`` subscription active against the same zone (e.g. a
 "now playing" orchestrator).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,7 @@
 sphinx == 5.0.2
 sphinx_rtd_theme
 pytest >= 2.5
-# Required by tests/test_events_asyncio.py — the async test fixtures use
-# @pytest.mark.asyncio. Without it pytest treats the coroutines as plain
-# functions and the assertions never run.
 pytest-asyncio
-# Required by soco.events_asyncio, which the test module imports. Without
-# aiohttp installed, pytest's collection step would hard-error before the
-# importorskip in the test file could take effect.
 aiohttp
 graphviz
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,14 @@
 sphinx == 5.0.2
 sphinx_rtd_theme
 pytest >= 2.5
+# Required by tests/test_events_asyncio.py — the async test fixtures use
+# @pytest.mark.asyncio. Without it pytest treats the coroutines as plain
+# functions and the assertions never run.
+pytest-asyncio
+# Required by soco.events_asyncio, which the test module imports. Without
+# aiohttp installed, pytest's collection step would hard-error before the
+# importorskip in the test file could take effect.
+aiohttp
 graphviz
 flake8
 pylint

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -70,16 +70,12 @@ import asyncio
 try:
     from aiohttp import ClientSession, ClientTimeout, web
 except ImportError as error:
-    print(
-        """ImportError: {}:
+    print("""ImportError: {}:
     Use of the SoCo events_asyncio module requires the 'aiohttp'
     package and its dependencies to be installed. aiohttp is not
     installed with SoCo by default due to potential issues installing
     the dependencies 'multidict' and 'yarl' on some platforms.
-    See: https://github.com/SoCo/SoCo/issues/819""".format(
-            error
-        )
-    )
+    See: https://github.com/SoCo/SoCo/issues/819""".format(error))
     sys.exit(1)
 
 # Event is imported for compatibility with events.py
@@ -221,10 +217,7 @@ class EventListener(EventListenerBase):
             # cancel it — the caller wants the listener up. If the runtime
             # resources are still alive (the grace window has not yet
             # expired), the listener can simply resume.
-            if (
-                self._stop_grace_task is not None
-                and not self._stop_grace_task.done()
-            ):
+            if self._stop_grace_task is not None and not self._stop_grace_task.done():
                 self._stop_grace_task.cancel()
                 self._stop_grace_task = None
                 if (
@@ -234,9 +227,7 @@ class EventListener(EventListenerBase):
                     and self.session is not None
                 ):
                     self.is_running = True
-                    log.debug(
-                        "Event Listener resumed (deferred stop cancelled)"
-                    )
+                    log.debug("Event Listener resumed (deferred stop cancelled)")
                     return
             if self.is_running:
                 return
@@ -411,10 +402,7 @@ class EventListener(EventListenerBase):
           so rapid consecutive ``stop_listening()`` calls coalesce into
           a single deferred teardown.
         """
-        if (
-            self._stop_grace_task is not None
-            and not self._stop_grace_task.done()
-        ):
+        if self._stop_grace_task is not None and not self._stop_grace_task.done():
             # Replace any prior pending stop with a fresh timer.
             self._stop_grace_task.cancel()
         self._stop_grace_task = asyncio.ensure_future(self._deferred_stop())
@@ -425,9 +413,7 @@ class EventListener(EventListenerBase):
             try:
                 t.result()
             except Exception as exc:  # pylint: disable=broad-except
-                log.debug(
-                    "async_stop scheduled by stop_listening raised: %r", exc
-                )
+                log.debug("async_stop scheduled by stop_listening raised: %r", exc)
 
         self._stop_grace_task.add_done_callback(_swallow_exception)
 

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -198,7 +198,7 @@ class EventListener(EventListenerBase):
         return
 
     def listen(self, ip_address):
-        """A stub since since async_listen is used."""
+        """A stub since async_listen is used."""
         return
 
     async def async_start(self, any_zone):
@@ -312,7 +312,7 @@ class EventListener(EventListenerBase):
         This is the prompt-shutdown path: resources are closed before the
         coroutine returns. Callers that want a deterministic teardown at
         process exit should ``await event_listener.async_stop()``
-        directly, since ``stop_listening()`` defers teardown by
+        directly; ``stop_listening()`` defers teardown by
         ``_stop_grace_seconds`` (default 5 s) to support
         unsubscribe→resubscribe reuse.
 
@@ -397,7 +397,7 @@ class EventListener(EventListenerBase):
         * Consumers that subscribe once and exit (no resubscribe) will
           see resources released ~``_stop_grace_seconds`` after the last
           ``unsubscribe()``. For deterministic prompt shutdown at process
-          exit, ``await event_listener.async_stop()`` directly.
+          exit, call ``await event_listener.async_stop()`` directly.
         * Each call replaces any prior pending stop with a fresh timer,
           so rapid consecutive ``stop_listening()`` calls coalesce into
           a single deferred teardown.

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -70,12 +70,16 @@ import asyncio
 try:
     from aiohttp import ClientSession, ClientTimeout, web
 except ImportError as error:
-    print("""ImportError: {}:
+    print(
+        """ImportError: {}:
     Use of the SoCo events_asyncio module requires the 'aiohttp'
     package and its dependencies to be installed. aiohttp is not
     installed with SoCo by default due to potential issues installing
     the dependencies 'multidict' and 'yarl' on some platforms.
-    See: https://github.com/SoCo/SoCo/issues/819""".format(error))
+    See: https://github.com/SoCo/SoCo/issues/819""".format(
+            error
+        )
+    )
     sys.exit(1)
 
 # Event is imported for compatibility with events.py
@@ -279,7 +283,16 @@ class EventListener(EventListenerBase):
         """Stop the listener."""
         self.is_running = False
         if self.site:
-            await self.site.stop()
+            try:
+                await self.site.stop()
+            except (ValueError, OSError) as exc:
+                # The underlying socket may already be closed if async_stop
+                # races with another shutdown path (e.g. when stop_listening
+                # fires async_stop as an untracked task while a resubscribe is
+                # in progress). aiohttp's SockSite.stop() ultimately calls
+                # loop._stop_serving(sock), which raises ValueError on a
+                # closed fd. Tolerate and continue cleanup.
+                log.debug("site.stop() during async_stop: %r", exc)
             self.site = None
         if self.runner:
             await self.runner.cleanup()
@@ -296,7 +309,19 @@ class EventListener(EventListenerBase):
     # pylint: disable=unused-argument
     def stop_listening(self, address):
         """Stop the listener."""
-        asyncio.ensure_future(self.async_stop())
+        task = asyncio.ensure_future(self.async_stop())
+
+        def _swallow_exception(t):
+            # Consume any exception so it doesn't surface as
+            # "Task exception was never retrieved" — the task is
+            # fire-and-forget cleanup and async_stop is already
+            # tolerant of the common race conditions.
+            try:
+                t.result()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.debug("async_stop scheduled by stop_listening raised: %r", exc)
+
+        task.add_done_callback(_swallow_exception)
 
 
 class Subscription(SubscriptionBase):

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -181,6 +181,15 @@ class EventListener(EventListenerBase):
         self.site = None
         self.session = None
         self.start_lock = None
+        # async_stop is serialized via stop_lock so overlapping callers
+        # don't double-close the same resources.
+        self.stop_lock = None
+        # stop_listening() schedules a deferred teardown via this task.
+        # A resubscribe within the grace window cancels the task and
+        # reuses the existing HTTP server, eliminating the
+        # teardown/rebuild churn (and FD races) on every renew cycle.
+        self._stop_grace_task = None
+        self._stop_grace_seconds = 5.0
 
     def start(self, any_zone):
         """A stub since the first subscribe calls async_start."""
@@ -202,6 +211,27 @@ class EventListener(EventListenerBase):
         if not self.start_lock:
             self.start_lock = asyncio.Lock()
         async with self.start_lock:
+            # If a deferred stop is pending from a recent stop_listening(),
+            # cancel it — the caller wants the listener up. If the runtime
+            # resources are still alive (the grace window has not yet
+            # expired), the listener can simply resume.
+            if (
+                self._stop_grace_task is not None
+                and not self._stop_grace_task.done()
+            ):
+                self._stop_grace_task.cancel()
+                self._stop_grace_task = None
+                if (
+                    self.site is not None
+                    and self.sock is not None
+                    and self.runner is not None
+                    and self.session is not None
+                ):
+                    self.is_running = True
+                    log.debug(
+                        "Event Listener resumed (deferred stop cancelled)"
+                    )
+                    return
             if self.is_running:
                 return
             # Use configured IP address if there is one, else detect
@@ -280,48 +310,98 @@ class EventListener(EventListenerBase):
         log.debug("Event listener running on %s", (self.ip_address, self.port))
 
     async def async_stop(self):
-        """Stop the listener."""
-        self.is_running = False
-        if self.site:
+        """Stop the listener. Idempotent and safe under concurrent calls.
+
+        Snapshots the runtime resources locally and clears the instance
+        attributes inside ``stop_lock``, then closes the snapshots
+        outside the lock. This way a concurrent ``async_start`` never
+        observes a half-torn-down listener, and a second overlapping
+        ``async_stop`` call sees the cleared attrs and returns early.
+        """
+        if not self.stop_lock:
+            self.stop_lock = asyncio.Lock()
+        async with self.stop_lock:
+            if (
+                not self.is_running
+                and self.site is None
+                and self.runner is None
+                and self.session is None
+                and self.sock is None
+            ):
+                # Already stopped (or never started) — nothing to do.
+                return
+            self.is_running = False
+            site, self.site = self.site, None
+            runner, self.runner = self.runner, None
+            session, self.session = self.session, None
+            sock, self.sock = self.sock, None
+            self.port = None
+            self.ip_address = None
+
+        # Tear down outside the lock; tolerate already-closed state.
+        if site is not None:
             try:
-                await self.site.stop()
+                await site.stop()
             except (ValueError, OSError) as exc:
-                # The underlying socket may already be closed if async_stop
-                # races with another shutdown path (e.g. when stop_listening
-                # fires async_stop as an untracked task while a resubscribe is
-                # in progress). aiohttp's SockSite.stop() ultimately calls
+                # aiohttp's SockSite.stop() ultimately calls
                 # loop._stop_serving(sock), which raises ValueError on a
                 # closed fd. Tolerate and continue cleanup.
                 log.debug("site.stop() during async_stop: %r", exc)
-            self.site = None
-        if self.runner:
-            await self.runner.cleanup()
-            self.runner = None
-        if self.session:
-            await self.session.close()
-            self.session = None
-        if self.sock:
-            self.sock.close()
-            self.sock = None
-        self.port = None
-        self.ip_address = None
+        if runner is not None:
+            try:
+                await runner.cleanup()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.debug("runner.cleanup() during async_stop: %r", exc)
+        if session is not None:
+            try:
+                await session.close()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.debug("session.close() during async_stop: %r", exc)
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError as exc:
+                log.debug("sock.close() during async_stop: %r", exc)
+
+    async def _deferred_stop(self):
+        """Sleep the grace window; stop only if no resubscribe arrived."""
+        await asyncio.sleep(self._stop_grace_seconds)
+        if subscriptions_map.count == 0:
+            await self.async_stop()
+        else:
+            log.debug(
+                "deferred stop aborted: %d subscription(s) appeared during grace",
+                subscriptions_map.count,
+            )
 
     # pylint: disable=unused-argument
     def stop_listening(self, address):
-        """Stop the listener."""
-        task = asyncio.ensure_future(self.async_stop())
+        """Stop the listener after a short grace window.
+
+        A resubscribe within the grace window cancels the pending stop,
+        so the underlying HTTP server stays up across the
+        unsubscribe→subscribe cycle. Eliminates teardown/rebuild churn
+        on every resubscribe (and the FD races that follow).
+        """
+        if (
+            self._stop_grace_task is not None
+            and not self._stop_grace_task.done()
+        ):
+            # Replace any prior pending stop with a fresh timer.
+            self._stop_grace_task.cancel()
+        self._stop_grace_task = asyncio.ensure_future(self._deferred_stop())
 
         def _swallow_exception(t):
-            # Consume any exception so it doesn't surface as
-            # "Task exception was never retrieved" — the task is
-            # fire-and-forget cleanup and async_stop is already
-            # tolerant of the common race conditions.
+            if t.cancelled():
+                return
             try:
                 t.result()
             except Exception as exc:  # pylint: disable=broad-except
-                log.debug("async_stop scheduled by stop_listening raised: %r", exc)
+                log.debug(
+                    "async_stop scheduled by stop_listening raised: %r", exc
+                )
 
-        task.add_done_callback(_swallow_exception)
+        self._stop_grace_task.add_done_callback(_swallow_exception)
 
 
 class Subscription(SubscriptionBase):

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -189,6 +189,12 @@ class EventListener(EventListenerBase):
         # reuses the existing HTTP server, eliminating the
         # teardown/rebuild churn (and FD races) on every renew cycle.
         self._stop_grace_task = None
+        # Grace window (seconds) between stop_listening() being called
+        # and the deferred async_stop() actually running. Intentionally
+        # an instance attribute so consumers and tests can tune it
+        # (e.g. shorten for fast unit tests, lengthen for noisy
+        # resubscribe patterns). 5 s is the default; values < 0 are
+        # treated as "stop immediately on next event-loop tick".
         self._stop_grace_seconds = 5.0
 
     def start(self, any_zone):
@@ -310,7 +316,14 @@ class EventListener(EventListenerBase):
         log.debug("Event listener running on %s", (self.ip_address, self.port))
 
     async def async_stop(self):
-        """Stop the listener. Idempotent and safe under concurrent calls.
+        """Stop the listener immediately. Idempotent and concurrency-safe.
+
+        This is the prompt-shutdown path: resources are closed before the
+        coroutine returns. Callers that want a deterministic teardown at
+        process exit should ``await event_listener.async_stop()``
+        directly, since ``stop_listening()`` defers teardown by
+        ``_stop_grace_seconds`` (default 5 s) to support
+        unsubscribe→resubscribe reuse.
 
         Snapshots the runtime resources locally and clears the instance
         attributes inside ``stop_lock``, then closes the snapshots
@@ -378,10 +391,25 @@ class EventListener(EventListenerBase):
     def stop_listening(self, address):
         """Stop the listener after a short grace window.
 
-        A resubscribe within the grace window cancels the pending stop,
+        Called by ``EventListenerBase.stop()`` when the last subscription
+        is removed. Schedules teardown via ``_deferred_stop`` rather than
+        tearing down immediately: a resubscribe inside the grace window
+        (``_stop_grace_seconds``, default 5 s) cancels the pending stop,
         so the underlying HTTP server stays up across the
-        unsubscribe→subscribe cycle. Eliminates teardown/rebuild churn
-        on every resubscribe (and the FD races that follow).
+        unsubscribe→resubscribe cycle. Eliminates teardown/rebuild churn
+        (and the FD races that follow) on every renew.
+
+        Behaviour notes for callers:
+
+        * Resources are **not** released by the time this method returns
+          — the deferred task runs ``_stop_grace_seconds`` later.
+        * Consumers that subscribe once and exit (no resubscribe) will
+          see resources released ~``_stop_grace_seconds`` after the last
+          ``unsubscribe()``. For deterministic prompt shutdown at process
+          exit, ``await event_listener.async_stop()`` directly.
+        * Each call replaces any prior pending stop with a fresh timer,
+          so rapid consecutive ``stop_listening()`` calls coalesce into
+          a single deferred teardown.
         """
         if (
             self._stop_grace_task is not None

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -1,0 +1,75 @@
+"""Tests for soco.events_asyncio listener shutdown behavior.
+
+These tests target the EventListener.async_stop() / stop_listening()
+shutdown paths to guard against the regressions documented in the
+"events_asyncio async_stop race" fix:
+
+  - async_stop() must not raise when the underlying socket has already
+    been closed by a concurrent shutdown path (manifests as
+    ``ValueError: Invalid file descriptor: -1`` from aiohttp's
+    ``SockSite.stop()``).
+
+  - stop_listening() schedules async_stop() as a fire-and-forget task;
+    any exception that bubbles out of that task must be consumed so it
+    does not surface as ``Task exception was never retrieved``.
+"""
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from soco import events_asyncio
+
+
+@pytest.mark.asyncio
+async def test_async_stop_tolerates_closed_socket(caplog):
+    """async_stop must not raise when site.stop() finds a closed fd."""
+    listener = events_asyncio.EventListener()
+    listener.site = mock.MagicMock()
+    listener.site.stop = mock.AsyncMock(
+        side_effect=ValueError("Invalid file descriptor: -1")
+    )
+    listener.runner = mock.MagicMock()
+    listener.runner.cleanup = mock.AsyncMock()
+    listener.session = mock.MagicMock()
+    listener.session.close = mock.AsyncMock()
+    listener.sock = mock.MagicMock()
+    listener.is_running = True
+
+    with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
+        await listener.async_stop()
+
+    # async_stop must run to completion even when site.stop() raises.
+    assert listener.is_running is False
+    assert listener.site is None
+    assert listener.runner is None
+    assert listener.session is None
+    assert listener.sock is None
+    # The error must be logged (at DEBUG) so operators can still diagnose.
+    assert any("Invalid file descriptor" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_stop_listening_swallows_task_exception(caplog):
+    """The async_stop task scheduled by stop_listening must not surface
+    as ``Task exception was never retrieved``.
+    """
+    listener = events_asyncio.EventListener()
+    # Force async_stop to raise so we can verify the spawned task's
+    # exception is handled rather than escaping.
+    listener.async_stop = mock.AsyncMock(side_effect=RuntimeError("boom"))
+
+    with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
+        listener.stop_listening(address=("127.0.0.1", 1400))
+        # Yield once so the scheduled task gets to run and the done
+        # callback fires.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    listener.async_stop.assert_called_once()
+    assert any(
+        "async_stop scheduled by stop_listening raised" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -49,15 +49,12 @@ def restore_subscriptions_map():
     """
     smap = events_asyncio.subscriptions_map
     saved_subs = dict(smap.subscriptions)
-    saved_pending = smap._pending
     try:
         smap.subscriptions.clear()
-        smap._pending = 0
         yield smap
     finally:
         smap.subscriptions.clear()
         smap.subscriptions.update(saved_subs)
-        smap._pending = saved_pending
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -23,7 +23,42 @@ from unittest import mock
 
 import pytest
 
-from soco import events_asyncio
+# ``soco.events_asyncio`` imports aiohttp at module load. Skip the entire
+# test module when aiohttp isn't available so SoCo's default test job
+# (which doesn't install the optional asyncio stack) still passes.
+pytest.importorskip("aiohttp")
+
+from soco import events_asyncio  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_subscriptions_map():
+    """Snapshot ``events_asyncio.subscriptions_map`` state, restore after.
+
+    Tests that mutate the module-level subscriptions map (to control which
+    branch of ``_deferred_stop`` runs) use this fixture so a mid-test
+    failure cannot leak state into subsequent tests in the module.
+
+    The fixture starts the test from a cleared state and yields the map
+    for convenience; the ``finally`` clause restores the snapshot
+    regardless of test outcome.
+    """
+    smap = events_asyncio.subscriptions_map
+    saved_subs = dict(smap.subscriptions)
+    saved_pending = smap._pending
+    try:
+        smap.subscriptions.clear()
+        smap._pending = 0
+        yield smap
+    finally:
+        smap.subscriptions.clear()
+        smap.subscriptions.update(saved_subs)
+        smap._pending = saved_pending
 
 
 # --------------------------------------------------------------------------
@@ -60,7 +95,9 @@ async def test_async_stop_tolerates_closed_socket(caplog):
 
 
 @pytest.mark.asyncio
-async def test_stop_listening_swallows_task_exception(caplog):
+async def test_stop_listening_swallows_task_exception(
+    caplog, restore_subscriptions_map
+):
     """An exception raised by the deferred async_stop must not surface as
     ``Task exception was never retrieved`` — the done-callback must
     consume it and log at DEBUG.
@@ -71,9 +108,8 @@ async def test_stop_listening_swallows_task_exception(caplog):
     # Force async_stop to raise so we can verify the spawned task's
     # exception is handled rather than escaping.
     listener.async_stop = mock.AsyncMock(side_effect=RuntimeError("boom"))
-    # Ensure the deferred-stop logic decides to actually call async_stop.
-    events_asyncio.subscriptions_map.subscriptions.clear()
-    events_asyncio.subscriptions_map._pending = 0
+    # restore_subscriptions_map starts in a cleared state so the deferred
+    # stop will actually invoke async_stop.
 
     with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
         listener.stop_listening(address=("127.0.0.1", 1400))
@@ -139,15 +175,16 @@ async def test_async_start_cancels_pending_deferred_stop_and_resumes():
 
 
 @pytest.mark.asyncio
-async def test_deferred_stop_runs_when_grace_expires_and_count_zero():
+async def test_deferred_stop_runs_when_grace_expires_and_count_zero(
+    restore_subscriptions_map,
+):
     """If no resubscribe arrives during the grace window and the
     subscription map is empty, the deferred stop actually runs."""
     listener = events_asyncio.EventListener()
     _populate_running_listener(listener)
     listener._stop_grace_seconds = 0.01
 
-    events_asyncio.subscriptions_map.subscriptions.clear()
-    events_asyncio.subscriptions_map._pending = 0
+    # restore_subscriptions_map ensures count == 0 so the deferred stop fires.
 
     # Capture mock references — async_stop will set the attrs to None.
     site_mock = listener.site
@@ -167,22 +204,22 @@ async def test_deferred_stop_runs_when_grace_expires_and_count_zero():
 
 
 @pytest.mark.asyncio
-async def test_deferred_stop_aborts_when_subscription_appears_in_grace(caplog):
+async def test_deferred_stop_aborts_when_subscription_appears_in_grace(
+    caplog, restore_subscriptions_map,
+):
     """If a subscription appears during the grace window — even without
     a corresponding async_start — the deferred stop must abort."""
     listener = events_asyncio.EventListener()
     _populate_running_listener(listener)
     listener._stop_grace_seconds = 0.05
 
-    events_asyncio.subscriptions_map.subscriptions.clear()
-    events_asyncio.subscriptions_map._pending = 0
-
     listener.stop_listening(address=("127.0.0.1", 1400))
 
-    # Insert a fake subscription before the grace expires.
+    # Insert a fake subscription before the grace expires. The fixture
+    # restores the map after the test regardless of outcome.
     fake_sub = mock.MagicMock()
     fake_sub.sid = "uuid:fake-1"
-    events_asyncio.subscriptions_map.subscriptions[fake_sub.sid] = fake_sub
+    restore_subscriptions_map.subscriptions[fake_sub.sid] = fake_sub
 
     with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
         await asyncio.sleep(0.15)
@@ -194,9 +231,6 @@ async def test_deferred_stop_aborts_when_subscription_appears_in_grace(caplog):
     assert any(
         "deferred stop aborted" in r.message for r in caplog.records
     )
-
-    # Cleanup module-level state for other tests.
-    events_asyncio.subscriptions_map.subscriptions.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -1,17 +1,20 @@
 """Tests for soco.events_asyncio listener shutdown behavior.
 
 These tests target the EventListener.async_stop() / stop_listening()
-shutdown paths to guard against the regressions documented in the
-"events_asyncio async_stop race" fix:
+shutdown paths to guard against two regression families:
 
-  - async_stop() must not raise when the underlying socket has already
-    been closed by a concurrent shutdown path (manifests as
-    ``ValueError: Invalid file descriptor: -1`` from aiohttp's
-    ``SockSite.stop()``).
+  1. Race tolerance — async_stop() must not raise when the underlying
+     socket has already been closed by a concurrent shutdown path
+     (manifests as ``ValueError: Invalid file descriptor: -1`` from
+     aiohttp's ``SockSite.stop()``), and stop_listening()'s
+     fire-and-forget task must not surface as
+     ``Task exception was never retrieved``.
 
-  - stop_listening() schedules async_stop() as a fire-and-forget task;
-    any exception that bubbles out of that task must be consumed so it
-    does not surface as ``Task exception was never retrieved``.
+  2. Deferred stop / refcounting — stop_listening() defers the actual
+     teardown by a short grace window. A resubscribe inside that window
+     cancels the pending stop and reuses the running HTTP server. This
+     eliminates teardown/rebuild churn (and the FD races above) on
+     every renew cycle.
 """
 
 import asyncio
@@ -21,6 +24,11 @@ from unittest import mock
 import pytest
 
 from soco import events_asyncio
+
+
+# --------------------------------------------------------------------------
+# Race tolerance — original band-aid behavior
+# --------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -53,23 +61,160 @@ async def test_async_stop_tolerates_closed_socket(caplog):
 
 @pytest.mark.asyncio
 async def test_stop_listening_swallows_task_exception(caplog):
-    """The async_stop task scheduled by stop_listening must not surface
-    as ``Task exception was never retrieved``.
+    """An exception raised by the deferred async_stop must not surface as
+    ``Task exception was never retrieved`` — the done-callback must
+    consume it and log at DEBUG.
     """
     listener = events_asyncio.EventListener()
+    # Short-circuit the grace window so the deferred task runs promptly.
+    listener._stop_grace_seconds = 0.01
     # Force async_stop to raise so we can verify the spawned task's
     # exception is handled rather than escaping.
     listener.async_stop = mock.AsyncMock(side_effect=RuntimeError("boom"))
+    # Ensure the deferred-stop logic decides to actually call async_stop.
+    events_asyncio.subscriptions_map.subscriptions.clear()
+    events_asyncio.subscriptions_map._pending = 0
 
     with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
         listener.stop_listening(address=("127.0.0.1", 1400))
-        # Yield once so the scheduled task gets to run and the done
-        # callback fires.
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        # Wait long enough for the grace window + the async_stop body.
+        await asyncio.sleep(0.1)
 
-    listener.async_stop.assert_called_once()
+    listener.async_stop.assert_awaited_once()
     assert any(
         "async_stop scheduled by stop_listening raised" in r.message
         for r in caplog.records
     )
+
+
+# --------------------------------------------------------------------------
+# Deferred stop / refcounting — Option B behavior
+# --------------------------------------------------------------------------
+
+
+def _populate_running_listener(listener):
+    """Set up a listener with the runtime resources of a started server."""
+    listener.is_running = True
+    listener.site = mock.MagicMock()
+    listener.site.stop = mock.AsyncMock()
+    listener.runner = mock.MagicMock()
+    listener.runner.cleanup = mock.AsyncMock()
+    listener.session = mock.MagicMock()
+    listener.session.close = mock.AsyncMock()
+    listener.sock = mock.MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_async_start_cancels_pending_deferred_stop_and_resumes():
+    """A resubscribe within the grace window cancels the deferred stop
+    and resumes the listener without tearing anything down — this is the
+    fast path that eliminates teardown/rebuild churn on every renew."""
+    listener = events_asyncio.EventListener()
+    _populate_running_listener(listener)
+    listener._stop_grace_seconds = 1.0
+
+    # The base class sets is_running=False before calling stop_listening,
+    # so model that here.
+    listener.is_running = False
+    listener.stop_listening(address=("127.0.0.1", 1400))
+    pending_task = listener._stop_grace_task
+    assert pending_task is not None
+    assert not pending_task.done()
+
+    # Simulate a fresh subscribe inside the grace window.
+    any_zone = mock.MagicMock()
+    any_zone.ip_address = "127.0.0.1"
+    await listener.async_start(any_zone)
+
+    # The deferred stop should have been cancelled and the listener resumed.
+    assert listener._stop_grace_task is None
+    assert listener.is_running is True
+    # Resources untouched — no teardown happened.
+    listener.site.stop.assert_not_called()
+    listener.runner.cleanup.assert_not_called()
+    listener.session.close.assert_not_called()
+    # Let the cancellation settle so pytest-asyncio doesn't warn.
+    await asyncio.sleep(0)
+    assert pending_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_deferred_stop_runs_when_grace_expires_and_count_zero():
+    """If no resubscribe arrives during the grace window and the
+    subscription map is empty, the deferred stop actually runs."""
+    listener = events_asyncio.EventListener()
+    _populate_running_listener(listener)
+    listener._stop_grace_seconds = 0.01
+
+    events_asyncio.subscriptions_map.subscriptions.clear()
+    events_asyncio.subscriptions_map._pending = 0
+
+    # Capture mock references — async_stop will set the attrs to None.
+    site_mock = listener.site
+    runner_mock = listener.runner
+    session_mock = listener.session
+
+    listener.stop_listening(address=("127.0.0.1", 1400))
+    # Wait past the grace window plus the async_stop body.
+    await asyncio.sleep(0.1)
+
+    site_mock.stop.assert_awaited_once()
+    runner_mock.cleanup.assert_awaited_once()
+    session_mock.close.assert_awaited_once()
+    assert listener.is_running is False
+    assert listener.site is None
+    assert listener.sock is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_stop_aborts_when_subscription_appears_in_grace(caplog):
+    """If a subscription appears during the grace window — even without
+    a corresponding async_start — the deferred stop must abort."""
+    listener = events_asyncio.EventListener()
+    _populate_running_listener(listener)
+    listener._stop_grace_seconds = 0.05
+
+    events_asyncio.subscriptions_map.subscriptions.clear()
+    events_asyncio.subscriptions_map._pending = 0
+
+    listener.stop_listening(address=("127.0.0.1", 1400))
+
+    # Insert a fake subscription before the grace expires.
+    fake_sub = mock.MagicMock()
+    fake_sub.sid = "uuid:fake-1"
+    events_asyncio.subscriptions_map.subscriptions[fake_sub.sid] = fake_sub
+
+    with caplog.at_level(logging.DEBUG, logger="soco.events_asyncio"):
+        await asyncio.sleep(0.15)
+
+    # Stop must NOT have run; resources stay intact.
+    listener.site.stop.assert_not_called()
+    listener.runner.cleanup.assert_not_called()
+    listener.session.close.assert_not_called()
+    assert any(
+        "deferred stop aborted" in r.message for r in caplog.records
+    )
+
+    # Cleanup module-level state for other tests.
+    events_asyncio.subscriptions_map.subscriptions.clear()
+
+
+@pytest.mark.asyncio
+async def test_async_stop_idempotent_under_parallel_calls():
+    """Two overlapping async_stop calls must not double-close; the
+    stop_lock serializes them and the second sees cleared attrs."""
+    listener = events_asyncio.EventListener()
+    _populate_running_listener(listener)
+    site_mock = listener.site
+    runner_mock = listener.runner
+    session_mock = listener.session
+    sock_mock = listener.sock
+
+    await asyncio.gather(listener.async_stop(), listener.async_stop())
+
+    # Each underlying close was invoked exactly once.
+    site_mock.stop.assert_awaited_once()
+    runner_mock.cleanup.assert_awaited_once()
+    session_mock.close.assert_awaited_once()
+    sock_mock.close.assert_called_once()
+    assert listener.is_running is False

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -30,7 +30,6 @@ pytest.importorskip("aiohttp")
 
 from soco import events_asyncio  # noqa: E402
 
-
 # --------------------------------------------------------------------------
 # Shared fixtures
 # --------------------------------------------------------------------------
@@ -205,7 +204,8 @@ async def test_deferred_stop_runs_when_grace_expires_and_count_zero(
 
 @pytest.mark.asyncio
 async def test_deferred_stop_aborts_when_subscription_appears_in_grace(
-    caplog, restore_subscriptions_map,
+    caplog,
+    restore_subscriptions_map,
 ):
     """If a subscription appears during the grace window — even without
     a corresponding async_start — the deferred stop must abort."""
@@ -228,9 +228,7 @@ async def test_deferred_stop_aborts_when_subscription_appears_in_grace(
     listener.site.stop.assert_not_called()
     listener.runner.cleanup.assert_not_called()
     listener.session.close.assert_not_called()
-    assert any(
-        "deferred stop aborted" in r.message for r in caplog.records
-    )
+    assert any("deferred stop aborted" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_events_asyncio.py
+++ b/tests/test_events_asyncio.py
@@ -6,8 +6,8 @@ shutdown paths to guard against two regression families:
   1. Race tolerance — async_stop() must not raise when the underlying
      socket has already been closed by a concurrent shutdown path
      (manifests as ``ValueError: Invalid file descriptor: -1`` from
-     aiohttp's ``SockSite.stop()``), and stop_listening()'s
-     fire-and-forget task must not surface as
+     aiohttp's ``SockSite.stop()``), and exceptions from the task
+     spawned by stop_listening() must not surface as
      ``Task exception was never retrieved``.
 
   2. Deferred stop / refcounting — stop_listening() defers the actual


### PR DESCRIPTION
## Summary

Fixes a lifecycle race in `soco.events_asyncio.EventListener` that, on every unsubscribe → resubscribe cycle, runs `EventListener.async_stop()` as a fire-and-forget task against a socket the next subscription has just replaced. Symptoms in the wild:

- `ValueError: Invalid file descriptor: -1` raised from inside `aiohttp.web_runner.SockSite.stop()` → `_loop._stop_serving(sock)` → `sock.fileno()` against an already-closed socket.
- The exception escapes as `Task exception was never retrieved` because `stop_listening()` schedules `async_stop()` via `asyncio.ensure_future` without retaining a reference or attaching a done callback.
- `async_stop` partially completes against the *new* listener's resources, intermittently orphaning the `runner` / `session` / `sock` pointers belonging to the fresh subscription.

Reproduced reliably on a long-lived asyncio consumer (Raspberry Pi orchestrator subscribing to `AVTransport` on a Sonos zone, with a 10-minute no-events watchdog that periodically resubscribes). Every watchdog resubscribe triggered the traceback. After this PR, 47 hours of continuous run with **122 clean resubscribe cycles, zero `Invalid file descriptor` errors, zero `Task exception was never retrieved` log lines.**

Original reproduction traceback:

```
ERROR asyncio Task exception was never retrieved
future: <Task finished name='Task-6060' coro=<EventListener.async_stop() done,
 defined at .../soco/events_asyncio.py:278>
 exception=ValueError('Invalid file descriptor: -1')>
Traceback (most recent call last):
  File ".../soco/events_asyncio.py", line 282, in async_stop
    await self.site.stop()
  File ".../aiohttp/web_runner.py", line 77, in stop
    self._server.close()
  File ".../asyncio/base_events.py", line 342, in close
    self._loop._stop_serving(sock)
  ...
  File ".../selectors.py", line 42, in _fileobj_to_fd
    raise ValueError("Invalid file descriptor: {}".format(fd))
ValueError: Invalid file descriptor: -1
```

Environment: soco 0.31.0, Python 3.13.7 (Pi OS Trixie), aiohttp 3.13.x.

## Why it happens

1. The last subscription's `unsubscribe()` calls `event_listener.stop()` → `stop_listening()`.
2. `stop_listening()` schedules `async_stop()` with `asyncio.ensure_future(self.async_stop())` — fire and forget.
3. The caller immediately resubscribes. `async_start()` opens a **new** socket and `web.SockSite` and assigns them to `self.sock` / `self.site` on the singleton listener.
4. The previously-scheduled `async_stop` finally runs. `await self.site.stop()` is now operating on the new site whose `_server.close()` calls `_loop._stop_serving(sock)` on a socket whose `fileno() == -1` because a closer path already closed it → `ValueError`.

## Fix

Three commits, logically separated for review:

### `65318ca` — Make `async_stop` tolerant of socket-close races

Wraps `site.stop()` in a `try/except (ValueError, OSError)` so the rest of the cleanup (runner, session, sock) still runs to completion. Attaches a done-callback on the task spawned by `stop_listening()` to consume any exception (no more `Task exception was never retrieved`). This is the defensive layer that handles edge cases the structural fix below doesn't anticipate.

### `c8bb455` — Defer `EventListener` teardown so resubscribes reuse the running server

The structural fix. `stop_listening()` now schedules teardown after a short grace window (`_stop_grace_seconds`, default 5.0s). `async_start()`, before checking `is_running`, cancels any pending deferred-stop task — and if the listener's runtime resources are still intact, simply restores `is_running = True` and returns without rebuilding anything. The HTTP server is reused across the unsubscribe → subscribe cycle.

`async_stop()` is also reworked to be race-safe: acquires a stop-lock, snapshots `site` / `runner` / `session` / `sock` into locals and clears the instance attributes *inside* the lock, then closes the snapshots *outside* the lock. A concurrent `async_start` never observes a half-torn-down listener, and a second overlapping `async_stop` sees cleared attrs and returns early (idempotent).

### `457c1a7` — Live-network verification example

`examples/events_asyncio_verify_listener_fix.py` exercises the deferred-stop path against a real Sonos zone (using `renderingControl` to avoid colliding with any consumer's `avTransport` subscription) and asserts:

- After `unsubscribe()`, `stop_listening` schedules a deferred-stop task; resources stay alive during the grace window.
- A resubscribe inside the grace window cancels the deferred stop — `site` and `sock` object identity preserved, ``Event Listener resumed (deferred stop cancelled)`` debug log fires.
- After a final unsubscribe with no resubscribe, the deferred stop runs after the grace window expires; resources cleared.

## Tests

Six new tests in `tests/test_events_asyncio.py`:

- `test_async_stop_tolerates_closed_socket` — covers `65318ca`.
- `test_stop_listening_swallows_task_exception` — covers `65318ca`.
- `test_async_start_cancels_pending_deferred_stop_and_resumes` — fast-path: resubscribe inside grace reuses the listener.
- `test_deferred_stop_runs_when_grace_expires_and_count_zero` — slow path: real shutdown after grace.
- `test_deferred_stop_aborts_when_subscription_appears_in_grace` — subscription arriving during grace aborts teardown.
- `test_async_stop_idempotent_under_parallel_calls` — overlapping `async_stop()` calls.

Full suite: **251 passed, 67 skipped** (integration tests requiring `--ip`). No regressions.

## Behavior compatibility

- Existing callers see no API change. `event_listener.async_stop()` still tears down immediately when called directly (idempotent now). `stop_listening()` still results in teardown — just deferred by 5s, which a final-shutdown path will naturally wait through.
- The grace window is exposed as `event_listener._stop_grace_seconds` so consumers (or tests) can shorten/lengthen it.
- For consumers that don't resubscribe (single subscribe → process exit), behavior is identical apart from a 5s delay on `async_stop` running. If that matters, callers should `await event_listener.async_stop()` directly during shutdown.

## Production evidence

Deployed via a git pin on a Raspberry Pi orchestrator (Sonos UPnP `AVTransport` subscription, watchdog-based resubscribe every ~10 min on event silence). Continuous run since 2026-05-21:

- 47 h uptime, **122 watchdog-driven resubscribe cycles**, all clean.
- Zero new tracebacks of any kind.
- Original user-facing symptom (kiosk failing to update for ~10 min after a state change on the Sonos zone) has not recurred.

## How to verify locally

After installing this branch, against a Sonos zone on your LAN:

```
python examples/events_asyncio_verify_listener_fix.py --zone "Living Room"
```

Exits 0 on PASS. Useful both as a regression guard and as a worked example of asyncio subscription lifecycle.