### PR TITLE
Guard DidlFavorite.reference against unusable resMD metadata

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -975,7 +975,12 @@ class DidlFavorite(DidlItem):
     # object available via the 'reference' property.
     @property
     def reference(self):
-        """The Didl object this favorite refers to."""
+        """The Didl object this favorite refers to.
+
+        Raises:
+            DIDLMetadataError: If the favorite has no ``resMD`` element, or if
+                its ``resMD`` element holds no DIDL item.
+        """
 
         # Import from_didl_string if it isn't present already. The import
         # happens here because it would cause cyclic import errors if the
@@ -986,7 +991,23 @@ class DidlFavorite(DidlItem):
 
             _FROM_DIDL_STRING_FUNCTION = data_structures_entry.from_didl_string
 
-        ref = _FROM_DIDL_STRING_FUNCTION(getattr(self, "resource_meta_data"))[0]
+        # Some speakers have been observed to return favorites without any
+        # resMD, or with a resMD that holds no item. Raise a SoCoException
+        # subclass rather than letting AttributeError or IndexError escape.
+        meta_data = getattr(self, "resource_meta_data", None)
+        if meta_data is None:
+            raise DIDLMetadataError(
+                "Favorite '%s' has no resource_meta_data (resMD) element" % self.title
+            )
+
+        references = _FROM_DIDL_STRING_FUNCTION(meta_data)
+        if not references:
+            raise DIDLMetadataError(
+                "Favorite '%s' has resource_meta_data containing no DIDL item"
+                % self.title
+            )
+
+        ref = references[0]
         # The resMD metadata lacks a <res> tag, so we use the resources from
         # the favorite to make 'reference' playable.
         ref.resources = self.resources

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -406,3 +406,70 @@ def test_didl_class_to_soco_class_none_raises():
     with pytest.raises(DIDLMetadataError) as excinfo:
         data_structures.didl_class_to_soco_class(None)
     assert "None" in str(excinfo.value)
+
+
+class TestDidlFavorite:
+    """Testing the DidlFavorite class and its 'reference' property."""
+
+    # A minimal but valid resMD payload, holding a single music track.
+    reference_didl = (
+        '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"'
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+        '<item id="riid" parentID="rpid" restricted="true">'
+        "<dc:title>referenced_title</dc:title>"
+        "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
+        "</item>"
+        "</DIDL-Lite>"
+    )
+
+    # Well formed DIDL-Lite, but with no <item> or <container> child. The
+    # recovering XML parser also reduces truncated resMD to this.
+    empty_didl = '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"/>'
+
+    @staticmethod
+    def make_favorite(**kwargs):
+        """Return a DidlFavorite, passing kwargs through to the constructor."""
+        return data_structures.DidlFavorite(
+            title="a_favorite", parent_id="pid", item_id="iid", **kwargs
+        )
+
+    def test_reference_returns_referenced_object(self):
+        favorite = self.make_favorite(
+            resource_meta_data=self.reference_didl,
+            resources=[data_structures.DidlResource("x-file-cifs://uri", "a:b:c:d")],
+        )
+
+        reference = favorite.reference
+
+        assert isinstance(reference, data_structures.DidlMusicTrack)
+        assert reference.title == "referenced_title"
+        # The resMD metadata lacks a <res> tag, so the favorite's own
+        # resources are copied across to make the reference playable.
+        assert reference.resources == favorite.resources
+
+    def test_reference_setter_round_trips(self):
+        favorite = self.make_favorite()
+        track = data_structures.DidlMusicTrack(
+            title="referenced_title",
+            parent_id="rpid",
+            item_id="riid",
+            resources=[data_structures.DidlResource("x-file-cifs://uri", "a:b:c:d")],
+        )
+
+        favorite.reference = track
+
+        assert favorite.reference.title == "referenced_title"
+        assert favorite.resources == track.resources
+
+    def test_reference_without_resource_meta_data_raises(self):
+        """A favorite with no <r:resMD> element must not raise AttributeError."""
+        favorite = self.make_favorite()
+        with pytest.raises(DIDLMetadataError, match="resource_meta_data"):
+            _ = favorite.reference
+
+    def test_reference_with_empty_resource_meta_data_raises(self):
+        """resMD that parses to zero items must not raise IndexError."""
+        favorite = self.make_favorite(resource_meta_data=self.empty_didl)
+        with pytest.raises(DIDLMetadataError, match="no DIDL item"):
+            _ = favorite.reference

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -474,6 +474,7 @@ class TestDidlFavorite:
         with pytest.raises(DIDLMetadataError, match="no DIDL item"):
             _ = favorite.reference
 
