### PR TITLE
Fix ZoneGroupState not updating on zone_group_state events (#975)

### DIFF
--- a/reproduce_issue_975.py
+++ b/reproduce_issue_975.py
@@ -1,0 +1,191 @@
+"""Live verification of the issue #975 fix (branch soco-fixes-1).
+
+Drives the Sonos system itself - no manual interaction needed. It subscribes
+to ZoneGroupTopology events, programmatically joins and unjoins two speakers,
+and verifies that `soco.all_groups` tracks the changes *purely from events*:
+while the subscription is active, the poll path is patched to raise, so any
+topology update visible via `all_groups` must have come from a
+zone_group_state event (via ZoneGroupTopology._update_cache_on_event).
+
+Usage: python reproduce_issue_975.py
+"""
+
+import sys
+import time
+
+from soco import discovery
+from soco.events import event_listener
+
+FAILURES = []
+
+
+def wait_for(predicate, what, timeout=20.0):
+    """Wait up to `timeout` seconds for predicate() to return True."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.2)
+    print(f"  TIMEOUT waiting for: {what}")
+    return False
+
+
+def groups_label(groups, device):
+    """Human-readable description of the groups containing `device`."""
+    labels = [f"    {g.label}" for g in groups if device in g]
+    return "\n".join(labels) if labels else "    (not in any group)"
+
+
+def main():
+    print("== Step 1: discover Sonos system ==")
+    devices = discovery.discover()
+    if not devices:
+        print("FAIL: no Sonos devices found on the network")
+        sys.exit(1)
+    print(f"  Found {len(devices)} device(s)")
+
+    # Use the largest household
+    households = {}
+    for d in devices:
+        households.setdefault(d.household_id, []).append(d)
+    household = max(households.values(), key=len)
+    print(f"  Using household with {len(household)} device(s):")
+    for d in household:
+        print(f"    {d.ip_address} {d.player_name}")
+    if len(household) < 2:
+        print("FAIL: need at least 2 speakers in one household to test grouping")
+        sys.exit(1)
+
+    # Populate the shared ZoneGroupState with one ordinary poll
+    zgs = household[0].zone_group_state
+    zgs.clear_cache()
+    baseline = household[0].all_groups
+    print(f"\n== Step 2: baseline topology ({len(baseline)} group(s)) ==")
+    for g in sorted(baseline, key=lambda g: g.label):
+        print(f"    {g.label}")
+
+    # Event source and join target must be usable speakers
+    usable = [
+        d
+        for d in household
+        if not getattr(d, "_is_satellite", False) and not getattr(d, "_is_bridge", False)
+    ]
+    if len(usable) < 2:
+        print("FAIL: need at least 2 non-satellite speakers in the household")
+        sys.exit(1)
+    soco = usable[0]
+
+    # Prefer a plain member of another group, else a solo speaker
+    other = None
+    for d in usable[1:]:
+        grp = next((g for g in baseline if d in g), None)
+        if grp is not None and grp.coordinator is not d and grp.coordinator is not soco:
+            other = d
+            break
+    if other is None:
+        other = usable[1]
+    print(f"\n  Event source: {soco.player_name} ({soco.ip_address})")
+    print(f"  Join target:  {other.player_name} ({other.ip_address})")
+
+    # Remember original membership for restoration
+    other_group = next((g for g in baseline if other in g), None)
+    restore_coordinator = None
+    if other_group is not None and other_group.coordinator is not other:
+        restore_coordinator = other_group.coordinator
+        print(
+            f"  (restore: rejoin {other.player_name} to "
+            f"{restore_coordinator.player_name})"
+        )
+
+    print(f"\n== Step 3: subscribe to ZoneGroupTopology events ==")
+    sub = soco.zoneGroupTopology.subscribe(auto_renew=True)
+    print(f"  Subscribed (sid={sub.sid})")
+
+    try:
+        # With the subscription active, poll() short-circuits. The initial
+        # event is the only possible source of the shared state.
+        print("\n== Step 4: initial event must populate the shared ZoneGroupState ==")
+        ok = wait_for(lambda: len(soco.all_groups) > 0, "initial zone_group_state event")
+        if not ok:
+            print("  FAIL: shared ZoneGroupState never populated from the initial event")
+            FAILURES.append("initial event did not populate the shared ZoneGroupState")
+        else:
+            print(
+                f"  PASS: shared state has {len(soco.all_groups)} group(s) "
+                "from the initial event alone (no poll)"
+            )
+
+        # From here on, a poll would mean the fix is broken: any topology
+        # change must arrive via the event hook.
+        def _no_poll(*_args, **_kwargs):
+            raise RuntimeError(
+                "GetZoneGroupState() called during verification - topology "
+                "changed via a poll, not via a zone_group_state event"
+            )
+
+        soco.zoneGroupTopology.GetZoneGroupState = _no_poll
+
+        print(f"\n== Step 5: join {other.player_name} -> {soco.player_name} ==")
+        other.unjoin()
+        other.join(soco)
+        ok = wait_for(
+            lambda: any(soco in g and other in g for g in soco.all_groups),
+            f"a group containing {soco.player_name} and {other.player_name}",
+        )
+        print("  all_groups after join:")
+        print(groups_label(soco.all_groups, soco))
+        if ok:
+            print("  PASS: join event updated all_groups")
+        else:
+            print("  FAIL: all_groups did not reflect the join")
+            FAILURES.append("join event did not update all_groups")
+
+        print(f"\n== Step 6: unjoin {other.player_name} ==")
+        other.unjoin()
+        ok = wait_for(
+            lambda: not any(soco in g and other in g for g in soco.all_groups)
+            and any(other in g and len(g.members) == 1 for g in soco.all_groups),
+            f"{other.player_name} to return to its own group",
+        )
+        print("  all_groups after unjoin:")
+        print(groups_label(soco.all_groups, soco))
+        if ok:
+            print("  PASS: unjoin event updated all_groups")
+        else:
+            print("  FAIL: all_groups did not reflect the unjoin")
+            FAILURES.append("unjoin event did not update all_groups")
+
+    finally:
+        print("\n== Step 7: restore original topology ==")
+        try:
+            other.unjoin()
+            if restore_coordinator is not None:
+                other.join(restore_coordinator)
+                wait_for(
+                    lambda: any(
+                        other in g and restore_coordinator in g for g in soco.all_groups
+                    ),
+                    "restore rejoin",
+                    timeout=10,
+                )
+            print("  Done")
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"  WARNING: restore failed: {exc}")
+        try:
+            sub.unsubscribe()
+            event_listener.stop()
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"  WARNING: cleanup failed: {exc}")
+
+    print("\n=============================================")
+    if FAILURES:
+        print("RESULT: FAIL")
+        for failure in FAILURES:
+            print(f"  - {failure}")
+        sys.exit(1)
+    print("RESULT: PASS - all_groups tracked every topology change from events")
+    print("=============================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/soco/core.py
+++ b/soco/core.py
@@ -1666,8 +1666,7 @@ class SoCo(_SocoSingletonBase):
     @property
     def all_groups(self):
         """set of :class:`soco.groups.ZoneGroup`: All available groups."""
-        self.zone_group_state.poll(self)
-        return self.zone_group_state.groups.copy()
+        return self.zone_group_state.get_groups(self)
 
     @property
     def group(self):
@@ -1696,14 +1695,12 @@ class SoCo(_SocoSingletonBase):
     @property
     def all_zones(self):
         """set of :class:`soco.groups.ZoneGroup`: All available zones."""
-        self.zone_group_state.poll(self)
-        return self.zone_group_state.all_zones.copy()
+        return self.zone_group_state.get_all_zones(self)
 
     @property
     def visible_zones(self):
         """set of :class:`soco.groups.ZoneGroup`: All visible zones."""
-        self.zone_group_state.poll(self)
-        return self.zone_group_state.visible_zones.copy()
+        return self.zone_group_state.get_visible_zones(self)
 
     def partymode(self):
         """Put all the speakers in the network in the same group, a.k.a Party

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -133,15 +133,6 @@ class EventNotifyHandler(EventNotifyHandlerBase):
             else:
                 variables = parse_event_xml(content)
 
-            if "zone_group_state" in variables:
-                # Pass ZGS payload to associated SoCo instance to update
-                # attributes. Keeps cache warm and avoids network calls.
-                service.soco.zone_group_state.process_payload(
-                    payload=variables["zone_group_state"],
-                    source="event",
-                    source_ip=service.soco.ip_address,
-                )
-
             # Build the Event object
             event = Event(sid, seq, service, timestamp, variables)
             # pass the event details on to the service so it can update

--- a/soco/services.py
+++ b/soco/services.py
@@ -823,6 +823,22 @@ class ZoneGroupTopology(Service):
     """Sonos zone group topology service, for functions relating to network
     topology, diagnostics and updates."""
 
+    def _update_cache_on_event(self, event):
+        """Keep the shared ZoneGroupState in sync with ZGS events (issue #975)."""
+        zone_group_state = event.variables.get("zone_group_state")
+        if zone_group_state is None:
+            return
+
+        try:
+            self.soco.zone_group_state.process_payload(
+                payload=zone_group_state,
+                source="event",
+                source_ip=self.soco.ip_address,
+            )
+        except Exception:  # pylint: disable=broad-except
+            # A bad payload must not stop event delivery.
+            log.exception("Failed to process zone_group_state event")
+
 
 class GroupManagement(Service):
     """Sonos group management service, for services relating to groups."""

--- a/soco/zonegroupstate.py
+++ b/soco/zonegroupstate.py
@@ -63,6 +63,7 @@ Example payload contents:
 
 import asyncio
 import logging
+import threading
 import time
 from weakref import WeakSet
 
@@ -114,6 +115,8 @@ class ZoneGroupState:
         self.all_zones = set()
         self.groups = set()
         self.visible_zones = set()
+        # Guards group set mutation and snapshotting against concurrent access.
+        self._lock = threading.RLock()
 
         self._cache_until = NEVER_TIME
         self._last_zgs = None
@@ -162,9 +165,28 @@ class ZoneGroupState:
 
     def clear_zone_groups(self):
         """Clear all known group sets."""
-        self.groups.clear()
-        self.all_zones.clear()
-        self.visible_zones.clear()
+        with self._lock:
+            self.groups.clear()
+            self.all_zones.clear()
+            self.visible_zones.clear()
+
+    def get_groups(self, soco):
+        """Poll if necessary and return a snapshot of the current groups."""
+        self.poll(soco)
+        with self._lock:
+            return self.groups.copy()
+
+    def get_all_zones(self, soco):
+        """Poll if necessary and return a snapshot of all zones."""
+        self.poll(soco)
+        with self._lock:
+            return self.all_zones.copy()
+
+    def get_visible_zones(self, soco):
+        """Poll if necessary and return a snapshot of the visible zones."""
+        self.poll(soco)
+        with self._lock:
+            return self.visible_zones.copy()
 
     def poll(self, soco):
         """Poll using the provided SoCo instance and process the payload."""
@@ -200,7 +222,20 @@ class ZoneGroupState:
         # SoCoUPnPException.
         try:
             zgs = soco.zoneGroupTopology.GetZoneGroupState()["ZoneGroupState"]
-            self.process_payload(payload=zgs, source="poll", source_ip=soco.ip_address)
+            # A subscription may have become active while the request was in
+            # flight; discard the result so it can't supersede event updates.
+            with self._lock:
+                if self.has_subscriptions:
+                    self.total_requests += 1
+                    _LOG.debug(
+                        "Subscription became active during poll for %s, "
+                        "discarding result",
+                        soco.ip_address,
+                    )
+                    return
+                self.process_payload(
+                    payload=zgs, source="poll", source_ip=soco.ip_address
+                )
             self._cache_until = time.monotonic() + POLLING_CACHE_TIMEOUT
             _LOG.debug("Extending ZGS cache by %ss", POLLING_CACHE_TIMEOUT)
 
@@ -290,26 +325,31 @@ class ZoneGroupState:
 
     def process_payload(self, payload, source, source_ip):
         """Update using the provided XML payload."""
-        self.total_requests += 1
-        tree = normalize_zgs_xml(payload)
-        normalized_zgs = str(tree)
-        if normalized_zgs == self._last_zgs:
+        # Serialize normalization and updates so concurrent payload processing
+        # cannot interleave. RLock: update_soco_instances() re-enters via
+        # clear_zone_groups().
+        with self._lock:
+            # Counted pre-parse so malformed payloads still count.
+            self.total_requests += 1
+            tree = normalize_zgs_xml(payload)
+            normalized_zgs = str(tree)
+            if normalized_zgs == self._last_zgs:
+                _LOG.debug(
+                    "Duplicate ZGS received from %s (%s), ignoring", source_ip, source
+                )
+                return
+
+            self.processed_count += 1
             _LOG.debug(
-                "Duplicate ZGS received from %s (%s), ignoring", source_ip, source
+                "Updating ZGS with %s payload from %s (%s/%s processed)",
+                source,
+                source_ip,
+                self.processed_count,
+                self.total_requests,
             )
-            return
 
-        self.processed_count += 1
-        _LOG.debug(
-            "Updating ZGS with %s payload from %s (%s/%s processed)",
-            source,
-            source_ip,
-            self.processed_count,
-            self.total_requests,
-        )
-
-        self.update_soco_instances(tree)
-        self._last_zgs = normalized_zgs
+            self.update_soco_instances(tree)
+            self._last_zgs = normalized_zgs
 
     def parse_zone_group_member(self, member_element):
         """Parse a ZoneGroupMember or Satellite element from Zone Group

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,9 +1,14 @@
 """Tests for the services module."""
 
+import logging
+from unittest import mock
+
 import pytest
 
 from soco.data_structures import DidlAudioLineIn
+from soco.events import EventNotifyHandler
 from soco.events_base import Event, parse_event_xml
+from soco.services import ZoneGroupTopology
 
 from conftest import DataLoader
 
@@ -124,3 +129,80 @@ def test_event_parsing_null_value():
     # Before the fix this raised AttributeError: 'NoneType' has no attribute 'startswith'
     result = parse_event_xml(event_xml)
     assert result["current_track_uri"] is None
+
+
+def _zgt_service():
+    """A real ZoneGroupTopology service backed by mocks."""
+    zgs = mock.Mock()
+    soco = mock.Mock()
+    soco.ip_address = "192.168.1.100"
+    soco.zone_group_state = zgs
+    return ZoneGroupTopology(soco), zgs
+
+
+def test_update_cache_on_event_updates_zone_group_state():
+    """ZGS events must update the shared ZoneGroupState (issue #975)."""
+    service, zgs = _zgt_service()
+    event = Event("sid", "0", service, 123.0, {"zone_group_state": "<ZoneGroups/>"})
+
+    service._update_cache_on_event(event)
+
+    zgs.process_payload.assert_called_once_with(
+        payload="<ZoneGroups/>", source="event", source_ip="192.168.1.100"
+    )
+
+
+def test_update_cache_on_event_without_zone_group_state():
+    """Non-ZGS events must not touch the ZoneGroupState."""
+    service, zgs = _zgt_service()
+    event = Event("sid", "0", service, 123.0, {"transport_state": "PLAYING"})
+
+    service._update_cache_on_event(event)
+
+    zgs.process_payload.assert_not_called()
+
+
+def test_update_cache_on_event_zgs_failure_logs(caplog):
+    """A failing ZGS update must be logged, not raised (issue #975).
+
+    The generic event handler calls this hook before delivering the event, so
+    swallowing here is what keeps a bad payload from suppressing delivery.
+    """
+    service, zgs = _zgt_service()
+    zgs.process_payload.side_effect = ValueError("bad ZGS")
+    event = Event("sid", "0", service, 123.0, {"zone_group_state": "<ZoneGroups/>"})
+
+    with caplog.at_level(logging.ERROR, logger="soco.services"):
+        service._update_cache_on_event(event)  # must not raise
+
+    assert "Failed to process zone_group_state event" in caplog.text
+
+
+def test_handle_notification_delivers_event_despite_zgs_failure(caplog):
+    """A ZGS failure in the cache hook must not suppress event delivery.
+
+    Exercises the real chain: EventNotifyHandler.handle_notification ->
+    ZoneGroupTopology._update_cache_on_event -> subscription.send_event.
+    """
+    zgs = mock.Mock()
+    zgs.process_payload.side_effect = ValueError("bad ZGS")
+    soco = mock.Mock()
+    soco.ip_address = "192.168.1.100"
+    soco.zone_group_state = zgs
+    service = ZoneGroupTopology(soco)
+    subscription = mock.Mock()
+    subscription.service = service
+    subscriptions_map = mock.Mock()
+    subscriptions_map.get_subscription.return_value = subscription
+
+    # Bypass BaseHTTPRequestHandler.__init__, which needs a live request/socket.
+    handler = EventNotifyHandler.__new__(EventNotifyHandler)
+    handler.subscriptions_map = subscriptions_map
+    handler.log_event = mock.Mock()  # Isolate from handler init-dependent logging.
+
+    with caplog.at_level(logging.ERROR, logger="soco.services"):
+        handler.handle_notification({"seq": "0", "sid": "uuid:test_sid"}, DUMMY_EVENT)
+
+    handler.log_event.assert_called_once()
+    subscription.send_event.assert_called_once()
+    assert "Failed to process zone_group_state event" in caplog.text

--- a/tests/test_zonegroupstate.py
+++ b/tests/test_zonegroupstate.py
@@ -1,0 +1,163 @@
+"""ZoneGroupState set mutations and snapshots must be mutually exclusive."""
+
+import threading
+from unittest import mock
+
+import pytest
+
+import soco.zonegroupstate as zgs_module
+from soco.core import SoCo
+from soco.zonegroupstate import ZoneGroupState
+
+ZGS_PAYLOAD = """<ZoneGroups>
+  <ZoneGroup Coordinator="RINCON_000XXX1400" ID="RINCON_000XXX1400:46">
+    <ZoneGroupMember UUID="RINCON_000XXX1400"
+        Location="http://192.168.1.101:1400/xml/device_description.xml"
+        ZoneName="Living Room"/>
+  </ZoneGroup>
+</ZoneGroups>"""
+
+
+def test_get_groups_blocks_while_payload_is_being_processed():
+    """get_groups() must block while process_payload() is mutating the sets."""
+    zgs = ZoneGroupState()
+    zgs.poll = lambda soco: None  # Isolate the snapshot logic from polling
+
+    update_started = threading.Event()
+    release_writer = threading.Event()
+    original_update = zgs.update_soco_instances
+
+    def slow_update(tree):
+        update_started.set()
+        assert release_writer.wait(timeout=5)
+        original_update(tree)
+
+    zgs.update_soco_instances = slow_update
+
+    writer = threading.Thread(
+        target=zgs.process_payload,
+        kwargs={"payload": ZGS_PAYLOAD, "source": "event", "source_ip": "192.168.1.1"},
+    )
+    writer.start()
+    assert update_started.wait(timeout=5), "writer thread never started"
+
+    # Writer is mid-mutation (holding the lock with the fix in place).
+    reader_started = threading.Event()
+    reader_finished = threading.Event()
+    result = []
+
+    def read_groups():
+        reader_started.set()
+        result.append(zgs.get_groups(None))
+        reader_finished.set()
+
+    reader = threading.Thread(target=read_groups)
+    reader.start()
+    try:
+        assert reader_started.wait(timeout=5), "reader never started"
+        # The reader is executing; it must not be able to finish.
+        assert not reader_finished.wait(timeout=0.1), (
+            "get_groups() returned while the ZGS was being mutated"
+        )
+    finally:
+        release_writer.set()  # Don't leave the writer thread blocked on failure.
+    writer.join(timeout=5)
+    reader.join(timeout=5)
+    assert not writer.is_alive(), "writer thread did not finish"
+    assert not reader.is_alive(), "reader thread did not finish after release"
+    assert result
+    assert result[0] == zgs.groups
+
+
+def test_poll_discards_result_when_subscription_becomes_active():
+    """A poll result fetched before a subscription became active is discarded.
+
+    Once eventing is live, events own the topology state, so the stale poll
+    result must not be applied.
+    """
+    zgs = ZoneGroupState()
+    soco = mock.Mock()
+    soco.ip_address = "192.168.1.100"
+    soco._is_satellite = False
+    soco.zoneGroupTopology.GetZoneGroupState.return_value = {
+        "ZoneGroupState": "<ZoneGroups/>"
+    }
+
+    with mock.patch.object(
+        type(zgs),
+        "has_subscriptions",
+        new_callable=mock.PropertyMock,
+        side_effect=[False, True],  # pre-fetch: none; post-fetch: active
+    ):
+        with mock.patch.object(zgs, "process_payload") as process:
+            zgs.poll(soco)
+
+    soco.zoneGroupTopology.GetZoneGroupState.assert_called_once()
+    process.assert_not_called()
+    assert zgs.total_requests == 1  # The discarded poll is still counted.
+
+
+def test_process_payload_is_atomic():
+    """A second payload must not interleave with one being processed."""
+    zgs = ZoneGroupState()
+    first_started = threading.Event()
+    release_first = threading.Event()
+    original_normalize = zgs_module.normalize_zgs_xml
+
+    def blocking_normalize(payload):
+        if not first_started.is_set():
+            first_started.set()
+            assert release_first.wait(timeout=5)
+        return original_normalize(payload)
+
+    with mock.patch.object(
+        zgs_module, "normalize_zgs_xml", side_effect=blocking_normalize
+    ):
+        writer = threading.Thread(
+            target=zgs.process_payload,
+            kwargs={"payload": ZGS_PAYLOAD, "source": "event", "source_ip": "1"},
+        )
+        writer.start()
+        assert first_started.wait(timeout=5), "first payload never started parsing"
+
+        # The first payload is mid-normalize (holding the lock with the fix).
+        second_started = threading.Event()
+        second_done = threading.Event()
+
+        def run_second():
+            second_started.set()
+            zgs.process_payload(ZGS_PAYLOAD, "event", "2")
+            second_done.set()
+
+        second = threading.Thread(target=run_second)
+        second.start()
+        try:
+            assert second_started.wait(timeout=5), "second payload never started"
+            # It must be blocked on the lock until the first payload finishes.
+            assert not second_done.wait(timeout=0.2)
+        finally:
+            release_first.set()  # Don't leave the writer blocked on failure.
+        writer.join(timeout=5)
+        second.join(timeout=5)
+        assert not writer.is_alive(), "writer thread did not finish"
+        assert not second.is_alive(), "second thread did not finish"
+    assert zgs.processed_count == 1  # Same payload: applied once, second deduped.
+
+
+@pytest.mark.parametrize(
+    ("property_name", "getter"),
+    [
+        ("all_groups", "get_groups"),
+        ("all_zones", "get_all_zones"),
+        ("visible_zones", "get_visible_zones"),
+    ],
+)
+def test_zone_properties_use_synchronized_getters(property_name, getter):
+    """SoCo's zone properties must use the lock-protected getters."""
+    soco = SoCo("192.168.1.200")
+    zgs = mock.Mock()
+    with mock.patch.object(
+        SoCo, "zone_group_state", new_callable=mock.PropertyMock, return_value=zgs
+    ):
+        getattr(soco, property_name)
+    getattr(zgs, getter).assert_called_once_with(soco)


### PR DESCRIPTION
The shared ZoneGroupState was only refreshed by explicit polls, so a zone_group_state event arriving via a ZoneGroupTopology subscription never updated it: callbacks reading SoCo.all_groups from inside an event handler kept seeing stale groups.

Route zone_group_state events into the shared ZoneGroupState through the documented Service._update_cache_on_event() hook, which every event backend (events, events_asyncio, events_twisted) calls before delivering an event:

* ZoneGroupTopology now overrides _update_cache_on_event() to feed the payload to ZoneGroupState.process_payload(), so subscribers see the fresh topology as soon as the event is delivered. A malformed payload is logged and never blocks delivery.
* The asyncio-specific inline ZGS handling is removed: all backends now share the hook instead of double-processing events.

ZoneGroupState is now written from event-handler threads as well as from polls, so make it concurrency-safe:

* The whole process_payload() update (parse, deduplicate, mutate) runs under a single RLock acquisition; an RLock is required because update_soco_instances() re-enters via clear_zone_groups().
* get_groups()/get_all_zones()/get_visible_zones() return snapshots taken under the lock, and SoCo.all_groups/all_zones/visible_zones delegate to them, so callers never copy the sets mid-update.
* An in-flight poll whose result would supersede event-driven updates is discarded: after GetZoneGroupState() returns, the subscription state is re-checked under the lock and the result dropped if eventing became active while the request was on the wire.

Tests cover the hook, its failure path, end-to-end delivery through the real event handler, reader/writer exclusion, stale-poll discard, and the synchronized public properties. Each test fails without its fix.