### PR TITLE
Relax strict checking for missing parentID in DIDL elements

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -576,7 +576,8 @@ class DidlObject(metaclass=DidlMetaClass):
         item_id = really_unicode(item_id)
         parent_id = element.get("parentID", None)
         if parent_id is None:
-            raise DIDLMetadataError("Missing parentID attribute")
+            # Relax strict checking for non-compliant DIDL metadata streams
+            parent_id = ""
         parent_id = really_unicode(parent_id)
 
         # CAUTION: This implementation deviates from the spec.


### PR DESCRIPTION
### Description
Some upstream music services and specific Sonos metadata streams (such as `enqueued_transport_uri_meta_data`) may omit the required UPnP `parentID` attribute. Currently, SoCo raises a strict `DIDLMetadataError` when this attribute is missing. In the case of an Event , the relevant field is then populated with an `EventParseException`.

### Fix
This change relaxes that strict constraint by defaulting `parent_id` to an empty string (`""`) if it is absent. This prevents background exception and allows downstream applications to access the data.