### PR TITLE
Support multi-port players such as Sonos Amp Multi

### DIFF
--- a/soco/core.py
+++ b/soco/core.py
@@ -120,9 +120,14 @@ class _ArgsSingleton(type):
         key = cls._class_group if hasattr(cls, "_class_group") else cls
         if key not in cls._instances:
             cls._instances[key] = {}
-        if args not in cls._instances[key]:
-            cls._instances[key][args] = super().__call__(*args, **kwargs)
-        return cls._instances[key][args]
+        instance_key = (
+            cls._singleton_key(*args, **kwargs)
+            if hasattr(cls, "_singleton_key")
+            else args
+        )
+        if instance_key not in cls._instances[key]:
+            cls._instances[key][instance_key] = super().__call__(*args, **kwargs)
+        return cls._instances[key][instance_key]
 
 
 class _SocoSingletonBase(  # pylint: disable=no-init
@@ -176,8 +181,8 @@ class SoCo(_SocoSingletonBase):
     For any given set of arguments to __init__, only one instance of this class
     may be created. Subsequent attempts to create an instance with the same
     arguments will return the previously created instance. This means that all
-    SoCo instances created with the same ip address are in fact the *same* SoCo
-    instance, reflecting the real world position.
+    SoCo instances created with the same IP address and port are in fact the
+    *same* SoCo instance, reflecting the real world player endpoint.
 
     ..  rubric:: Basic Methods
     ..  autosummary::
@@ -325,8 +330,13 @@ class SoCo(_SocoSingletonBase):
     _class_group = "SoCo"
     zone_group_states = {}
 
+    @staticmethod
+    def _singleton_key(ip_address, port=1400):
+        """Return the network endpoint used to identify a player instance."""
+        return (ip_address, int(port))
+
     # pylint: disable=super-on-old-class
-    def __init__(self, ip_address):
+    def __init__(self, ip_address, port=1400):
         # Note: Creation of a SoCo instance should be as cheap and quick as
         # possible. Do not make any network calls here
         super().__init__()
@@ -338,6 +348,10 @@ class SoCo(_SocoSingletonBase):
             raise ValueError("Not a valid IP address string") from error
         #: The speaker's ip address
         self.ip_address = ip_address
+        #: The speaker's UPnP port
+        self.port = int(port)
+        if not 1 <= self.port <= 65535:
+            raise ValueError("Not a valid port")
         self.speaker_info = {}  # Stores information about the current speaker
 
         # The services which we use
@@ -378,7 +392,14 @@ class SoCo(_SocoSingletonBase):
         return f"<{self.__class__.__name__} object at ip {self.ip_address}>"
 
     def __repr__(self):
-        return f'{self.__class__.__name__}("{self.ip_address}")'
+        if self.port == 1400:
+            return f'{self.__class__.__name__}("{self.ip_address}")'
+        return f'{self.__class__.__name__}("{self.ip_address}", {self.port})'
+
+    @property
+    def base_url(self):
+        """Return the base URL for this Sonos player."""
+        return f"http://{self.ip_address}:{self.port}"
 
     @property
     def boot_seqnum(self):
@@ -2176,8 +2197,7 @@ class SoCo(_SocoSingletonBase):
             return self.speaker_info
         else:
             response = requests.get(
-                "http://" + self.ip_address + ":1400/xml/device_description.xml",
-                timeout=timeout,
+                self.base_url + "/xml/device_description.xml", timeout=timeout
             )
             dom = XML.fromstring(response.content)
 
@@ -3004,8 +3024,7 @@ class SoCo(_SocoSingletonBase):
         # Retrieve information from the speaker's status URL
         try:
             response = requests.get(
-                "http://" + self.ip_address + ":1400/status/batterystatus",
-                timeout=timeout,
+                self.base_url + "/status/batterystatus", timeout=timeout
             )
         except (ConnectTimeout, ReadTimeout) as error:
             raise TimeoutError from error

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -65,7 +65,7 @@ class MusicLibrary:
         # Add on the full album art link, as the URI version
         # does not include the ipaddress
         if not url.startswith(("http:", "https:")):
-            url = "http://" + self.soco.ip_address + ":1400" + url
+            url = self.soco.base_url + url
         return url
 
     def _update_album_art_to_full_uri(self, item):

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -72,7 +72,7 @@ class Account:
         # This returns an encrypted string, and, so far, we cannot decrypt it
         device = soco or discovery.any_soco()
         log.debug("Fetching account data from %s", device)
-        settings_url = "http://{}:1400/status/accounts".format(device.ip_address)
+        settings_url = device.base_url + "/status/accounts"
         result = requests.get(settings_url, timeout=config.REQUEST_TIMEOUT).content
         log.debug("Account data: %s", result)
         return result

--- a/soco/services.py
+++ b/soco/services.py
@@ -140,7 +140,7 @@ class Service:
         self.version = 1
         self.service_id = self.service_type
         #: str: The base URL for sending UPnP Actions.
-        self.base_url = f"http://{self.soco.ip_address}:1400"
+        self.base_url = self.soco.base_url
         #: str: The UPnP Control URL.
         self.control_url = f"/{self.service_type}/Control"
         #: str: The service control protocol description URL.

--- a/soco/zonegroupstate.py
+++ b/soco/zonegroupstate.py
@@ -64,6 +64,7 @@ Example payload contents:
 import asyncio
 import logging
 import time
+from urllib.parse import urlparse
 from weakref import WeakSet
 
 from lxml import etree as LXML
@@ -325,8 +326,16 @@ class ZoneGroupState:
 
         # Example Location contents:
         #   http://192.168.1.100:1400/xml/device_description.xml
-        ip_addr = member_attribs["Location"].split("//")[1].split(":")[0]
-        zone = config.SOCO_CLASS(ip_addr)
+        location = urlparse(member_attribs["Location"])
+        ip_addr = location.hostname
+        port = location.port or 1400
+        # Preserve compatibility with instances initially created by discovery,
+        # which constructs default-port players using only their IP address.
+        zone = (
+            config.SOCO_CLASS(ip_addr)
+            if port == 1400
+            else config.SOCO_CLASS(ip_addr, port)
+        )
         for key, attrib in ZGS_ATTRIB_MAPPING.items():
             setattr(zone, attrib, member_attribs.get(key))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,6 +159,32 @@ ZGS = (
     </ZoneGroupState>"""
 )
 
+AMP_MULTI_ZGS = """<ZoneGroupState>
+  <ZoneGroups>
+    <ZoneGroup Coordinator="RINCON_00112233445501400" ID="RINCON_00112233445501400:1">
+      <ZoneGroupMember UUID="RINCON_00112233445501400"
+        Location="http://192.0.2.10:1400/xml/device_description.xml"
+        ZoneName="Zone 1"/>
+    </ZoneGroup>
+    <ZoneGroup Coordinator="RINCON_00112233445501500" ID="RINCON_00112233445501500:2">
+      <ZoneGroupMember UUID="RINCON_00112233445501500"
+        Location="http://192.0.2.10:1500/xml/device_description.xml"
+        ZoneName="Zone 2"/>
+    </ZoneGroup>
+    <ZoneGroup Coordinator="RINCON_00112233445501600" ID="RINCON_00112233445501600:3">
+      <ZoneGroupMember UUID="RINCON_00112233445501600"
+        Location="http://192.0.2.10:1600/xml/device_description.xml"
+        ZoneName="Zone 3"/>
+    </ZoneGroup>
+    <ZoneGroup Coordinator="RINCON_00112233445501700" ID="RINCON_00112233445501700:4">
+      <ZoneGroupMember UUID="RINCON_00112233445501700"
+        Location="http://192.0.2.10:1700/xml/device_description.xml"
+        ZoneName="Zone 4"/>
+    </ZoneGroup>
+  </ZoneGroups>
+  <VanishedDevices/>
+</ZoneGroupState>"""
+
 
 @pytest.fixture()
 def moco_zgs(moco):
@@ -1689,6 +1715,29 @@ class TestZoneGroupTopology:
         for zone in zones:
             assert isinstance(zone, SoCo)
         assert moco_zgs in zones
+
+    def test_multi_zone_device_with_shared_ip(self, moco):
+        """Each advertised port represents a distinct virtual player."""
+        moco.zoneGroupTopology.GetZoneGroupState.return_value = {
+            "ZoneGroupState": AMP_MULTI_ZGS
+        }
+
+        zones = moco.visible_zones
+
+        assert {
+            (zone.ip_address, zone.port, zone.uid, zone.player_name) for zone in zones
+        } == {
+            ("192.0.2.10", 1400, "RINCON_00112233445501400", "Zone 1"),
+            ("192.0.2.10", 1500, "RINCON_00112233445501500", "Zone 2"),
+            ("192.0.2.10", 1600, "RINCON_00112233445501600", "Zone 3"),
+            ("192.0.2.10", 1700, "RINCON_00112233445501700", "Zone 4"),
+        }
+        assert {zone.base_url for zone in zones} == {
+            "http://192.0.2.10:1400",
+            "http://192.0.2.10:1500",
+            "http://192.0.2.10:1600",
+            "http://192.0.2.10:1700",
+        }
 
     def test_group_label(selfself, moco_zgs):
         g = moco_zgs.group

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+from soco import SoCo
 from soco.exceptions import SoCoUPnPException, UnknownSoCoException
 from soco.services import ContentDirectory, Service, Action, Argument, Vartype
 
@@ -115,6 +116,7 @@ def service():
 
     mock_soco = mock.MagicMock()
     mock_soco.ip_address = "192.168.1.101"
+    mock_soco.base_url = "http://192.168.1.101:1400"
     mock_service = Service(mock_soco)
     return mock_service
 
@@ -125,6 +127,7 @@ def content_directory_service():
 
     mock_soco = mock.MagicMock()
     mock_soco.ip_address = "192.168.1.101"
+    mock_soco.base_url = "http://192.168.1.101:1400"
     mock_service = ContentDirectory(mock_soco)
     return mock_service
 
@@ -138,6 +141,13 @@ def test_init_defaults(service):
     assert service.control_url == "/Service/Control"
     assert service.scpd_url == "/xml/Service1.xml"
     assert service.event_subscription_url == "/Service/Event"
+
+
+def test_init_alternate_port():
+    """Check that services preserve a player's non-default UPnP port."""
+    service = Service(SoCo("192.168.1.101", 1500))
+
+    assert service.base_url == "http://192.168.1.101:1500"
 
 
 def test_method_dispatcher_function_creation(service):

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,6 +1,6 @@
 """Tests for the SoCoSingletonBase and _ArgsSingleton classes in core."""
 
-from soco import soco_reset
+from soco import SoCo, soco_reset
 from soco.core import _SocoSingletonBase as Base
 
 
@@ -57,3 +57,16 @@ def test_soco_reset_clears_instances():
     soco_reset()
     instance_after = ASingleton("aa")
     assert instance_before is not instance_after
+
+
+def test_soco_instances_are_unique_per_port():
+    """A multi-zone device can expose multiple players on a single IP."""
+    default = SoCo("192.168.1.100")
+    alternate = SoCo("192.168.1.100", 1500)
+
+    assert default is SoCo("192.168.1.100")
+    assert default is SoCo("192.168.1.100", 1400)
+    assert default is SoCo("192.168.1.100", port=1400)
+    assert alternate is SoCo("192.168.1.100", 1500)
+    assert alternate is SoCo("192.168.1.100", port=1500)
+    assert default is not alternate


### PR DESCRIPTION
## Problem

Sonos Amp Multi can expose up to four independently controlled virtual players from one physical device. Each player shares the same IP address but advertises a different UPnP port in ZoneGroupState, typically 1400, 1500, 1600, and 1700.

SoCo currently discards the port from each ZoneGroupMember Location, creates singleton instances using only the IP address, and sends all requests to port 1400. As the topology is processed, the virtual players overwrite one another's UUID and zone metadata. Consumers therefore see one incorrectly identified player instead of every Amp Multi zone.

## Change

- Add an optional UPnP port to SoCo, defaulting to 1400.
- Identify singleton instances by IP address and port.
- Preserve non-default ports from ZoneGroupState Location URLs.
- Use the player's base URL for UPnP services, device descriptions, battery status, album art, and account requests.
- Preserve existing construction and representation behavior for normal port-1400 players.

## Tests

The new regression fixture models four virtual players sharing one IP address. It verifies that all four remain distinct by port, UUID, and name and that their base URLs use the correct ports.

Local checks:

- pytest: 270 passed, 67 hardware integration tests skipped
- flake8 soco: clean
- flake8 critical-error scan: clean
- pylint soco: 10.00/10
- black --check soco tests: clean
- Sphinx documentation build: successful

The change was also tested read-only against two physical Sonos Amp Multi units, exposing eight virtual zones in total. SoCo discovered all eight and independently retrieved each zone's device information, volume, mute state, and transport state. The test did not change playback or device state.

## Out of scope

- SSDP still discovers the physical device on its standard endpoint; the additional virtual players are learned from ZoneGroupState.
- Consumer-specific device-registry presentation for several virtual players sharing one physical MAC address.
