### PR TITLE
Prevent unhandled exception when processing favorite missing DIDL class

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -73,6 +73,8 @@ def to_didl_string(*args):
 
 def didl_class_to_soco_class(didl_class):
     """Translate a DIDL-Lite class to the corresponding SoCo data structures class"""
+    if didl_class is None:
+        raise DIDLMetadataError("DIDL class is None")
     # Certain music services have been observed to sub-class via a .# or # syntax.
     # We simply remove these subclasses.
     for separator in (".#", "#"):
@@ -1267,7 +1269,9 @@ class ListOfMusicInfoItems(list):
                 dictionary [\'{0}\'] is deprecated. Please use the named
                 attribute {1}.{0} instead. The deprecated way of retrieving the
                 metadata will be removed from the third release after
-                0.8""".format(key, self.__class__.__name__)
+                0.8""".format(
+                    key, self.__class__.__name__
+                )
             message = textwrap.dedent(message).replace("\n", " ").lstrip()
             warnings.warn(message, stacklevel=2)
             return self._metadata[key]

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1269,9 +1269,7 @@ class ListOfMusicInfoItems(list):
                 dictionary [\'{0}\'] is deprecated. Please use the named
                 attribute {1}.{0} instead. The deprecated way of retrieving the
                 metadata will be removed from the third release after
-                0.8""".format(
-                    key, self.__class__.__name__
-                )
+                0.8""".format(key, self.__class__.__name__)
             message = textwrap.dedent(message).replace("\n", " ").lstrip()
             warnings.warn(message, stacklevel=2)
             return self._metadata[key]

--- a/soco/data_structures_entry.py
+++ b/soco/data_structures_entry.py
@@ -34,6 +34,8 @@ def from_didl_string(string):
     for elt in root:
         if elt.tag.endswith("item") or elt.tag.endswith("container"):
             item_class = elt.findtext(ns_tag("upnp", "class"))
+            if item_class is None:
+                raise DIDLMetadataError("DIDL element has no upnp:class child element")
             cls = didl_class_to_soco_class(item_class)
             item = cls.from_element(elt)
             items.append(item)

--- a/tests/test_data_structures_entry_integration.py
+++ b/tests/test_data_structures_entry_integration.py
@@ -127,3 +127,22 @@ def test_vendor_extended_didl_class(class_name, base_class, didl_xml_string, dat
     assert item.__class__.__name__ == class_name
     assert base_class is item.__class__.__bases__[0]
     assert base_class._translation == item._translation
+
+
+def test_from_didl_string_missing_upnp_class_raises():
+    """Test that from_didl_string raises DIDLMetadataError when a DIDL item
+    has no upnp:class element (regression test for GitHub issue SoCo/#177460)."""
+    from soco.exceptions import DIDLMetadataError
+
+    didl_missing_class = (
+        '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"'
+        ' xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">'
+        '<item id="1" parentID="0" restricted="true">'
+        "<dc:title>A Track Without Class</dc:title>"
+        "</item>"
+        "</DIDL-Lite>"
+    )
+    with pytest.raises(DIDLMetadataError) as excinfo:
+        from_didl_string(didl_missing_class)
+    assert "upnp:class" in str(excinfo.value)

--- a/tests/test_data_structures_entry_integration.py
+++ b/tests/test_data_structures_entry_integration.py
@@ -131,7 +131,7 @@ def test_vendor_extended_didl_class(class_name, base_class, didl_xml_string, dat
 
 def test_from_didl_string_missing_upnp_class_raises():
     """Test that from_didl_string raises DIDLMetadataError when a DIDL item
-    has no upnp:class element (regression test for GitHub issue SoCo/#177460)."""
+    has no upnp:class element. """
     from soco.exceptions import DIDLMetadataError
 
     didl_missing_class = (

--- a/tests/test_data_structures_entry_integration.py
+++ b/tests/test_data_structures_entry_integration.py
@@ -131,7 +131,7 @@ def test_vendor_extended_didl_class(class_name, base_class, didl_xml_string, dat
 
 def test_from_didl_string_missing_upnp_class_raises():
     """Test that from_didl_string raises DIDLMetadataError when a DIDL item
-    has no upnp:class element. """
+    has no upnp:class element."""
     from soco.exceptions import DIDLMetadataError
 
     didl_missing_class = (

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -399,3 +399,10 @@ def test_didl_object_inheritance():
         base_didl_class = ".".join(didl_class.split(".")[:-1])
         base_class = data_structures._DIDL_CLASS_TO_CLASS[base_didl_class]
         assert base_class == soco_class.__bases__[0]
+
+
+def test_didl_class_to_soco_class_none_raises():
+    """Test that didl_class_to_soco_class raises DIDLMetadataError when passed None."""
+    with pytest.raises(DIDLMetadataError) as excinfo:
+        data_structures.didl_class_to_soco_class(None)
+    assert "None" in str(excinfo.value)


### PR DESCRIPTION
When a favorite is returned from the speaker that does not have a DIDL class; the library was raising an unhandled type exception. The change checks for this condition and raises a DIDLMetadataError

https://github.com/home-assistant/core/issues/177460

```
  File "/usr/src/homeassistant/homeassistant/components/sonos/favorites.py", line 133, in update_cache
    if fav.reference.resources:

  File "/usr/local/lib/python3.14/site-packages/soco/data_structures.py", line 987, in reference
    ref = _FROM_DIDL_STRING_FUNCTION(getattr(self, "resource_meta_data"))[0]

  File "/usr/local/lib/python3.14/site-packages/soco/data_structures.py", line 79, in didl_class_to_soco_class
    if separator in didl_class:

TypeError: argument of type 'NoneType' is not a container or iterable
```