+
 def test_didl_class_to_soco_class_generated_class_has_docstring():
     """Test that an automatically created subclass gets a docstring.
 


### PR DESCRIPTION
Follow-up to #1006.

That PR converted a `TypeError` into a `DIDLMetadataError` when a favorite's DIDL item had no `<upnp:class>`. Two sibling paths in `DidlFavorite.reference` were still unguarded, and both fail the same way for the same users:

```python
ref = _FROM_DIDL_STRING_FUNCTION(getattr(self, "resource_meta_data"))[0]
```

| Case | Input | Exception before this PR |
|---|---|---|
| 1 | Favorite with no `<r:resMD>` element | `AttributeError: 'DidlFavorite' object has no attribute 'resource_meta_data'` |
| 2 | `resMD` present, but parsing to zero DIDL items | `IndexError: list index out of range` |

Case 1 is reachable because `resource_meta_data` is an *optional* entry in `DidlFavorite._translation`, and `DidlObject.from_element` only sets attributes for elements actually present in the XML.

Case 2 is reachable because `from_didl_string` parses with `ET.XMLParser(recover=True)`, which silently discards malformed or truncated content — a damaged `resMD` yields an empty tree rather than a parse error.

Neither `AttributeError` nor `IndexError` subclasses `SoCoException`. Home Assistant's `sonos/favorites.py::update_cache` wraps the reference access in `except SoCoException`, so both escape it and one malformed favorite aborts the entire favorites cache update — the same user-visible failure #1006 addressed, one layer up.

## Change

Both cases now raise `DIDLMetadataError`, naming the offending favorite so a user with one bad favorite among many can identify it:

```
Favorite 'Broken Fav' has no resource_meta_data (resMD) element
Favorite 'Broken Fav' has resource_meta_data containing no DIDL item
```

Verified against HA's exact call pattern — both are now caught by its existing handler and the favorite is skipped and logged, with no change needed downstream.

The emptiness check deliberately lives in `reference` rather than in `from_didl_string`: `music_library.browse()` legitimately returns `[]` for an empty container, so raising there would break normal operation. The "exactly one item expected" assumption belongs to `reference`.

Returning `None` was considered and rejected — callers do `fav.reference.resources`, so it would relocate the unhandled crash rather than fix it.

## Tests

`DidlFavorite.reference` had no test coverage. The new `TestDidlFavorite` adds four tests covering the contract, not just the bug:

- missing `resMD` raises `DIDLMetadataError`
- `resMD` parsing to zero items raises `DIDLMetadataError`
- happy path returns the referenced object with the favorite's `resources` copied across
- the `reference` setter round-trips

The first two were confirmed to fail with the `AttributeError` / `IndexError` above before the fix was written. The last two pass either way and are there as regression guards.

## Out of scope

- The `reference` **setter** and its unguarded `value.resources` access — a caller-error path, not a malformed-device-data path.
- Missing `Raises:` docstrings on `from_didl_string` / `didl_class_to_soco_class`.

## Checks

`pytest`: 266 passed, 67 skipped · `black --check soco tests`: clean · `flake8 soco`: clean · `pylint soco`: 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
