### PR TITLE
Fix __doc__ key when generating vendor extended DIDL classes

### DIFF
--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -92,7 +92,7 @@ def didl_class_to_soco_class(didl_class):
             (base_class,),
             {
                 "item_class": didl_class,
-                __doc__: f"Class that represents a {didl_class}",
+                "__doc__": f"Class that represents a {didl_class}",
             },
         )
         _DIDL_CLASS_TO_CLASS[didl_class] = cls

--- a/tests/test_new_datastructures.py
+++ b/tests/test_new_datastructures.py
@@ -406,3 +406,18 @@ def test_didl_class_to_soco_class_none_raises():
     with pytest.raises(DIDLMetadataError) as excinfo:
         data_structures.didl_class_to_soco_class(None)
     assert "None" in str(excinfo.value)
+
+
+def test_didl_class_to_soco_class_generated_class_has_docstring():
+    """Test that an automatically created subclass gets a docstring.
+
+    The class namespace must be keyed by the *string* "__doc__". Using a bare
+    __doc__ instead resolves to this module's docstring at function scope,
+    which leaves the generated class undocumented and pollutes its namespace.
+    """
+    didl_class = "object.item.audioItem.musicTrack.exampleVendorTrack"
+    soco_class = data_structures.didl_class_to_soco_class(didl_class)
+
+    assert soco_class.__doc__ == f"Class that represents a {didl_class}"
+    # The module docstring must not have leaked in as a namespace key.
+    assert data_structures.__doc__ not in soco_class.__dict__


### PR DESCRIPTION
`didl_class_to_soco_class` creates a subclass on the fly for any unknown DIDL class, and builds its namespace like this:

```python
cls = type(
    new_class_name,
    (base_class,),
    {
        "item_class": didl_class,
        __doc__: f"Class that represents a {didl_class}",   # <- bare __doc__
    },
)
```

The key is the bare name `__doc__`, not the string `"__doc__"`. At function scope that resolves by ordinary global lookup to the **module's** docstring, so every generated class ends up with:

- a junk namespace key holding the entire `data_structures` module docstring, and
- `cls.__doc__` still `None`

Observable on master:

```python
>>> cls = didl_class_to_soco_class("object.item.audioItem.musicTrack.customTrack")
>>> cls.__doc__ is None
True
>>> [repr(k)[:40] for k in cls.__dict__]
["'item_class'",
 '"\\nThis module contains classes for han',   # <- the module docstring, as a key
 "'__module__'",
 "'__doc__'"]
```

Quoting the key fixes both. One-character change.

## Impact

Cosmetic rather than functional — nothing reads these docstrings at runtime, and the stray key is inert. It does mean vendor extended classes are undocumented under `help()` and in generated API docs, which is the opposite of what the code intends.

## Tests

Adds `test_didl_class_to_soco_class_generated_class_has_docstring`, asserting the generated class carries its intended docstring and that the module docstring has not leaked in as a namespace key. Confirmed failing on master (`assert None == 'Class that represents a ...'`) before the fix.

The test deliberately avoids asserting exact `__dict__` ordering, which is not stable across the Python versions in CI.

## Checks

`pytest`: 263 passed, 67 skipped · `black --check soco tests`: clean · `flake8 soco`: clean · `pylint soco`: 10.00/10

Independent of #1007; both branch from master and touch different regions of `soco/data_structures.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
