### PR TITLE
Don't read cross_fade in snapshot() for non-coordinators (#621)

### DIFF
--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -127,7 +127,9 @@ class Snapshot:
         if self.is_playing_queue:
             # playing from queue - save repeat, random, cross fade, track, etc.
             self.play_mode = self.device.play_mode
-            self.cross_fade = self.device.cross_fade
+            if self.is_coordinator:
+                # cross_fade is only readable on the coordinator (#621)
+                self.cross_fade = self.device.cross_fade
 
             # Get information about the currently playing track
             track_info = self.device.get_current_track_info()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,9 +1,26 @@
 """Tests for the snapshot module."""
 
-from unittest.mock import MagicMock, call
+from unittest import mock
+from unittest.mock import MagicMock, PropertyMock, call
 
 from soco.data_structures import DidlMusicTrack, DidlResource
 from soco.snapshot import Snapshot
+
+
+QUEUE_URI = "x-rincon-queue:RINCON_000XXX1400#0"
+
+
+def make_snapshot_playing_queue(moco):
+    """Point the mock device at its local queue, as returned by GetMediaInfo."""
+    moco.avTransport.GetMediaInfo.return_value = {
+        "CurrentURI": QUEUE_URI,
+        "CurrentURIMetaData": "",
+    }
+    return mock.patch.object(
+        moco,
+        "get_current_track_info",
+        return_value={"playlist_position": "", "position": ""},
+    )
 
 
 def make_track(uri, protocol_info="http-get:*:audio/mpeg:*"):
@@ -61,3 +78,29 @@ def test_restore_queue_skipped_when_none(moco):
     moco.add_uri_to_queue = MagicMock()
     snap._restore_queue()
     moco.add_uri_to_queue.assert_not_called()
+
+
+def test_snapshot_skips_cross_fade_when_not_coordinator(moco):
+    """cross_fade must not be read on a non-coordinator (#621)."""
+    with make_snapshot_playing_queue(moco):
+        with mock.patch.object(
+            type(moco), "is_coordinator", new_callable=PropertyMock, return_value=False
+        ):
+            snap = Snapshot(moco)
+            assert snap.snapshot() is False
+    assert snap.cross_fade is None
+
+
+def test_snapshot_saves_cross_fade_when_coordinator(moco):
+    """cross_fade is saved when the device is a coordinator."""
+    with make_snapshot_playing_queue(moco):
+        with mock.patch.object(
+            type(moco), "is_coordinator", new_callable=PropertyMock, return_value=True
+        ):
+            with mock.patch.object(
+                type(moco), "cross_fade", new_callable=PropertyMock, return_value=False
+            ) as cross_fade:
+                snap = Snapshot(moco)
+                assert snap.snapshot() is True
+    cross_fade.assert_called_once()
+    assert snap.cross_fade is False


### PR DESCRIPTION
Snapshot.snapshot() reads device.cross_fade whenever the device plays from its local queue, but the getter is decorated @only_on_master: if the ZoneGroupState is stale (e.g. the device just became a coordinator after a group change), it raises SoCoSlaveException and the snapshot crashes.

Only read cross_fade when the device is a coordinator, using the flag already captured at the top of snapshot(); the restore path was already gated on the same flag. Tests cover both the coordinator and non-coordinator paths; the non-coordinator test fails with the exact SoCoSlaveException from the issue if the guard is removed.